### PR TITLE
fix: time multiplier was not applied if the timeout was in the spec

### DIFF
--- a/controllers/client/grafana_client.go
+++ b/controllers/client/grafana_client.go
@@ -177,7 +177,7 @@ func NewGeneratedGrafanaClient(ctx context.Context, c client.Client, grafana *v1
 			timeout = 0
 		}
 	} else {
-		timeout = time.Second * 10
+		timeout = 10
 	}
 
 	credentials, err := getAdminCredentials(ctx, c, grafana)
@@ -194,7 +194,7 @@ func NewGeneratedGrafanaClient(ctx context.Context, c client.Client, grafana *v1
 
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   timeout,
+		Timeout:   timeout * time.Second,
 	}
 
 	cfg := &genapi.TransportConfig{


### PR DESCRIPTION
Time multiplier was only applied when no timeout was provided.