### PR TITLE
OLM add skips in correct location

### DIFF
--- a/bundle/manifests/grafana-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/grafana-operator.clusterserviceversion.yaml
@@ -95,13 +95,13 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: ghcr.io/grafana/grafana-operator@sha256:97561cef949b58f55ec67d133c02ac205e2ec3fb77388aeb868dacfcebad0752
-    createdAt: "2024-02-07T09:39:40Z"
+    createdAt: "2024-02-11T09:40:22Z"
     description: Deploys and manages Grafana instances, dashboards and data sources
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/grafana/grafana-operator
     support: Grafana Labs
-  name: grafana-operator.v5.6.1
+  name: grafana-operator.v5.6.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -333,7 +333,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: ghcr.io/grafana/grafana-operator@sha256:49ed7bdbae0b9a43e31df2e8ad2baad07042cf098d3c5944c4ce96e20a296695
+                    image: ghcr.io/grafana/grafana-operator@sha256:e398d39e48abdd16ae126233bc3b485b0c7f79e9b087fc5db5c164e9d64da276
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -427,7 +427,7 @@ spec:
   relatedImages:
     - image: docker.io/grafana/grafana@sha256:ff68ed4324e471ffa269aa5308cdcf12276ef2d5a660daea95db9d629a32a7d8
       name: grafana
-    - image: ghcr.io/grafana/grafana-operator@sha256:49ed7bdbae0b9a43e31df2e8ad2baad07042cf098d3c5944c4ce96e20a296695
+    - image: ghcr.io/grafana/grafana-operator@sha256:e398d39e48abdd16ae126233bc3b485b0c7f79e9b087fc5db5c164e9d64da276
       name: manager
     - image: ghcr.io/grafana/grafana-operator@sha256:97561cef949b58f55ec67d133c02ac205e2ec3fb77388aeb868dacfcebad0752
       name: grafana-operator-97561cef949b58f55ec67d133c02ac205e2ec3fb77388aeb868dacfcebad0752-annotation

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -15,4 +15,4 @@ configMapGenerator:
 images:
 - name: controller
   newName: ghcr.io/grafana/grafana-operator
-  newTag: v5.6.1
+  newTag: v5.6.3

--- a/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/grafana-operator.clusterserviceversion.yaml
@@ -69,5 +69,7 @@ spec:
   provider:
     name: Grafana Labs
     url: https://grafana.com
-  replaces: grafana-operator.v5.6.0
+  replaces: grafana-operator.v5.6.2
+  skips:
+  - grafana-operator.v5.6.1
   version: 0.0.0


### PR DESCRIPTION
I changed in the wrong location in https://github.com/grafana/grafana-operator/pull/1405
This is now corrected. I will still use 5.6.3 when fixing the OLM stuff, but it's good that it's correct for the future.