### PR TITLE
use dependabot group feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      gha:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      gomod:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This to only get one PR from dependabot instead of n.
You can read more about groups in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.
