### PR TITLE
fix: do not delete non-existing dashboard

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -305,10 +305,14 @@ func (r *GrafanaDashboardReconciler) onDashboardDeleted(ctx context.Context, nam
 			resp, err := grafanaClient.Dashboards.GetDashboardByUID(*uid)
 			if err != nil {
 				var notFound *dashboards.GetDashboardByUIDNotFound
-				if !errors.As(err, &notFound) {
-					return err
+				if errors.As(err, &notFound) {
+					// nothing to do if the dashboard doesn't exist
+					return nil
 				}
+
+				return err
 			}
+
 			dash := resp.GetPayload()
 
 			_, err = grafanaClient.Dashboards.DeleteDashboardByUID(*uid) //nolint:errcheck


### PR DESCRIPTION
fixes #1498 

When a dashboard is not found, we should not try to delete it.