### PR TITLE
fix: do not hardcode namespace used in e2e tests

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -4,7 +4,6 @@ kind: Configuration
 metadata:
   name: configuration
 spec:
-  namespace: grafana-operator-system
   timeouts:
     assert: 2m0s
     cleanup: 2m0s

--- a/tests/e2e/example-test/00-assert.yaml
+++ b/tests/e2e/example-test/00-assert.yaml
@@ -3,7 +3,7 @@ kind: Grafana
 metadata:
   name: grafana
 status:
-  adminUrl: http://grafana-service.grafana-operator-system:3000
+  (wildcard('http://grafana-service.*:3000', adminUrl || '')): true
   stage: complete
   stageStatus: success
 ---

--- a/tests/e2e/example-test/chainsaw-test.yaml
+++ b/tests/e2e/example-test/chainsaw-test.yaml
@@ -2,7 +2,6 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  creationTimestamp: null
   name: example-test
 spec:
   steps:


### PR DESCRIPTION
Do not hardcode namespace used in e2e tests.