### PR TITLE
Updated crossnamespace to mention that dashboards need spec.allowCrossNamespaceImport as well

### DIFF
--- a/examples/crossnamespace/README.md
+++ b/examples/crossnamespace/README.md
@@ -4,7 +4,7 @@ linkTitle: "Cross namespace"
 ---
 
 
-If you want your datasource to be able to be used by a grafana instance in another namespace you need to set `spec.allowCrossNamespaceImport: true`.
+If you want your dashboard or datasource to be able to be used by a grafana instance in another namespace you need to set `spec.allowCrossNamespaceImport: true`.
 
 In the resources file you will find examples how to do this.
 


### PR DESCRIPTION


Inspired by https://github.com/grafana/grafana-operator/issues/1142.