### PR TITLE
fix: persistent volume example

### DIFF
--- a/examples/persistent_volume/resources.yaml
+++ b/examples/persistent_volume/resources.yaml
@@ -13,7 +13,7 @@ spec:
       resources:
         requests:
           storage: 10Gi
-      storageClassName: <storage-class-name>
+      # storageClassName: "" # Customize storage class if needed
   config:
     log:
       mode: "console"
@@ -34,7 +34,7 @@ spec:
                 readOnlyRootFilesystem: false
               readinessProbe:
                 failureThreshold: 3
-        volumes:
-          - name: grafana-data
-            persistentVolumeClaim:
-              claimName: grafana-pvc
+          volumes:
+            - name: grafana-data
+              persistentVolumeClaim:
+                claimName: grafana-pvc


### PR DESCRIPTION
This PR fixes our persistent volume example - indentation was a bit off.

Also, I commented out `storageClassName`. - In most environments, there would be a default storage class, so we don't necessarily need to override it => easier to deploy the example as is.

Fixes: #1418