### PR TITLE
fix: remove unused permissions (tokenreviews, subjectaccessreviews)

### DIFF
--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -222,18 +222,6 @@ rules:
       - update
       - watch
   {{- end }}
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if not $namespaceScoped }}Cluster{{ end }}RoleBinding

--- a/deploy/kustomize/overlays/cluster_scoped/rbac.yaml
+++ b/deploy/kustomize/overlays/cluster_scoped/rbac.yaml
@@ -201,18 +201,6 @@ rules:
       - list
       - update
       - watch
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/kustomize/overlays/namespace_scoped/rbac.yaml
+++ b/deploy/kustomize/overlays/namespace_scoped/rbac.yaml
@@ -202,18 +202,6 @@ rules:
       - list
       - update
       - watch
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
As discussed under #1330, `tokenreviews` and `subjectaccessreviews` are unused by the operator, so should be removed from our manifests.

Fixes: #1330 