### PR TITLE
update default grafana to 9.5.17

### DIFF
--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -3,7 +3,7 @@ package config
 const (
 	// Grafana
 	GrafanaImage   = "docker.io/grafana/grafana"
-	GrafanaVersion = "9.1.6"
+	GrafanaVersion = "9.5.17"
 
 	// Paths
 	GrafanaDataPath               = "/var/lib/grafana"


### PR DESCRIPTION
Update grafana to [9.5.17 ](https://hub.docker.com/layers/grafana/grafana/9.5.17/images/sha256-2c81e58c65ea74c5874eea8976581988f51d971568e67807b93336d9d4f7650a?context=explore)to get the alert feature working by default as described in https://github.com/grafana/grafana-operator/issues/1451

In grafana 10 there area breaking changes that we need to take in to consideration. 
That is why we have created https://github.com/grafana/grafana-operator/issues/1446

This way we should be able to release a new version of the operator and the majority of our users should be able to use the alert feature without any issues. And we can work on a good migration path to grafana 10/11.