### PR TITLE
fix nil pointer exception in jsonnet logic

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   timeouts:
     assert: 2m0s
-    cleanup: 2m0s
+    cleanup: 3m0s
     delete: 2m0s
     error: 2m0s
     exec: 2m0s

--- a/tests/e2e/example-test/05-dashboard.yaml
+++ b/tests/e2e/example-test/05-dashboard.yaml
@@ -14,8 +14,9 @@ spec:
     matchLabels:
       dashboards: "grafana"
   envFrom:
-    - configMapRef:
+    - configMapKeyRef:
         name: grafana-user-envs
+        key: "CUSTOM_RANGE_ENV"
   plugins:
     - name: grafana-piechart-panel
       version: 1.3.9


### PR DESCRIPTION
Fixes a nil pointer exception caused by the logic attempting to parse SecretKeyRefs even if ConfigMapKeyRefs were declared in the `dashboard.Spec.EnvFrom`

Additionally, fix the ` envFrom:   - configMapKeyRef` case in e2e tests 
