### PR TITLE
fix(jsonnet): flaky test TestGetJsonProjectBuildRoundName

### DIFF
--- a/controllers/fetchers/jsonnet_fetcher.go
+++ b/controllers/fetchers/jsonnet_fetcher.go
@@ -130,7 +130,11 @@ func generateRandomString(length int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(randomBytes)[:length], nil
+
+	s := base64.URLEncoding.EncodeToString(randomBytes)[:length]
+	s = strings.ReplaceAll(s, "-", "a")
+
+	return s, nil
 }
 
 func getJsonProjectBuildRoundName(dashboardName string) (string, error) {


### PR DESCRIPTION
I've noticed across multiple builds (e.g. [here](https://github.com/grafana/grafana-operator/actions/runs/7166202293/job/19509711911?pr=1341#step:4:109)) that we have a flaky test called `TestGetJsonProjectBuildRoundName`.

Basically, there is function `getJsonProjectBuildRoundName` that is supposed to return a 3-segment string (separated by hyphens) that consists of a dashboard name, a timestamp, and a random string. Sometimes, the latter contains a hyphen, which breaks the expected pattern in `TestGetJsonProjectBuildRoundName`.
It can be fixed in various ways, but I think a simple replace of `-` to something else (`a` in the PR) should be enough.