### PR TITLE
Fix ingress definition

### DIFF
--- a/pkg/controller/model/grafanaIngress.go
+++ b/pkg/controller/model/grafanaIngress.go
@@ -64,7 +64,6 @@ func getIngressSpec(cr *v1alpha1.Grafana) v12.IngressSpec {
 									Service: &v12.IngressServiceBackend{
 										Name: serviceName(cr),
 										Port: v12.ServiceBackendPort{
-											Name:   "http",
 											Number: GetIngressTargetPort(cr).IntVal,
 										},
 									},


### PR DESCRIPTION
## Description
Ingress definition cannot have both the name and the number of the port of the backend defined at the same time.

This is how the grafana resource status looks like in case we enable ingress:

```
status:
  message: 'Ingress.extensions "grafana-ingress" is invalid: spec.rules[0].http.paths[0].backend:
    Invalid value: "": cannot set both port name & port number'
  phase: failing
  previousServiceName: grafana-service
```

## Relevant issues/tickets
#554 seems exactly the same issue

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->

Enable ingress for a grafana resource and verify it's created.
