### PR TITLE
remove permissions for openshift only resources in helm chart

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -43,6 +43,7 @@ It's easier to just manage this configuration outside of the operator.
 | image.repository | string | `"ghcr.io/grafana/grafana-operator"` | grafana operator image repository |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | image pull secrets |
+| isOpenShift | bool | `false` | Determines if the target cluster is OpenShift. Additional rbac permissions for routes will be added on OpenShift |
 | leaderElect | bool | `false` | If you want to run multiple replicas of the grafana-operator, this is not recommended. |
 | metricsService.metricsPort | int | `9090` | metrics service port |
 | metricsService.type | string | `"ClusterIP"` | metrics service type |

--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -1,7 +1,11 @@
 {{- $watchNamespaces := coalesce .Values.watchNamespaces .Release.Namespace }}
 {{- $namespaceScoped := false }}
+{{- $isOpenShift := false }}
 {{- if or (.Values.namespaceScope) (.Values.watchNamespaces) }}
 {{- $namespaceScoped = true }}
+{{- end }}
+{{- if (.Values.isOpenShift) }}
+  {{- $isOpenShift = true }}
 {{- end }}
 {{- $operatorNamespace := .Release.Namespace }}
 {{- range ( split "," $watchNamespaces ) }}
@@ -204,6 +208,7 @@ rules:
       - patch
       - update
       - watch
+  {{- if $isOpenShift }}
   - apiGroups:
       - route.openshift.io
     resources:
@@ -216,6 +221,7 @@ rules:
       - list
       - update
       - watch
+  {{- end }}
   - apiGroups:
       - authentication.k8s.io
     resources:

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -10,6 +10,9 @@ leaderElect: false
 # By default it's all namespaces, if you only want to listen for the same namespace as the operator is deployed to look at namespaceScope.
 watchNamespaces: ""
 
+# -- Determines if the target cluster is OpenShift. Additional rbac permissions for routes will be added on OpenShift
+isOpenShift: false
+
 # -- Additional environment variables
 env: []
   # -- grafana image, e.g. docker.io/grafana/grafana:9.1.6, overwrites the default grafana image defined in the operator


### PR DESCRIPTION
Fixes #1331 

This removes all OpenShift related permissions (routes) from the Helm chart. I've verified that the Helm chart can still be deployed on OpenShift.