### PR TITLE
fix(api-docs): generate CRDs for api-docs and add missing reference to grafanacontactpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ endif
 manifests: yq controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd:maxDescLen=0,generateEmbeddedObjectMeta=false output:crd:artifacts:config=config/crd/bases
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd:maxDescLen=0,generateEmbeddedObjectMeta=false output:crd:artifacts:config=deploy/helm/grafana-operator/crds
+	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=config/
 	yq -i '(select(.kind == "Deployment") | .spec.template.spec.containers[0].env[] | select (.name == "RELATED_IMAGE_GRAFANA")).value="$(GRAFANA_IMAGE):$(GRAFANA_VERSION)"' config/manager/manager.yaml
 
 .PHONY: kustomize-crd

--- a/config/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/config/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: grafanaalertrulegroups.grafana.integreatly.org
 spec:
   group: grafana.integreatly.org
@@ -21,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -41,8 +46,9 @@ spec:
                 description: Match GrafanaFolders CRs to infer the uid
                 type: string
               folderUID:
-                description: UID of the folder containing this rule group Overrides
-                  the FolderSelector
+                description: |-
+                  UID of the folder containing this rule group
+                  Overrides the FolderSelector
                 type: string
               instanceSelector:
                 description: selects Grafanas for import
@@ -51,24 +57,24 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -81,11 +87,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -122,9 +127,9 @@ spec:
                               above properties as well as custom properties.
                             x-kubernetes-preserve-unknown-fields: true
                           queryType:
-                            description: QueryType is an optional identifier for the
-                              type of query. It can be used to distinguish different
-                              types of queries.
+                            description: |-
+                              QueryType is an optional identifier for the type of query.
+                              It can be used to distinguish different types of queries.
                             type: string
                           refId:
                             description: RefID is the unique identifier of the query,
@@ -200,42 +205,42 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -249,11 +254,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: grafanacontactpoints.grafana.integreatly.org
 spec:
   group: grafana.integreatly.org
@@ -21,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -46,24 +51,24 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -76,11 +81,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -123,47 +127,47 @@ spec:
             description: GrafanaContactPointStatus defines the observed state of GrafanaContactPoint
             properties:
               conditions:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -177,11 +181,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/grafana.integreatly.org_grafanadashboards.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: grafanadashboards.grafana.integreatly.org
 spec:
   group: grafana.integreatly.org
@@ -31,14 +31,19 @@ spec:
         description: GrafanaDashboard is the Schema for the grafanadashboards API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -56,8 +61,10 @@ spec:
                     description: The key to select.
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
                     type: string
                   optional:
                     description: Specify whether the ConfigMap or its key must be
@@ -94,8 +101,10 @@ spec:
                           description: The key to select.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
                           description: Specify whether the ConfigMap or its key must
@@ -113,8 +122,10 @@ spec:
                             be a valid secret key.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
                           description: Specify whether the Secret or its key must
@@ -146,8 +157,10 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -165,8 +178,10 @@ spec:
                                 be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must
@@ -206,24 +221,24 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -236,11 +251,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -280,8 +294,11 @@ spec:
                   type: object
                 type: array
               resyncPeriod:
+                default: 5m
                 description: how often the dashboard is refreshed, defaults to 5m
                   if not set
+                format: duration
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               url:
                 description: dashboard url

--- a/config/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/grafana.integreatly.org_grafanadatasources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: grafanadatasources.grafana.integreatly.org
 spec:
   group: grafana.integreatly.org
@@ -31,14 +31,19 @@ spec:
         description: GrafanaDatasource is the Schema for the grafanadatasources API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -60,7 +65,7 @@ spec:
                   database:
                     type: string
                   editable:
-                    description: Deprecated field. Please, remove it from your manifests
+                    description: Deprecated field, it has no effect
                     type: boolean
                   isDefault:
                     type: boolean
@@ -70,7 +75,7 @@ spec:
                   name:
                     type: string
                   orgId:
-                    description: Deprecated field. Please, remove it from your manifests
+                    description: Deprecated field, it has no effect
                     format: int64
                     type: integer
                   secureJsonData:
@@ -92,24 +97,24 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -122,11 +127,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -144,8 +148,11 @@ spec:
                   type: object
                 type: array
               resyncPeriod:
+                default: 5m
                 description: how often the datasource is refreshed, defaults to 5m
                   if not set
+                format: duration
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               valuesFrom:
                 description: environments variables from secrets or config maps
@@ -162,8 +169,10 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -181,8 +190,10 @@ spec:
                                 be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must

--- a/config/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/grafana.integreatly.org_grafanafolders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: grafanafolders.grafana.integreatly.org
 spec:
   group: grafana.integreatly.org
@@ -27,14 +27,19 @@ spec:
         description: GrafanaFolder is the Schema for the grafanafolders API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -52,24 +57,24 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -82,11 +87,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -94,8 +98,11 @@ spec:
                 description: raw json with folder permissions
                 type: string
               resyncPeriod:
+                default: 5m
                 description: how often the folder is synced, defaults to 5m if not
                   set
+                format: duration
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               title:
                 type: string
@@ -110,9 +117,9 @@ spec:
                   instances
                 type: boolean
               hash:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 type: string
               lastResync:
                 description: Last time the folder was resynced

--- a/config/grafana.integreatly.org_grafanas.yaml
+++ b/config/grafana.integreatly.org_grafanas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: grafanas.grafana.integreatly.org
 spec:
   group: grafana.integreatly.org
@@ -33,14 +33,19 @@ spec:
         description: Grafana is the Schema for the grafanas API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -104,17 +109,17 @@ spec:
                         format: int32
                         type: integer
                       selector:
-                        description: A label selector is a label query over a set
-                          of resources. The result of matchLabels and matchExpressions
-                          are ANDed. An empty label selector matches all objects.
-                          A null label selector matches no objects.
+                        description: |-
+                          A label selector is a label query over a set of resources. The result of matchLabels and
+                          matchExpressions are ANDed. An empty label selector matches all objects. A null
+                          label selector matches no objects.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
@@ -122,17 +127,16 @@ spec:
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -144,11 +148,10 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -157,47 +160,45 @@ spec:
                           pods with new ones.
                         properties:
                           rollingUpdate:
-                            description: 'Rolling update config params. Present only
-                              if DeploymentStrategyType = RollingUpdate. --- TODO:
-                              Update this to follow our convention for oneOf, whatever
-                              we decide it to be.'
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
+                              ---
+                              TODO: Update this to follow our convention for oneOf, whatever we decide it
+                              to be.
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: 'The maximum number of pods that can
-                                  be scheduled above the desired number of pods. Value
-                                  can be an absolute number (ex: 5) or a percentage
-                                  of desired pods (ex: 10%). This can not be 0 if
-                                  MaxUnavailable is 0. Absolute number is calculated
-                                  from percentage by rounding up. Defaults to 25%.
-                                  Example: when this is set to 30%, the new ReplicaSet
-                                  can be scaled up immediately when the rolling update
-                                  starts, such that the total number of old and new
-                                  pods do not exceed 130% of desired pods. Once old
-                                  pods have been killed, new ReplicaSet can be scaled
-                                  up further, ensuring that total number of pods running
-                                  at any time during the update is at most 130% of
-                                  desired pods.'
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  This can not be 0 if MaxUnavailable is 0.
+                                  Absolute number is calculated from percentage by rounding up.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                  the rolling update starts, such that the total number of old and new pods do not exceed
+                                  130% of desired pods. Once old pods have been killed,
+                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of desired pods.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: 'The maximum number of pods that can
-                                  be unavailable during the update. Value can be an
-                                  absolute number (ex: 5) or a percentage of desired
-                                  pods (ex: 10%). Absolute number is calculated from
-                                  percentage by rounding down. This can not be 0 if
-                                  MaxSurge is 0. Defaults to 25%. Example: when this
-                                  is set to 30%, the old ReplicaSet can be scaled
-                                  down to 70% of desired pods immediately when the
-                                  rolling update starts. Once new pods are ready,
-                                  old ReplicaSet can be scaled down further, followed
-                                  by scaling up the new ReplicaSet, ensuring that
-                                  the total number of pods available at all times
-                                  during the update is at least 70% of desired pods.'
+                                description: |-
+                                  The maximum number of pods that can be unavailable during the update.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding down.
+                                  This can not be 0 if MaxSurge is 0.
+                                  Defaults to 25%.
+                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                  that the total number of pods available at all times during the update is at
+                                  least 70% of desired pods.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
@@ -208,8 +209,9 @@ spec:
                       template:
                         properties:
                           metadata:
-                            description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            description: |-
+                              Standard object's metadata.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                             properties:
                               annotations:
                                 additionalProperties:
@@ -221,8 +223,9 @@ spec:
                                 type: object
                             type: object
                           spec:
-                            description: 'Specification of the desired behavior of
-                              the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                            description: |-
+                              Specification of the desired behavior of the pod.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                             properties:
                               activeDeadlineSeconds:
                                 format: int64
@@ -235,27 +238,20 @@ spec:
                                       rules for the pod.
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          affinity expressions specified by this field,
-                                          but it may choose a node that violates one
-                                          or more of the expressions. The node that
-                                          is most preferred is the one with the greatest
-                                          sum of weights, i.e. for each node that
-                                          meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          affinity expressions, etc.), compute a sum
-                                          by iterating through the elements of this
-                                          field and adding "weight" to the sum if
-                                          the node matches the corresponding matchExpressions;
-                                          the node(s) with the highest sum are the
-                                          most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
-                                          description: An empty preferred scheduling
-                                            term matches all objects with implicit
-                                            weight 0 (i.e. it's a no-op). A null preferred
-                                            scheduling term matches no objects (i.e.
-                                            is also a no-op).
+                                          description: |-
+                                            An empty preferred scheduling term matches all objects with implicit weight 0
+                                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                           properties:
                                             preference:
                                               description: A node selector term, associated
@@ -265,9 +261,8 @@ spec:
                                                   description: A list of node selector
                                                     requirements by node's labels.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
                                                       that relates the key and values.
                                                     properties:
                                                       key:
@@ -276,27 +271,17 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -309,9 +294,8 @@ spec:
                                                   description: A list of node selector
                                                     requirements by node's fields.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
                                                       that relates the key and values.
                                                     properties:
                                                       key:
@@ -320,27 +304,17 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -363,31 +337,28 @@ spec:
                                           type: object
                                         type: array
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the affinity requirements specified
-                                          by this field cease to be met at some point
-                                          during pod execution (e.g. due to an update),
-                                          the system may or may not try to eventually
-                                          evict the pod from its node.
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to an update), the system
+                                          may or may not try to eventually evict the pod from its node.
                                         properties:
                                           nodeSelectorTerms:
                                             description: Required. A list of node
                                               selector terms. The terms are ORed.
                                             items:
-                                              description: A null or empty node selector
-                                                term matches no objects. The requirements
-                                                of them are ANDed. The TopologySelectorTerm
-                                                type implements a subset of the NodeSelectorTerm.
+                                              description: |-
+                                                A null or empty node selector term matches no objects. The requirements of
+                                                them are ANDed.
+                                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                               properties:
                                                 matchExpressions:
                                                   description: A list of node selector
                                                     requirements by node's labels.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
                                                       that relates the key and values.
                                                     properties:
                                                       key:
@@ -396,27 +367,17 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -429,9 +390,8 @@ spec:
                                                   description: A list of node selector
                                                     requirements by node's fields.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
                                                       that relates the key and values.
                                                     properties:
                                                       key:
@@ -440,27 +400,17 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -483,21 +433,16 @@ spec:
                                       zone, etc. as some other pod(s)).
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          affinity expressions specified by this field,
-                                          but it may choose a node that violates one
-                                          or more of the expressions. The node that
-                                          is most preferred is the one with the greatest
-                                          sum of weights, i.e. for each node that
-                                          meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          affinity expressions, etc.), compute a sum
-                                          by iterating through the elements of this
-                                          field and adding "weight" to the sum if
-                                          the node has pods which matches the corresponding
-                                          podAffinityTerm; the node(s) with the highest
-                                          sum are the most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
                                             WeightedPodAffinityTerm fields are added
@@ -509,10 +454,9 @@ spec:
                                                 weight.
                                               properties:
                                                 labelSelector:
-                                                  description: A label query over
-                                                    a set of resources, in this case
-                                                    pods. If it's null, this PodAffinityTerm
-                                                    matches with no Pods.
+                                                  description: |-
+                                                    A label query over a set of resources, in this case pods.
+                                                    If it's null, this PodAffinityTerm matches with no Pods.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -520,10 +464,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -532,24 +474,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -562,82 +495,50 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 matchLabelKeys:
-                                                  description: MatchLabelKeys is a
-                                                    set of pod label keys to select
-                                                    which pods will be taken into
-                                                    consideration. The keys are used
-                                                    to lookup values from the incoming
-                                                    pod labels, those key-value labels
-                                                    are merged with `LabelSelector`
-                                                    as `key in (value)` to select
-                                                    the group of existing pods which
-                                                    pods will be taken into consideration
-                                                    for the incoming pod's pod (anti)
-                                                    affinity. Keys that don't exist
-                                                    in the incoming pod labels will
-                                                    be ignored. The default value
-                                                    is empty. The same key is forbidden
-                                                    to exist in both MatchLabelKeys
-                                                    and LabelSelector. Also, MatchLabelKeys
-                                                    cannot be set when LabelSelector
-                                                    isn't set. This is an alpha field
-                                                    and requires enabling MatchLabelKeysInPodAffinity
-                                                    feature gate.
+                                                  description: |-
+                                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                                   items:
                                                     type: string
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                                 mismatchLabelKeys:
-                                                  description: MismatchLabelKeys is
-                                                    a set of pod label keys to select
-                                                    which pods will be taken into
-                                                    consideration. The keys are used
-                                                    to lookup values from the incoming
-                                                    pod labels, those key-value labels
-                                                    are merged with `LabelSelector`
-                                                    as `key notin (value)` to select
-                                                    the group of existing pods which
-                                                    pods will be taken into consideration
-                                                    for the incoming pod's pod (anti)
-                                                    affinity. Keys that don't exist
-                                                    in the incoming pod labels will
-                                                    be ignored. The default value
-                                                    is empty. The same key is forbidden
-                                                    to exist in both MismatchLabelKeys
-                                                    and LabelSelector. Also, MismatchLabelKeys
-                                                    cannot be set when LabelSelector
-                                                    isn't set. This is an alpha field
-                                                    and requires enabling MatchLabelKeysInPodAffinity
-                                                    feature gate.
+                                                  description: |-
+                                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                                   items:
                                                     type: string
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                                 namespaceSelector:
-                                                  description: A label query over
-                                                    the set of namespaces that the
-                                                    term applies to. The term is applied
-                                                    to the union of the namespaces
-                                                    selected by this field and the
-                                                    ones listed in the namespaces
-                                                    field. null selector and null
-                                                    or empty namespaces list means
-                                                    "this pod's namespace". An empty
-                                                    selector ({}) matches all namespaces.
+                                                  description: |-
+                                                    A label query over the set of namespaces that the term applies to.
+                                                    The term is applied to the union of the namespaces selected by this field
+                                                    and the ones listed in the namespaces field.
+                                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                                    An empty selector ({}) matches all namespaces.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -645,10 +546,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -657,24 +556,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -687,51 +577,36 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 namespaces:
-                                                  description: namespaces specifies
-                                                    a static list of namespace names
-                                                    that the term applies to. The
-                                                    term is applied to the union of
-                                                    the namespaces listed in this
-                                                    field and the ones selected by
-                                                    namespaceSelector. null or empty
-                                                    namespaces list and null namespaceSelector
-                                                    means "this pod's namespace".
+                                                  description: |-
+                                                    namespaces specifies a static list of namespace names that the term applies to.
+                                                    The term is applied to the union of the namespaces listed in this field
+                                                    and the ones selected by namespaceSelector.
+                                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
                                                 topologyKey:
-                                                  description: This pod should be
-                                                    co-located (affinity) or not co-located
-                                                    (anti-affinity) with the pods
-                                                    matching the labelSelector in
-                                                    the specified namespaces, where
-                                                    co-located is defined as running
-                                                    on a node whose value of the label
-                                                    with key topologyKey matches that
-                                                    of any node on which any of the
-                                                    selected pods is running. Empty
-                                                    topologyKey is not allowed.
+                                                  description: |-
+                                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                                    selected pods is running.
+                                                    Empty topologyKey is not allowed.
                                                   type: string
                                               required:
                                               - topologyKey
                                               type: object
                                             weight:
-                                              description: weight associated with
-                                                matching the corresponding podAffinityTerm,
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
                                               format: int32
                                               type: integer
@@ -741,45 +616,36 @@ spec:
                                           type: object
                                         type: array
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the affinity requirements specified
-                                          by this field cease to be met at some point
-                                          during pod execution (e.g. due to a pod
-                                          label update), the system may or may not
-                                          try to eventually evict the pod from its
-                                          node. When there are multiple elements,
-                                          the lists of nodes corresponding to each
-                                          podAffinityTerm are intersected, i.e. all
-                                          terms must be satisfied.
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                         items:
-                                          description: Defines a set of pods (namely
-                                            those matching the labelSelector relative
-                                            to the given namespace(s)) that this pod
-                                            should be co-located (affinity) or not
-                                            co-located (anti-affinity) with, where
-                                            co-located is defined as running on a
-                                            node whose value of the label with key
-                                            <topologyKey> matches that of any node
-                                            on which a pod of the set of pods is running
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set
-                                                of resources, in this case pods. If
-                                                it's null, this PodAffinityTerm matches
-                                                with no Pods.
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -787,23 +653,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -815,87 +674,59 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set
-                                                of pod label keys to select which
-                                                pods will be taken into consideration.
-                                                The keys are used to lookup values
-                                                from the incoming pod labels, those
-                                                key-value labels are merged with `LabelSelector`
-                                                as `key in (value)` to select the
-                                                group of existing pods which pods
-                                                will be taken into consideration for
-                                                the incoming pod's pod (anti) affinity.
-                                                Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default
-                                                value is empty. The same key is forbidden
-                                                to exist in both MatchLabelKeys and
-                                                LabelSelector. Also, MatchLabelKeys
-                                                cannot be set when LabelSelector isn't
-                                                set. This is an alpha field and requires
-                                                enabling MatchLabelKeysInPodAffinity
-                                                feature gate.
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a
-                                                set of pod label keys to select which
-                                                pods will be taken into consideration.
-                                                The keys are used to lookup values
-                                                from the incoming pod labels, those
-                                                key-value labels are merged with `LabelSelector`
-                                                as `key notin (value)` to select the
-                                                group of existing pods which pods
-                                                will be taken into consideration for
-                                                the incoming pod's pod (anti) affinity.
-                                                Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default
-                                                value is empty. The same key is forbidden
-                                                to exist in both MismatchLabelKeys
-                                                and LabelSelector. Also, MismatchLabelKeys
-                                                cannot be set when LabelSelector isn't
-                                                set. This is an alpha field and requires
-                                                enabling MatchLabelKeysInPodAffinity
-                                                feature gate.
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the
-                                                set of namespaces that the term applies
-                                                to. The term is applied to the union
-                                                of the namespaces selected by this
-                                                field and the ones listed in the namespaces
-                                                field. null selector and null or empty
-                                                namespaces list means "this pod's
-                                                namespace". An empty selector ({})
-                                                matches all namespaces.
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -903,23 +734,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -931,41 +755,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a
-                                                static list of namespace names that
-                                                the term applies to. The term is applied
-                                                to the union of the namespaces listed
-                                                in this field and the ones selected
-                                                by namespaceSelector. null or empty
-                                                namespaces list and null namespaceSelector
-                                                means "this pod's namespace".
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
@@ -978,21 +790,16 @@ spec:
                                       node, zone, etc. as some other pod(s)).
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          anti-affinity expressions specified by this
-                                          field, but it may choose a node that violates
-                                          one or more of the expressions. The node
-                                          that is most preferred is the one with the
-                                          greatest sum of weights, i.e. for each node
-                                          that meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          anti-affinity expressions, etc.), compute
-                                          a sum by iterating through the elements
-                                          of this field and adding "weight" to the
-                                          sum if the node has pods which matches the
-                                          corresponding podAffinityTerm; the node(s)
-                                          with the highest sum are the most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the anti-affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
                                             WeightedPodAffinityTerm fields are added
@@ -1004,10 +811,9 @@ spec:
                                                 weight.
                                               properties:
                                                 labelSelector:
-                                                  description: A label query over
-                                                    a set of resources, in this case
-                                                    pods. If it's null, this PodAffinityTerm
-                                                    matches with no Pods.
+                                                  description: |-
+                                                    A label query over a set of resources, in this case pods.
+                                                    If it's null, this PodAffinityTerm matches with no Pods.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -1015,10 +821,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -1027,24 +831,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -1057,82 +852,50 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 matchLabelKeys:
-                                                  description: MatchLabelKeys is a
-                                                    set of pod label keys to select
-                                                    which pods will be taken into
-                                                    consideration. The keys are used
-                                                    to lookup values from the incoming
-                                                    pod labels, those key-value labels
-                                                    are merged with `LabelSelector`
-                                                    as `key in (value)` to select
-                                                    the group of existing pods which
-                                                    pods will be taken into consideration
-                                                    for the incoming pod's pod (anti)
-                                                    affinity. Keys that don't exist
-                                                    in the incoming pod labels will
-                                                    be ignored. The default value
-                                                    is empty. The same key is forbidden
-                                                    to exist in both MatchLabelKeys
-                                                    and LabelSelector. Also, MatchLabelKeys
-                                                    cannot be set when LabelSelector
-                                                    isn't set. This is an alpha field
-                                                    and requires enabling MatchLabelKeysInPodAffinity
-                                                    feature gate.
+                                                  description: |-
+                                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                                   items:
                                                     type: string
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                                 mismatchLabelKeys:
-                                                  description: MismatchLabelKeys is
-                                                    a set of pod label keys to select
-                                                    which pods will be taken into
-                                                    consideration. The keys are used
-                                                    to lookup values from the incoming
-                                                    pod labels, those key-value labels
-                                                    are merged with `LabelSelector`
-                                                    as `key notin (value)` to select
-                                                    the group of existing pods which
-                                                    pods will be taken into consideration
-                                                    for the incoming pod's pod (anti)
-                                                    affinity. Keys that don't exist
-                                                    in the incoming pod labels will
-                                                    be ignored. The default value
-                                                    is empty. The same key is forbidden
-                                                    to exist in both MismatchLabelKeys
-                                                    and LabelSelector. Also, MismatchLabelKeys
-                                                    cannot be set when LabelSelector
-                                                    isn't set. This is an alpha field
-                                                    and requires enabling MatchLabelKeysInPodAffinity
-                                                    feature gate.
+                                                  description: |-
+                                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                                   items:
                                                     type: string
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                                 namespaceSelector:
-                                                  description: A label query over
-                                                    the set of namespaces that the
-                                                    term applies to. The term is applied
-                                                    to the union of the namespaces
-                                                    selected by this field and the
-                                                    ones listed in the namespaces
-                                                    field. null selector and null
-                                                    or empty namespaces list means
-                                                    "this pod's namespace". An empty
-                                                    selector ({}) matches all namespaces.
+                                                  description: |-
+                                                    A label query over the set of namespaces that the term applies to.
+                                                    The term is applied to the union of the namespaces selected by this field
+                                                    and the ones listed in the namespaces field.
+                                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                                    An empty selector ({}) matches all namespaces.
                                                   properties:
                                                     matchExpressions:
                                                       description: matchExpressions
@@ -1140,10 +903,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -1152,24 +913,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -1182,51 +934,36 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 namespaces:
-                                                  description: namespaces specifies
-                                                    a static list of namespace names
-                                                    that the term applies to. The
-                                                    term is applied to the union of
-                                                    the namespaces listed in this
-                                                    field and the ones selected by
-                                                    namespaceSelector. null or empty
-                                                    namespaces list and null namespaceSelector
-                                                    means "this pod's namespace".
+                                                  description: |-
+                                                    namespaces specifies a static list of namespace names that the term applies to.
+                                                    The term is applied to the union of the namespaces listed in this field
+                                                    and the ones selected by namespaceSelector.
+                                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                   items:
                                                     type: string
                                                   type: array
                                                 topologyKey:
-                                                  description: This pod should be
-                                                    co-located (affinity) or not co-located
-                                                    (anti-affinity) with the pods
-                                                    matching the labelSelector in
-                                                    the specified namespaces, where
-                                                    co-located is defined as running
-                                                    on a node whose value of the label
-                                                    with key topologyKey matches that
-                                                    of any node on which any of the
-                                                    selected pods is running. Empty
-                                                    topologyKey is not allowed.
+                                                  description: |-
+                                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                                    selected pods is running.
+                                                    Empty topologyKey is not allowed.
                                                   type: string
                                               required:
                                               - topologyKey
                                               type: object
                                             weight:
-                                              description: weight associated with
-                                                matching the corresponding podAffinityTerm,
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
                                               format: int32
                                               type: integer
@@ -1236,45 +973,36 @@ spec:
                                           type: object
                                         type: array
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the anti-affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the anti-affinity requirements
-                                          specified by this field cease to be met
-                                          at some point during pod execution (e.g.
-                                          due to a pod label update), the system may
-                                          or may not try to eventually evict the pod
-                                          from its node. When there are multiple elements,
-                                          the lists of nodes corresponding to each
-                                          podAffinityTerm are intersected, i.e. all
-                                          terms must be satisfied.
+                                        description: |-
+                                          If the anti-affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the anti-affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                         items:
-                                          description: Defines a set of pods (namely
-                                            those matching the labelSelector relative
-                                            to the given namespace(s)) that this pod
-                                            should be co-located (affinity) or not
-                                            co-located (anti-affinity) with, where
-                                            co-located is defined as running on a
-                                            node whose value of the label with key
-                                            <topologyKey> matches that of any node
-                                            on which a pod of the set of pods is running
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
                                           properties:
                                             labelSelector:
-                                              description: A label query over a set
-                                                of resources, in this case pods. If
-                                                it's null, this PodAffinityTerm matches
-                                                with no Pods.
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -1282,23 +1010,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1310,87 +1031,59 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: MatchLabelKeys is a set
-                                                of pod label keys to select which
-                                                pods will be taken into consideration.
-                                                The keys are used to lookup values
-                                                from the incoming pod labels, those
-                                                key-value labels are merged with `LabelSelector`
-                                                as `key in (value)` to select the
-                                                group of existing pods which pods
-                                                will be taken into consideration for
-                                                the incoming pod's pod (anti) affinity.
-                                                Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default
-                                                value is empty. The same key is forbidden
-                                                to exist in both MatchLabelKeys and
-                                                LabelSelector. Also, MatchLabelKeys
-                                                cannot be set when LabelSelector isn't
-                                                set. This is an alpha field and requires
-                                                enabling MatchLabelKeysInPodAffinity
-                                                feature gate.
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: MismatchLabelKeys is a
-                                                set of pod label keys to select which
-                                                pods will be taken into consideration.
-                                                The keys are used to lookup values
-                                                from the incoming pod labels, those
-                                                key-value labels are merged with `LabelSelector`
-                                                as `key notin (value)` to select the
-                                                group of existing pods which pods
-                                                will be taken into consideration for
-                                                the incoming pod's pod (anti) affinity.
-                                                Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default
-                                                value is empty. The same key is forbidden
-                                                to exist in both MismatchLabelKeys
-                                                and LabelSelector. Also, MismatchLabelKeys
-                                                cannot be set when LabelSelector isn't
-                                                set. This is an alpha field and requires
-                                                enabling MatchLabelKeysInPodAffinity
-                                                feature gate.
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: A label query over the
-                                                set of namespaces that the term applies
-                                                to. The term is applied to the union
-                                                of the namespaces selected by this
-                                                field and the ones listed in the namespaces
-                                                field. null selector and null or empty
-                                                namespaces list means "this pod's
-                                                namespace". An empty selector ({})
-                                                matches all namespaces.
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -1398,23 +1091,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1426,41 +1112,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: namespaces specifies a
-                                                static list of namespace names that
-                                                the term applies to. The term is applied
-                                                to the union of the namespaces listed
-                                                in this field and the ones selected
-                                                by namespaceSelector. null or empty
-                                                namespaces list and null namespaceSelector
-                                                means "this pod's namespace".
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
@@ -1479,42 +1153,35 @@ spec:
                                     you want to run within a pod.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        container image''s CMD is used if this is
-                                        not provided. Variable references $(VAR_NAME)
-                                        are expanded using the container''s environment.
-                                        If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. Double
-                                        $$ are reduced to a single $, which allows
-                                        for escaping the $(VAR_NAME) syntax: i.e.
-                                        "$$(VAR_NAME)" will produce the string literal
-                                        "$(VAR_NAME)". Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The container image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The container image''s ENTRYPOINT
-                                        is used if this is not provided. Variable
-                                        references $(VAR_NAME) are expanded using
-                                        the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                        produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded,
-                                        regardless of whether the variable exists
-                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The container image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -1524,19 +1191,16 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previously defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. Double $$ are reduced to
-                                              a single $, which allows for escaping
-                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                              will produce the string literal "$(VAR_NAME)".
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -1550,10 +1214,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1565,11 +1229,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                                 properties:
                                                   apiVersion:
                                                     description: Version of the schema
@@ -1586,12 +1248,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                                 properties:
                                                   containerName:
                                                     description: 'Container name:
@@ -1625,10 +1284,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1644,15 +1303,13 @@ spec:
                                         type: object
                                       type: array
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -1661,10 +1318,10 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -1681,10 +1338,10 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1695,50 +1352,43 @@ spec:
                                         type: object
                                       type: array
                                     image:
-                                      description: 'Container image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images
-                                        This field is optional to allow higher level
-                                        config management to default or override container
-                                        images in workload controllers like Deployments
-                                        and StatefulSets.'
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
-                                      description: Actions that the management system
-                                        should take in response to container lifecycle
-                                        events. Cannot be updated.
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1748,10 +1398,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -1763,11 +1412,9 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name. This will be canonicalized
-                                                          upon output, so case-variant
-                                                          names will be understood
-                                                          as the same header.
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -1786,14 +1433,15 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
@@ -1812,12 +1460,10 @@ spec:
                                               - seconds
                                               type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1828,51 +1474,38 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The Pod''s termination grace
-                                            period countdown begins before the PreStop
-                                            hook is executed. Regardless of the outcome
-                                            of the handler, the container will eventually
-                                            terminate within the Pod''s termination
-                                            grace period (unless delayed by finalizers).
-                                            Other management of the container blocks
-                                            until the hook completes or until the
-                                            termination grace period is reached. More
-                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1882,10 +1515,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -1897,11 +1529,9 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name. This will be canonicalized
-                                                          upon output, so case-variant
-                                                          names will be understood
-                                                          as the same header.
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -1920,14 +1550,15 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
@@ -1946,12 +1577,10 @@ spec:
                                               - seconds
                                               type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1962,10 +1591,10 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -1973,35 +1602,31 @@ spec:
                                           type: object
                                       type: object
                                     livenessProbe:
-                                      description: 'Periodic probe of container liveness.
+                                      description: |-
+                                        Periodic probe of container liveness.
                                         Container will be restarted if the probe fails.
-                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -2015,11 +1640,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -2029,10 +1655,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2044,11 +1669,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -2067,36 +1690,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -2111,68 +1733,59 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the container specified
-                                        as a DNS_LABEL. Each container in a pod must
-                                        have a unique name (DNS_LABEL). Cannot be
-                                        updated.
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
                                       type: string
                                     ports:
-                                      description: List of ports to expose from the
-                                        container. Not specifying a port here DOES
-                                        NOT prevent that port from being exposed.
-                                        Any port which is listening on the default
-                                        "0.0.0.0" address inside a container will
-                                        be accessible from the network. Modifying
-                                        this array with strategic merge patch may
-                                        corrupt the data. For more information See
-                                        https://github.com/kubernetes/kubernetes/issues/108255.
+                                      description: |-
+                                        List of ports to expose from the container. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Modifying this array with strategic merge patch may corrupt the data.
+                                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                         Cannot be updated.
                                       items:
                                         description: ContainerPort represents a network
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -2180,25 +1793,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -2209,36 +1821,31 @@ spec:
                                       - protocol
                                       x-kubernetes-list-type: map
                                     readinessProbe:
-                                      description: 'Periodic probe of container service
-                                        readiness. Container will be removed from
-                                        service endpoints if the probe fails. Cannot
-                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -2252,11 +1859,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -2266,10 +1874,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2281,11 +1888,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -2304,36 +1909,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -2348,40 +1952,33 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
@@ -2393,14 +1990,14 @@ spec:
                                           resource resize policy for the container.
                                         properties:
                                           resourceName:
-                                            description: 'Name of the resource to
-                                              which this resource resize policy applies.
-                                              Supported values: cpu, memory.'
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
                                             type: string
                                           restartPolicy:
-                                            description: Restart policy to apply when
-                                              specified resource is resized. If not
-                                              specified, it defaults to NotRequired.
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
                                             type: string
                                         required:
                                         - resourceName
@@ -2409,27 +2006,30 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     resources:
-                                      description: 'Compute Resources required by
-                                        this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of
-                                            resources, defined in spec.resourceClaims,
-                                            that are used by this container. \n This
-                                            is an alpha field and requires enabling
-                                            the DynamicResourceAllocation feature
-                                            gate. \n This field is immutable. It can
-                                            only be set for containers."
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+
+                                            This is an alpha field and requires enabling the
+                                            DynamicResourceAllocation feature gate.
+
+
+                                            This field is immutable. It can only be set for containers.
                                           items:
                                             description: ResourceClaim references
                                               one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name
-                                                  of one entry in pod.spec.resourceClaims
-                                                  of the Pod where this field is used.
-                                                  It makes that resource available
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
                                                   inside a container.
                                                 type: string
                                             required:
@@ -2446,9 +2046,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -2457,65 +2057,52 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. Requests cannot exceed Limits.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                       type: object
                                     restartPolicy:
-                                      description: 'RestartPolicy defines the restart
-                                        behavior of individual containers in a pod.
-                                        This field may only be set for init containers,
-                                        and the only allowed value is "Always". For
-                                        non-init containers or when this field is
-                                        not specified, the restart behavior is defined
-                                        by the Pod''s restart policy and the container
-                                        type. Setting the RestartPolicy as "Always"
-                                        for the init container will have the following
-                                        effect: this init container will be continually
-                                        restarted on exit until all regular containers
-                                        have terminated. Once all regular containers
-                                        have completed, all init containers with restartPolicy
-                                        "Always" will be shut down. This lifecycle
-                                        differs from normal init containers and is
-                                        often referred to as a "sidecar" container.
-                                        Although this init container still starts
-                                        in the init container sequence, it does not
-                                        wait for the container to complete before
-                                        proceeding to the next init container. Instead,
-                                        the next init container starts immediately
-                                        after this init container is started, or after
-                                        any startupProbe has successfully completed.'
+                                      description: |-
+                                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                                        This field may only be set for init containers, and the only allowed value is "Always".
+                                        For non-init containers or when this field is not specified,
+                                        the restart behavior is defined by the Pod's restart policy and the container type.
+                                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                        this init container will be continually restarted on
+                                        exit until all regular containers have terminated. Once all regular
+                                        containers have completed, all init containers with restartPolicy "Always"
+                                        will be shut down. This lifecycle differs from normal init containers and
+                                        is often referred to as a "sidecar" container. Although this init
+                                        container still starts in the init container sequence, it does not wait
+                                        for the container to complete before proceeding to the next init
+                                        container. Instead, the next init container starts immediately after this
+                                        init container is started, or after any startupProbe has successfully
+                                        completed.
                                       type: string
                                     securityContext:
-                                      description: 'SecurityContext defines the security
-                                        options the container should be run with.
-                                        If set, the fields of SecurityContext override
-                                        the equivalent fields of PodSecurityContext.
-                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      description: |-
+                                        SecurityContext defines the security options the container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN
-                                            Note that this field cannot be set when
-                                            spec.os.name is windows.'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime. Note that this
-                                            field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -2533,73 +2120,60 @@ spec:
                                               type: array
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false. Note that
-                                            this field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled. Note that this field cannot
-                                            be set when spec.os.name is windows.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false. Note that this field cannot be
-                                            set when spec.os.name is windows.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -2619,53 +2193,44 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must be set if type
-                                                is "Localhost". Must NOT be set for
-                                                any other type.
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence. Note
-                                            that this field cannot be set when spec.os.name
-                                            is linux.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -2673,67 +2238,50 @@ spec:
                                                 spec to use.
                                               type: string
                                             hostProcess:
-                                              description: HostProcess determines
-                                                if a container should be run as a
-                                                'Host Process' container. All of a
-                                                Pod's containers must have the same
-                                                effective HostProcess value (it is
-                                                not allowed to have a mix of HostProcess
-                                                containers and non-HostProcess containers).
-                                                In addition, if HostProcess is true
-                                                then HostNetwork must also be set
-                                                to true.
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
                                               type: boolean
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
                                     startupProbe:
-                                      description: 'StartupProbe indicates that the
-                                        Pod has successfully initialized. If specified,
-                                        no other probes are executed until this completes
-                                        successfully. If this probe fails, the Pod
-                                        will be restarted, just as if the livenessProbe
-                                        failed. This can be used to provide different
-                                        probe parameters at the beginning of a Pod''s
-                                        lifecycle, when it might take a long time
-                                        to load data or warm a cache, than during
-                                        steady-state operation. This cannot be updated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -2747,11 +2295,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -2761,10 +2310,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2776,11 +2324,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -2799,36 +2345,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -2843,93 +2388,76 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -2953,48 +2481,45 @@ spec:
                                         type: object
                                       type: array
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
@@ -3002,34 +2527,36 @@ spec:
                                         type: object
                                       type: array
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
                               dnsConfig:
-                                description: Specifies the DNS parameters of a pod.
-                                  Parameters specified here will be merged to the
-                                  generated DNS configuration based on DNSPolicy.
+                                description: |-
+                                  Specifies the DNS parameters of a pod.
+                                  Parameters specified here will be merged to the generated DNS
+                                  configuration based on DNSPolicy.
                                 properties:
                                   nameservers:
-                                    description: A list of DNS name server IP addresses.
-                                      This will be appended to the base nameservers
-                                      generated from DNSPolicy. Duplicated nameservers
-                                      will be removed.
+                                    description: |-
+                                      A list of DNS name server IP addresses.
+                                      This will be appended to the base nameservers generated from DNSPolicy.
+                                      Duplicated nameservers will be removed.
                                     items:
                                       type: string
                                     type: array
                                   options:
-                                    description: A list of DNS resolver options. This
-                                      will be merged with the base options generated
-                                      from DNSPolicy. Duplicated entries will be removed.
-                                      Resolution options given in Options will override
-                                      those that appear in the base DNSPolicy.
+                                    description: |-
+                                      A list of DNS resolver options.
+                                      This will be merged with the base options generated from DNSPolicy.
+                                      Duplicated entries will be removed. Resolution options given in Options
+                                      will override those that appear in the base DNSPolicy.
                                     items:
                                       description: PodDNSConfigOption defines DNS
                                         resolver options of a pod.
@@ -3042,9 +2569,9 @@ spec:
                                       type: object
                                     type: array
                                   searches:
-                                    description: A list of DNS search domains for
-                                      host-name lookup. This will be appended to the
-                                      base search paths generated from DNSPolicy.
+                                    description: |-
+                                      A list of DNS search domains for host-name lookup.
+                                      This will be appended to the base search paths generated from DNSPolicy.
                                       Duplicated search paths will be removed.
                                     items:
                                       type: string
@@ -3055,61 +2582,54 @@ spec:
                                   be configured.
                                 type: string
                               enableServiceLinks:
-                                description: 'EnableServiceLinks indicates whether
-                                  information about services should be injected into
-                                  pod''s environment variables, matching the syntax
-                                  of Docker links. Optional: Defaults to true.'
+                                description: |-
+                                  EnableServiceLinks indicates whether information about services should be injected into pod's
+                                  environment variables, matching the syntax of Docker links.
+                                  Optional: Defaults to true.
                                 type: boolean
                               ephemeralContainers:
                                 items:
-                                  description: "An EphemeralContainer is a temporary
-                                    container that you may add to an existing Pod
-                                    for user-initiated activities such as debugging.
-                                    Ephemeral containers have no resource or scheduling
-                                    guarantees, and they will not be restarted when
-                                    they exit or when a Pod is removed or restarted.
-                                    The kubelet may evict a Pod if an ephemeral container
-                                    causes the Pod to exceed its resource allocation.
-                                    \n To add an ephemeral container, use the ephemeralcontainers
-                                    subresource of an existing Pod. Ephemeral containers
-                                    may not be removed or restarted."
+                                  description: |-
+                                    An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                    user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                    scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                    removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                    Pod to exceed its resource allocation.
+
+
+                                    To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                                    Pod. Ephemeral containers may not be removed or restarted.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        image''s CMD is used if this is not provided.
-                                        Variable references $(VAR_NAME) are expanded
-                                        using the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                        produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded,
-                                        regardless of whether the variable exists
-                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The image''s ENTRYPOINT is
-                                        used if this is not provided. Variable references
-                                        $(VAR_NAME) are expanded using the container''s
-                                        environment. If a variable cannot be resolved,
-                                        the reference in the input string will be
-                                        unchanged. Double $$ are reduced to a single
-                                        $, which allows for escaping the $(VAR_NAME)
-                                        syntax: i.e. "$$(VAR_NAME)" will produce the
-                                        string literal "$(VAR_NAME)". Escaped references
-                                        will never be expanded, regardless of whether
-                                        the variable exists or not. Cannot be updated.
-                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -3119,19 +2639,16 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previously defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. Double $$ are reduced to
-                                              a single $, which allows for escaping
-                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                              will produce the string literal "$(VAR_NAME)".
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -3145,10 +2662,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3160,11 +2677,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                                 properties:
                                                   apiVersion:
                                                     description: Version of the schema
@@ -3181,12 +2696,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                                 properties:
                                                   containerName:
                                                     description: 'Container name:
@@ -3220,10 +2732,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3239,15 +2751,13 @@ spec:
                                         type: object
                                       type: array
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -3256,10 +2766,10 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -3276,10 +2786,10 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3290,45 +2800,40 @@ spec:
                                         type: object
                                       type: array
                                     image:
-                                      description: 'Container image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images'
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
                                       description: Lifecycle is not allowed for ephemeral
                                         containers.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -3338,10 +2843,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -3353,11 +2857,9 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name. This will be canonicalized
-                                                          upon output, so case-variant
-                                                          names will be understood
-                                                          as the same header.
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -3376,14 +2878,15 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
@@ -3402,12 +2905,10 @@ spec:
                                               - seconds
                                               type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -3418,51 +2919,38 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The Pod''s termination grace
-                                            period countdown begins before the PreStop
-                                            hook is executed. Regardless of the outcome
-                                            of the handler, the container will eventually
-                                            terminate within the Pod''s termination
-                                            grace period (unless delayed by finalizers).
-                                            Other management of the container blocks
-                                            until the hook completes or until the
-                                            termination grace period is reached. More
-                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -3472,10 +2960,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -3487,11 +2974,9 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name. This will be canonicalized
-                                                          upon output, so case-variant
-                                                          names will be understood
-                                                          as the same header.
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -3510,14 +2995,15 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
@@ -3536,12 +3022,10 @@ spec:
                                               - seconds
                                               type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -3552,10 +3036,10 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -3571,26 +3055,20 @@ spec:
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -3604,11 +3082,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -3618,10 +3097,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3633,11 +3111,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -3656,36 +3132,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -3700,48 +3175,40 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the ephemeral container
-                                        specified as a DNS_LABEL. This name must be
-                                        unique among all containers, init containers
-                                        and ephemeral containers.
+                                      description: |-
+                                        Name of the ephemeral container specified as a DNS_LABEL.
+                                        This name must be unique among all containers, init containers and ephemeral containers.
                                       type: string
                                     ports:
                                       description: Ports are not allowed for ephemeral
@@ -3751,9 +3218,9 @@ spec:
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -3761,25 +3228,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -3798,26 +3264,20 @@ spec:
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -3831,11 +3291,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -3845,10 +3306,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3860,11 +3320,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -3883,36 +3341,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -3927,40 +3384,33 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
@@ -3972,14 +3422,14 @@ spec:
                                           resource resize policy for the container.
                                         properties:
                                           resourceName:
-                                            description: 'Name of the resource to
-                                              which this resource resize policy applies.
-                                              Supported values: cpu, memory.'
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
                                             type: string
                                           restartPolicy:
-                                            description: Restart policy to apply when
-                                              specified resource is resized. If not
-                                              specified, it defaults to NotRequired.
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
                                             type: string
                                         required:
                                         - resourceName
@@ -3988,27 +3438,29 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     resources:
-                                      description: Resources are not allowed for ephemeral
-                                        containers. Ephemeral containers use spare
-                                        resources already allocated to the pod.
+                                      description: |-
+                                        Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                        already allocated to the pod.
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of
-                                            resources, defined in spec.resourceClaims,
-                                            that are used by this container. \n This
-                                            is an alpha field and requires enabling
-                                            the DynamicResourceAllocation feature
-                                            gate. \n This field is immutable. It can
-                                            only be set for containers."
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+
+                                            This is an alpha field and requires enabling the
+                                            DynamicResourceAllocation feature gate.
+
+
+                                            This field is immutable. It can only be set for containers.
                                           items:
                                             description: ResourceClaim references
                                               one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name
-                                                  of one entry in pod.spec.resourceClaims
-                                                  of the Pod where this field is used.
-                                                  It makes that resource available
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
                                                   inside a container.
                                                 type: string
                                             required:
@@ -4025,9 +3477,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -4036,47 +3488,40 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. Requests cannot exceed Limits.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                       type: object
                                     restartPolicy:
-                                      description: Restart policy for the container
-                                        to manage the restart behavior of each container
-                                        within a pod. This may only be set for init
-                                        containers. You cannot set this field on ephemeral
-                                        containers.
+                                      description: |-
+                                        Restart policy for the container to manage the restart behavior of each
+                                        container within a pod.
+                                        This may only be set for init containers. You cannot set this field on
+                                        ephemeral containers.
                                       type: string
                                     securityContext:
-                                      description: 'Optional: SecurityContext defines
-                                        the security options the ephemeral container
-                                        should be run with. If set, the fields of
-                                        SecurityContext override the equivalent fields
-                                        of PodSecurityContext.'
+                                      description: |-
+                                        Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN
-                                            Note that this field cannot be set when
-                                            spec.os.name is windows.'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime. Note that this
-                                            field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -4094,73 +3539,60 @@ spec:
                                               type: array
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false. Note that
-                                            this field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled. Note that this field cannot
-                                            be set when spec.os.name is windows.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false. Note that this field cannot be
-                                            set when spec.os.name is windows.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -4180,53 +3612,44 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must be set if type
-                                                is "Localhost". Must NOT be set for
-                                                any other type.
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence. Note
-                                            that this field cannot be set when spec.os.name
-                                            is linux.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -4234,26 +3657,18 @@ spec:
                                                 spec to use.
                                               type: string
                                             hostProcess:
-                                              description: HostProcess determines
-                                                if a container should be run as a
-                                                'Host Process' container. All of a
-                                                Pod's containers must have the same
-                                                effective HostProcess value (it is
-                                                not allowed to have a mix of HostProcess
-                                                containers and non-HostProcess containers).
-                                                In addition, if HostProcess is true
-                                                then HostNetwork must also be set
-                                                to true.
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
                                               type: boolean
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
@@ -4266,26 +3681,20 @@ spec:
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -4299,11 +3708,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -4313,10 +3723,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -4328,11 +3737,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -4351,36 +3758,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -4395,105 +3801,86 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     targetContainerName:
-                                      description: "If set, the name of the container
-                                        from PodSpec that this ephemeral container
-                                        targets. The ephemeral container will be run
-                                        in the namespaces (IPC, PID, etc) of this
-                                        container. If not set then the ephemeral container
-                                        uses the namespaces configured in the Pod
-                                        spec. \n The container runtime must implement
-                                        support for this feature. If the runtime does
-                                        not support namespace targeting then the result
-                                        of setting this field is undefined."
+                                      description: |-
+                                        If set, the name of the container from PodSpec that this ephemeral container targets.
+                                        The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                        If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                        The container runtime must implement support for this feature. If the runtime does not
+                                        support namespace targeting then the result of setting this field is undefined.
                                       type: string
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -4517,49 +3904,45 @@ spec:
                                         type: object
                                       type: array
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Subpath mounts are not allowed
-                                        for ephemeral containers. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
@@ -4567,24 +3950,24 @@ spec:
                                         type: object
                                       type: array
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
                               hostAliases:
-                                description: HostAliases is an optional list of hosts
-                                  and IPs that will be injected into the pod's hosts
-                                  file if specified. This is only valid for non-hostNetwork
-                                  pods.
+                                description: |-
+                                  HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                  file if specified. This is only valid for non-hostNetwork pods.
                                 items:
-                                  description: HostAlias holds the mapping between
-                                    IP and hostnames that will be injected as an entry
-                                    in the pod's hosts file.
+                                  description: |-
+                                    HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                    pod's hosts file.
                                   properties:
                                     hostnames:
                                       description: Hostnames for the above IP address.
@@ -4597,55 +3980,53 @@ spec:
                                   type: object
                                 type: array
                               hostIPC:
-                                description: 'Use the host''s ipc namespace. Optional:
-                                  Default to false.'
+                                description: |-
+                                  Use the host's ipc namespace.
+                                  Optional: Default to false.
                                 type: boolean
                               hostNetwork:
-                                description: Host networking requested for this pod.
-                                  Use the host's network namespace. If this option
-                                  is set, the ports that will be used must be specified.
+                                description: |-
+                                  Host networking requested for this pod. Use the host's network namespace.
+                                  If this option is set, the ports that will be used must be specified.
                                   Default to false.
                                 type: boolean
                               hostPID:
-                                description: 'Use the host''s pid namespace. Optional:
-                                  Default to false.'
+                                description: |-
+                                  Use the host's pid namespace.
+                                  Optional: Default to false.
                                 type: boolean
                               hostUsers:
-                                description: 'Use the host''s user namespace. Optional:
-                                  Default to true. If set to true or not present,
-                                  the pod will be run in the host user namespace,
-                                  useful for when the pod needs a feature only available
-                                  to the host user namespace, such as loading a kernel
-                                  module with CAP_SYS_MODULE. When set to false, a
-                                  new userns is created for the pod. Setting false
-                                  is useful for mitigating container breakout vulnerabilities
-                                  even allowing users to run their containers as root
-                                  without actually having root privileges on the host.
-                                  This field is alpha-level and is only honored by
-                                  servers that enable the UserNamespacesSupport feature.'
+                                description: |-
+                                  Use the host's user namespace.
+                                  Optional: Default to true.
+                                  If set to true or not present, the pod will be run in the host user namespace, useful
+                                  for when the pod needs a feature only available to the host user namespace, such as
+                                  loading a kernel module with CAP_SYS_MODULE.
+                                  When set to false, a new userns is created for the pod. Setting false is useful for
+                                  mitigating container breakout vulnerabilities even allowing users to run their
+                                  containers as root without actually having root privileges on the host.
+                                  This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                                 type: boolean
                               hostname:
-                                description: Specifies the hostname of the Pod If
-                                  not specified, the pod's hostname will be set to
-                                  a system-defined value.
+                                description: |-
+                                  Specifies the hostname of the Pod
+                                  If not specified, the pod's hostname will be set to a system-defined value.
                                 type: string
                               imagePullSecrets:
-                                description: 'ImagePullSecrets is an optional list
-                                  of references to secrets in the same namespace to
-                                  use for pulling any of the images used by this PodSpec.
-                                  If specified, these secrets will be passed to individual
-                                  puller implementations for them to use. More info:
-                                  https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                description: |-
+                                  ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                  If specified, these secrets will be passed to individual puller implementations for them to use.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                                 items:
-                                  description: LocalObjectReference contains enough
-                                    information to let you locate the referenced object
-                                    inside the same namespace.
+                                  description: |-
+                                    LocalObjectReference contains enough information to let you locate the
+                                    referenced object inside the same namespace.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -4656,42 +4037,35 @@ spec:
                                     you want to run within a pod.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        container image''s CMD is used if this is
-                                        not provided. Variable references $(VAR_NAME)
-                                        are expanded using the container''s environment.
-                                        If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. Double
-                                        $$ are reduced to a single $, which allows
-                                        for escaping the $(VAR_NAME) syntax: i.e.
-                                        "$$(VAR_NAME)" will produce the string literal
-                                        "$(VAR_NAME)". Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The container image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The container image''s ENTRYPOINT
-                                        is used if this is not provided. Variable
-                                        references $(VAR_NAME) are expanded using
-                                        the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                        produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded,
-                                        regardless of whether the variable exists
-                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The container image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -4701,19 +4075,16 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previously defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. Double $$ are reduced to
-                                              a single $, which allows for escaping
-                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                              will produce the string literal "$(VAR_NAME)".
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -4727,10 +4098,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4742,11 +4113,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                                 properties:
                                                   apiVersion:
                                                     description: Version of the schema
@@ -4763,12 +4132,9 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                                 properties:
                                                   containerName:
                                                     description: 'Container name:
@@ -4802,10 +4168,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -4821,15 +4187,13 @@ spec:
                                         type: object
                                       type: array
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -4838,10 +4202,10 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -4858,10 +4222,10 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -4872,50 +4236,43 @@ spec:
                                         type: object
                                       type: array
                                     image:
-                                      description: 'Container image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images
-                                        This field is optional to allow higher level
-                                        config management to default or override container
-                                        images in workload controllers like Deployments
-                                        and StatefulSets.'
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
-                                      description: Actions that the management system
-                                        should take in response to container lifecycle
-                                        events. Cannot be updated.
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -4925,10 +4282,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -4940,11 +4296,9 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name. This will be canonicalized
-                                                          upon output, so case-variant
-                                                          names will be understood
-                                                          as the same header.
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -4963,14 +4317,15 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
@@ -4989,12 +4344,10 @@ spec:
                                               - seconds
                                               type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -5005,51 +4358,38 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The Pod''s termination grace
-                                            period countdown begins before the PreStop
-                                            hook is executed. Regardless of the outcome
-                                            of the handler, the container will eventually
-                                            terminate within the Pod''s termination
-                                            grace period (unless delayed by finalizers).
-                                            Other management of the container blocks
-                                            until the hook completes or until the
-                                            termination grace period is reached. More
-                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
                                               description: Exec specifies the action
                                                 to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -5059,10 +4399,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -5074,11 +4413,9 @@ spec:
                                                       HTTP probes
                                                     properties:
                                                       name:
-                                                        description: The header field
-                                                          name. This will be canonicalized
-                                                          upon output, so case-variant
-                                                          names will be understood
-                                                          as the same header.
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -5097,14 +4434,15 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
@@ -5123,12 +4461,10 @@ spec:
                                               - seconds
                                               type: object
                                             tcpSocket:
-                                              description: Deprecated. TCPSocket is
-                                                NOT supported as a LifecycleHandler
-                                                and kept for the backward compatibility.
-                                                There are no validation of this field
-                                                and lifecycle hooks will fail in runtime
-                                                when tcp handler is specified.
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for the backward compatibility. There are no validation of this field and
+                                                lifecycle hooks will fail in runtime when tcp handler is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -5139,10 +4475,10 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -5150,35 +4486,31 @@ spec:
                                           type: object
                                       type: object
                                     livenessProbe:
-                                      description: 'Periodic probe of container liveness.
+                                      description: |-
+                                        Periodic probe of container liveness.
                                         Container will be restarted if the probe fails.
-                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -5192,11 +4524,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -5206,10 +4539,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -5221,11 +4553,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -5244,36 +4574,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -5288,68 +4617,59 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the container specified
-                                        as a DNS_LABEL. Each container in a pod must
-                                        have a unique name (DNS_LABEL). Cannot be
-                                        updated.
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
                                       type: string
                                     ports:
-                                      description: List of ports to expose from the
-                                        container. Not specifying a port here DOES
-                                        NOT prevent that port from being exposed.
-                                        Any port which is listening on the default
-                                        "0.0.0.0" address inside a container will
-                                        be accessible from the network. Modifying
-                                        this array with strategic merge patch may
-                                        corrupt the data. For more information See
-                                        https://github.com/kubernetes/kubernetes/issues/108255.
+                                      description: |-
+                                        List of ports to expose from the container. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Modifying this array with strategic merge patch may corrupt the data.
+                                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                         Cannot be updated.
                                       items:
                                         description: ContainerPort represents a network
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -5357,25 +4677,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -5386,36 +4705,31 @@ spec:
                                       - protocol
                                       x-kubernetes-list-type: map
                                     readinessProbe:
-                                      description: 'Periodic probe of container service
-                                        readiness. Container will be removed from
-                                        service endpoints if the probe fails. Cannot
-                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -5429,11 +4743,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -5443,10 +4758,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -5458,11 +4772,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -5481,36 +4793,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -5525,40 +4836,33 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
@@ -5570,14 +4874,14 @@ spec:
                                           resource resize policy for the container.
                                         properties:
                                           resourceName:
-                                            description: 'Name of the resource to
-                                              which this resource resize policy applies.
-                                              Supported values: cpu, memory.'
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
                                             type: string
                                           restartPolicy:
-                                            description: Restart policy to apply when
-                                              specified resource is resized. If not
-                                              specified, it defaults to NotRequired.
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
                                             type: string
                                         required:
                                         - resourceName
@@ -5586,27 +4890,30 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     resources:
-                                      description: 'Compute Resources required by
-                                        this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       properties:
                                         claims:
-                                          description: "Claims lists the names of
-                                            resources, defined in spec.resourceClaims,
-                                            that are used by this container. \n This
-                                            is an alpha field and requires enabling
-                                            the DynamicResourceAllocation feature
-                                            gate. \n This field is immutable. It can
-                                            only be set for containers."
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+
+                                            This is an alpha field and requires enabling the
+                                            DynamicResourceAllocation feature gate.
+
+
+                                            This field is immutable. It can only be set for containers.
                                           items:
                                             description: ResourceClaim references
                                               one entry in PodSpec.ResourceClaims.
                                             properties:
                                               name:
-                                                description: Name must match the name
-                                                  of one entry in pod.spec.resourceClaims
-                                                  of the Pod where this field is used.
-                                                  It makes that resource available
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
                                                   inside a container.
                                                 type: string
                                             required:
@@ -5623,9 +4930,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -5634,65 +4941,52 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. Requests cannot exceed Limits.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                           type: object
                                       type: object
                                     restartPolicy:
-                                      description: 'RestartPolicy defines the restart
-                                        behavior of individual containers in a pod.
-                                        This field may only be set for init containers,
-                                        and the only allowed value is "Always". For
-                                        non-init containers or when this field is
-                                        not specified, the restart behavior is defined
-                                        by the Pod''s restart policy and the container
-                                        type. Setting the RestartPolicy as "Always"
-                                        for the init container will have the following
-                                        effect: this init container will be continually
-                                        restarted on exit until all regular containers
-                                        have terminated. Once all regular containers
-                                        have completed, all init containers with restartPolicy
-                                        "Always" will be shut down. This lifecycle
-                                        differs from normal init containers and is
-                                        often referred to as a "sidecar" container.
-                                        Although this init container still starts
-                                        in the init container sequence, it does not
-                                        wait for the container to complete before
-                                        proceeding to the next init container. Instead,
-                                        the next init container starts immediately
-                                        after this init container is started, or after
-                                        any startupProbe has successfully completed.'
+                                      description: |-
+                                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                                        This field may only be set for init containers, and the only allowed value is "Always".
+                                        For non-init containers or when this field is not specified,
+                                        the restart behavior is defined by the Pod's restart policy and the container type.
+                                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                        this init container will be continually restarted on
+                                        exit until all regular containers have terminated. Once all regular
+                                        containers have completed, all init containers with restartPolicy "Always"
+                                        will be shut down. This lifecycle differs from normal init containers and
+                                        is often referred to as a "sidecar" container. Although this init
+                                        container still starts in the init container sequence, it does not wait
+                                        for the container to complete before proceeding to the next init
+                                        container. Instead, the next init container starts immediately after this
+                                        init container is started, or after any startupProbe has successfully
+                                        completed.
                                       type: string
                                     securityContext:
-                                      description: 'SecurityContext defines the security
-                                        options the container should be run with.
-                                        If set, the fields of SecurityContext override
-                                        the equivalent fields of PodSecurityContext.
-                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      description: |-
+                                        SecurityContext defines the security options the container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN
-                                            Note that this field cannot be set when
-                                            spec.os.name is windows.'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime. Note that this
-                                            field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -5710,73 +5004,60 @@ spec:
                                               type: array
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false. Note that
-                                            this field cannot be set when spec.os.name
-                                            is windows.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled. Note that this field cannot
-                                            be set when spec.os.name is windows.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false. Note that this field cannot be
-                                            set when spec.os.name is windows.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -5796,53 +5077,44 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options. Note that this field
-                                            cannot be set when spec.os.name is windows.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must be set if type
-                                                is "Localhost". Must NOT be set for
-                                                any other type.
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence. Note
-                                            that this field cannot be set when spec.os.name
-                                            is linux.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -5850,67 +5122,50 @@ spec:
                                                 spec to use.
                                               type: string
                                             hostProcess:
-                                              description: HostProcess determines
-                                                if a container should be run as a
-                                                'Host Process' container. All of a
-                                                Pod's containers must have the same
-                                                effective HostProcess value (it is
-                                                not allowed to have a mix of HostProcess
-                                                containers and non-HostProcess containers).
-                                                In addition, if HostProcess is true
-                                                then HostNetwork must also be set
-                                                to true.
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
                                               type: boolean
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
                                     startupProbe:
-                                      description: 'StartupProbe indicates that the
-                                        Pod has successfully initialized. If specified,
-                                        no other probes are executed until this completes
-                                        successfully. If this probe fails, the Pod
-                                        will be restarted, just as if the livenessProbe
-                                        failed. This can be used to provide different
-                                        probe parameters at the beginning of a Pod''s
-                                        lifecycle, when it might take a long time
-                                        to load data or warm a cache, than during
-                                        steady-state operation. This cannot be updated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
                                           description: Exec specifies the action to
                                             take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         grpc:
@@ -5924,11 +5179,12 @@ spec:
                                               format: int32
                                               type: integer
                                             service:
-                                              description: "Service is the name of
-                                                the service to place in the gRPC HealthCheckRequest
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
                                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                                \n If this is not specified, the default
-                                                behavior is defined by gRPC."
+
+
+                                                If this is not specified, the default behavior is defined by gRPC.
                                               type: string
                                           required:
                                           - port
@@ -5938,10 +5194,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -5953,11 +5208,9 @@ spec:
                                                   probes
                                                 properties:
                                                   name:
-                                                    description: The header field
-                                                      name. This will be canonicalized
-                                                      upon output, so case-variant
-                                                      names will be understood as
-                                                      the same header.
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
                                                     description: The header field
@@ -5976,36 +5229,35 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
@@ -6020,93 +5272,76 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         terminationGracePeriodSeconds:
-                                          description: Optional duration in seconds
-                                            the pod needs to terminate gracefully
-                                            upon probe failure. The grace period is
-                                            the duration in seconds after the processes
-                                            running in the pod are sent a termination
-                                            signal and the time when the processes
-                                            are forcibly halted with a kill signal.
-                                            Set this value longer than the expected
-                                            cleanup time for your process. If this
-                                            value is nil, the pod's terminationGracePeriodSeconds
-                                            will be used. Otherwise, this value overrides
-                                            the value provided by the pod spec. Value
-                                            must be non-negative integer. The value
-                                            zero indicates stop immediately via the
-                                            kill signal (no opportunity to shut down).
-                                            This is a beta field and requires enabling
-                                            ProbeTerminationGracePeriod feature gate.
-                                            Minimum value is 1. spec.terminationGracePeriodSeconds
-                                            is used if unset.
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -6130,48 +5365,45 @@ spec:
                                         type: object
                                       type: array
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
@@ -6179,59 +5411,70 @@ spec:
                                         type: object
                                       type: array
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
                               nodeName:
-                                description: NodeName is a request to schedule this
-                                  pod onto a specific node. If it is non-empty, the
-                                  scheduler simply schedules this pod onto that node,
-                                  assuming that it fits resource requirements.
+                                description: |-
+                                  NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                  the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                  requirements.
                                 type: string
                               nodeSelector:
                                 additionalProperties:
                                   type: string
-                                description: 'NodeSelector is a selector which must
-                                  be true for the pod to fit on a node. Selector which
-                                  must match a node''s labels for the pod to be scheduled
-                                  on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                description: |-
+                                  NodeSelector is a selector which must be true for the pod to fit on a node.
+                                  Selector which must match a node's labels for the pod to be scheduled on that node.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                 type: object
                                 x-kubernetes-map-type: atomic
                               os:
-                                description: "Specifies the OS of the containers in
-                                  the pod. Some pod and container fields are restricted
-                                  if this is set. \n If the OS field is set to linux,
-                                  the following fields must be unset: -securityContext.windowsOptions
-                                  \n If the OS field is set to windows, following
-                                  fields must be unset: - spec.hostPID - spec.hostIPC
-                                  - spec.hostUsers - spec.securityContext.seLinuxOptions
-                                  - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                                  - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                                  - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                                  - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
+                                description: |-
+                                  Specifies the OS of the containers in the pod.
+                                  Some pod and container fields are restricted if this is set.
+
+
+                                  If the OS field is set to linux, the following fields must be unset:
+                                  -securityContext.windowsOptions
+
+
+                                  If the OS field is set to windows, following fields must be unset:
+                                  - spec.hostPID
+                                  - spec.hostIPC
+                                  - spec.hostUsers
+                                  - spec.securityContext.seLinuxOptions
+                                  - spec.securityContext.seccompProfile
+                                  - spec.securityContext.fsGroup
+                                  - spec.securityContext.fsGroupChangePolicy
+                                  - spec.securityContext.sysctls
+                                  - spec.shareProcessNamespace
+                                  - spec.securityContext.runAsUser
+                                  - spec.securityContext.runAsGroup
+                                  - spec.securityContext.supplementalGroups
                                   - spec.containers[*].securityContext.seLinuxOptions
                                   - spec.containers[*].securityContext.seccompProfile
                                   - spec.containers[*].securityContext.capabilities
                                   - spec.containers[*].securityContext.readOnlyRootFilesystem
                                   - spec.containers[*].securityContext.privileged
                                   - spec.containers[*].securityContext.allowPrivilegeEscalation
-                                  - spec.containers[*].securityContext.procMount -
-                                  spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup"
+                                  - spec.containers[*].securityContext.procMount
+                                  - spec.containers[*].securityContext.runAsUser
+                                  - spec.containers[*].securityContext.runAsGroup
                                 properties:
                                   name:
-                                    description: 'Name is the name of the operating
-                                      system. The currently supported values are linux
-                                      and windows. Additional value may be defined
-                                      in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                      Clients should expect to handle additional values
-                                      and treat unrecognized values in this field
-                                      as os: null'
+                                    description: |-
+                                      Name is the name of the operating system. The currently supported values are linux and windows.
+                                      Additional value may be defined in future and can be one of:
+                                      https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                      Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                     type: string
                                 required:
                                 - name
@@ -6243,49 +5486,45 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Overhead represents the resource overhead
-                                  associated with running a pod for a given RuntimeClass.
-                                  This field will be autopopulated at admission time
-                                  by the RuntimeClass admission controller. If the
-                                  RuntimeClass admission controller is enabled, overhead
-                                  must not be set in Pod create requests. The RuntimeClass
-                                  admission controller will reject Pod create requests
-                                  which have the overhead already set. If RuntimeClass
-                                  is configured and selected in the PodSpec, Overhead
-                                  will be set to the value defined in the corresponding
-                                  RuntimeClass, otherwise it will remain unset and
-                                  treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                description: |-
+                                  Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                  This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                  the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                  The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                  set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                                  defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
                                 type: object
                               preemptionPolicy:
-                                description: PreemptionPolicy is the Policy for preempting
-                                  pods with lower priority. One of Never, PreemptLowerPriority.
+                                description: |-
+                                  PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                  One of Never, PreemptLowerPriority.
                                   Defaults to PreemptLowerPriority if unset.
                                 type: string
                               priority:
-                                description: The priority value. Various system components
-                                  use this field to find the priority of the pod.
-                                  When Priority Admission Controller is enabled, it
-                                  prevents users from setting this field. The admission
-                                  controller populates this field from PriorityClassName.
+                                description: |-
+                                  The priority value. Various system components use this field to find the
+                                  priority of the pod. When Priority Admission Controller is enabled, it
+                                  prevents users from setting this field. The admission controller populates
+                                  this field from PriorityClassName.
                                   The higher the value, the higher the priority.
                                 format: int32
                                 type: integer
                               priorityClassName:
-                                description: If specified, indicates the pod's priority.
-                                  "system-node-critical" and "system-cluster-critical"
-                                  are two special keywords which indicate the highest
-                                  priorities with the former being the highest priority.
-                                  Any other name must be defined by creating a PriorityClass
-                                  object with that name. If not specified, the pod
-                                  priority will be default or zero if there is no
+                                description: |-
+                                  If specified, indicates the pod's priority. "system-node-critical" and
+                                  "system-cluster-critical" are two special keywords which indicate the
+                                  highest priorities with the former being the highest priority. Any other
+                                  name must be defined by creating a PriorityClass object with that name.
+                                  If not specified, the pod priority will be default or zero if there is no
                                   default.
                                 type: string
                               readinessGates:
-                                description: 'If specified, all readiness gates will
-                                  be evaluated for pod readiness. A pod is ready when
-                                  all its containers are ready AND all conditions
-                                  specified in the readiness gates have status equal
-                                  to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                                description: |-
+                                  If specified, all readiness gates will be evaluated for pod readiness.
+                                  A pod is ready when all its containers are ready AND
+                                  all conditions specified in the readiness gates have status equal to "True"
+                                  More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                                 items:
                                   description: PodReadinessGate contains the reference
                                     to a pod condition
@@ -6300,100 +5539,93 @@ spec:
                                   type: object
                                 type: array
                               restartPolicy:
-                                description: RestartPolicy describes how the container
-                                  should be restarted. Only one of the following restart
-                                  policies may be specified. If none of the following
-                                  policies is specified, the default one is RestartPolicyAlways.
+                                description: |-
+                                  RestartPolicy describes how the container should be restarted.
+                                  Only one of the following restart policies may be specified.
+                                  If none of the following policies is specified, the default one
+                                  is RestartPolicyAlways.
                                 type: string
                               runtimeClassName:
-                                description: 'RuntimeClassName refers to a RuntimeClass
-                                  object in the node.k8s.io group, which should be
-                                  used to run this pod.  If no RuntimeClass resource
-                                  matches the named class, the pod will not be run.
-                                  If unset or empty, the "legacy" RuntimeClass will
-                                  be used, which is an implicit class with an empty
-                                  definition that uses the default runtime handler.
-                                  More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                description: |-
+                                  RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                  to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                  If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                  empty definition that uses the default runtime handler.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                                 type: string
                               schedulerName:
-                                description: If specified, the pod will be dispatched
-                                  by specified scheduler. If not specified, the pod
-                                  will be dispatched by default scheduler.
+                                description: |-
+                                  If specified, the pod will be dispatched by specified scheduler.
+                                  If not specified, the pod will be dispatched by default scheduler.
                                 type: string
                               securityContext:
-                                description: 'SecurityContext holds pod-level security
-                                  attributes and common container settings. Optional:
-                                  Defaults to empty.  See type description for default
-                                  values of each field.'
+                                description: |-
+                                  SecurityContext holds pod-level security attributes and common container settings.
+                                  Optional: Defaults to empty.  See type description for default values of each field.
                                 properties:
                                   fsGroup:
-                                    description: "A special supplemental group that
-                                      applies to all containers in a pod. Some volume
-                                      types allow the Kubelet to change the ownership
-                                      of that volume to be owned by the pod: \n 1.
-                                      The owning GID will be the FSGroup 2. The setgid
-                                      bit is set (new files created in the volume
-                                      will be owned by FSGroup) 3. The permission
-                                      bits are OR'd with rw-rw---- \n If unset, the
-                                      Kubelet will not modify the ownership and permissions
-                                      of any volume. Note that this field cannot be
-                                      set when spec.os.name is windows."
+                                    description: |-
+                                      A special supplemental group that applies to all containers in a pod.
+                                      Some volume types allow the Kubelet to change the ownership of that volume
+                                      to be owned by the pod:
+
+
+                                      1. The owning GID will be the FSGroup
+                                      2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                      3. The permission bits are OR'd with rw-rw----
+
+
+                                      If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   fsGroupChangePolicy:
-                                    description: 'fsGroupChangePolicy defines behavior
-                                      of changing ownership and permission of the
-                                      volume before being exposed inside Pod. This
-                                      field will only apply to volume types which
-                                      support fsGroup based ownership(and permissions).
-                                      It will have no effect on ephemeral volume types
-                                      such as: secret, configmaps and emptydir. Valid
-                                      values are "OnRootMismatch" and "Always". If
-                                      not specified, "Always" is used. Note that this
-                                      field cannot be set when spec.os.name is windows.'
+                                    description: |-
+                                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                      before being exposed inside Pod. This field will only apply to
+                                      volume types which support fsGroup based ownership(and permissions).
+                                      It will have no effect on ephemeral volume types such as: secret, configmaps
+                                      and emptydir.
+                                      Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   runAsGroup:
-                                    description: The GID to run the entrypoint of
-                                      the container process. Uses runtime default
-                                      if unset. May also be set in SecurityContext.  If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence for that container. Note that this
-                                      field cannot be set when spec.os.name is windows.
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   runAsNonRoot:
-                                    description: Indicates that the container must
-                                      run as a non-root user. If true, the Kubelet
-                                      will validate the image at runtime to ensure
-                                      that it does not run as UID 0 (root) and fail
-                                      to start the container if it does. If unset
-                                      or false, no such validation will be performed.
-                                      May also be set in SecurityContext.  If set
-                                      in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence.
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: boolean
                                   runAsUser:
-                                    description: The UID to run the entrypoint of
-                                      the container process. Defaults to user specified
-                                      in image metadata if unspecified. May also be
-                                      set in SecurityContext.  If set in both SecurityContext
-                                      and PodSecurityContext, the value specified
-                                      in SecurityContext takes precedence for that
-                                      container. Note that this field cannot be set
-                                      when spec.os.name is windows.
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   seLinuxOptions:
-                                    description: The SELinux context to be applied
-                                      to all containers. If unspecified, the container
-                                      runtime will allocate a random SELinux context
-                                      for each container.  May also be set in SecurityContext.  If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence for that container. Note that this
-                                      field cannot be set when spec.os.name is windows.
+                                    description: |-
+                                      The SELinux context to be applied to all containers.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in SecurityContext.  If set in
+                                      both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                      takes precedence for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       level:
                                         description: Level is SELinux level label
@@ -6413,55 +5645,48 @@ spec:
                                         type: string
                                     type: object
                                   seccompProfile:
-                                    description: The seccomp options to use by the
-                                      containers in this pod. Note that this field
-                                      cannot be set when spec.os.name is windows.
+                                    description: |-
+                                      The seccomp options to use by the containers in this pod.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       localhostProfile:
-                                        description: localhostProfile indicates a
-                                          profile defined in a file on the node should
-                                          be used. The profile must be preconfigured
-                                          on the node to work. Must be a descending
-                                          path, relative to the kubelet's configured
-                                          seccomp profile location. Must be set if
-                                          type is "Localhost". Must NOT be set for
-                                          any other type.
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
                                         type: string
                                       type:
-                                        description: "type indicates which kind of
-                                          seccomp profile will be applied. Valid options
-                                          are: \n Localhost - a profile defined in
-                                          a file on the node should be used. RuntimeDefault
-                                          - the container runtime default profile
-                                          should be used. Unconfined - no profile
-                                          should be applied."
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
                                         type: string
                                     required:
                                     - type
                                     type: object
                                   supplementalGroups:
-                                    description: A list of groups applied to the first
-                                      process run in each container, in addition to
-                                      the container's primary GID, the fsGroup (if
-                                      specified), and group memberships defined in
-                                      the container image for the uid of the container
-                                      process. If unspecified, no additional groups
-                                      are added to any container. Note that group
-                                      memberships defined in the container image for
-                                      the uid of the container process are still effective,
+                                    description: |-
+                                      A list of groups applied to the first process run in each container, in addition
+                                      to the container's primary GID, the fsGroup (if specified), and group memberships
+                                      defined in the container image for the uid of the container process. If unspecified,
+                                      no additional groups are added to any container. Note that group memberships
+                                      defined in the container image for the uid of the container process are still effective,
                                       even if they are not included in this list.
-                                      Note that this field cannot be set when spec.os.name
-                                      is windows.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     items:
                                       format: int64
                                       type: integer
                                     type: array
                                   sysctls:
-                                    description: Sysctls hold a list of namespaced
-                                      sysctls used for the pod. Pods with unsupported
-                                      sysctls (by the container runtime) might fail
-                                      to launch. Note that this field cannot be set
-                                      when spec.os.name is windows.
+                                    description: |-
+                                      Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                      sysctls (by the container runtime) might fail to launch.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     items:
                                       description: Sysctl defines a kernel parameter
                                         to be set
@@ -6478,81 +5703,68 @@ spec:
                                       type: object
                                     type: array
                                   windowsOptions:
-                                    description: The Windows specific settings applied
-                                      to all containers. If unspecified, the options
-                                      within a container's SecurityContext will be
-                                      used. If set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence. Note that this field cannot be set
-                                      when spec.os.name is linux.
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options within a container's SecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
                                     properties:
                                       gmsaCredentialSpec:
-                                        description: GMSACredentialSpec is where the
-                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                          inlines the contents of the GMSA credential
-                                          spec named by the GMSACredentialSpecName
-                                          field.
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
                                         type: string
                                       gmsaCredentialSpecName:
                                         description: GMSACredentialSpecName is the
                                           name of the GMSA credential spec to use.
                                         type: string
                                       hostProcess:
-                                        description: HostProcess determines if a container
-                                          should be run as a 'Host Process' container.
-                                          All of a Pod's containers must have the
-                                          same effective HostProcess value (it is
-                                          not allowed to have a mix of HostProcess
-                                          containers and non-HostProcess containers).
-                                          In addition, if HostProcess is true then
-                                          HostNetwork must also be set to true.
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
                                         type: boolean
                                       runAsUserName:
-                                        description: The UserName in Windows to run
-                                          the entrypoint of the container process.
-                                          Defaults to the user specified in image
-                                          metadata if unspecified. May also be set
-                                          in PodSecurityContext. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: string
                                     type: object
                                 type: object
                               serviceAccount:
-                                description: 'DeprecatedServiceAccount is a depreciated
-                                  alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                  instead.'
+                                description: |-
+                                  DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                  Deprecated: Use serviceAccountName instead.
                                 type: string
                               serviceAccountName:
-                                description: 'ServiceAccountName is the name of the
-                                  ServiceAccount to use to run this pod. More info:
-                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                                description: |-
+                                  ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                                 type: string
                               setHostnameAsFQDN:
-                                description: If true the pod's hostname will be configured
-                                  as the pod's FQDN, rather than the leaf name (the
-                                  default). In Linux containers, this means setting
-                                  the FQDN in the hostname field of the kernel (the
-                                  nodename field of struct utsname). In Windows containers,
-                                  this means setting the registry value of hostname
-                                  for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                  to FQDN. If a pod does not have FQDN, this has no
-                                  effect. Default to false.
+                                description: |-
+                                  If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                  In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                                  In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                                  If a pod does not have FQDN, this has no effect.
+                                  Default to false.
                                 type: boolean
                               shareProcessNamespace:
-                                description: 'Share a single process namespace between
-                                  all of the containers in a pod. When this is set
-                                  containers will be able to view and signal processes
-                                  from other containers in the same pod, and the first
-                                  process in each container will not be assigned PID
-                                  1. HostPID and ShareProcessNamespace cannot both
-                                  be set. Optional: Default to false.'
+                                description: |-
+                                  Share a single process namespace between all of the containers in a pod.
+                                  When this is set containers will be able to view and signal processes from other containers
+                                  in the same pod, and the first process in each container will not be assigned PID 1.
+                                  HostPID and ShareProcessNamespace cannot both be set.
+                                  Optional: Default to false.
                                 type: boolean
                               subdomain:
-                                description: If specified, the fully qualified Pod
-                                  hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                  domain>". If not specified, the pod will not have
-                                  a domainname at all.
+                                description: |-
+                                  If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                  If not specified, the pod will not have a domainname at all.
                                 type: string
                               terminationGracePeriodSeconds:
                                 format: int64
@@ -6560,64 +5772,55 @@ spec:
                               tolerations:
                                 description: If specified, the pod's tolerations.
                                 items:
-                                  description: The pod this Toleration is attached
-                                    to tolerates any taint that matches the triple
-                                    <key,value,effect> using the matching operator
-                                    <operator>.
+                                  description: |-
+                                    The pod this Toleration is attached to tolerates any taint that matches
+                                    the triple <key,value,effect> using the matching operator <operator>.
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect
-                                        to match. Empty means match all taint effects.
-                                        When specified, allowed values are NoSchedule,
-                                        PreferNoSchedule and NoExecute.
+                                      description: |-
+                                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration
-                                        applies to. Empty means match all taint keys.
-                                        If the key is empty, operator must be Exists;
-                                        this combination means to match all values
-                                        and all keys.
+                                      description: |-
+                                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship
-                                        to the value. Valid operators are Exists and
-                                        Equal. Defaults to Equal. Exists is equivalent
-                                        to wildcard for value, so that a pod can tolerate
-                                        all taints of a particular category.
+                                      description: |-
+                                        Operator represents a key's relationship to the value.
+                                        Valid operators are Exists and Equal. Defaults to Equal.
+                                        Exists is equivalent to wildcard for value, so that a pod can
+                                        tolerate all taints of a particular category.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the
-                                        period of time the toleration (which must
-                                        be of effect NoExecute, otherwise this field
-                                        is ignored) tolerates the taint. By default,
-                                        it is not set, which means tolerate the taint
-                                        forever (do not evict). Zero and negative
-                                        values will be treated as 0 (evict immediately)
-                                        by the system.
+                                      description: |-
+                                        TolerationSeconds represents the period of time the toleration (which must be
+                                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                        negative values will be treated as 0 (evict immediately) by the system.
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration
-                                        matches to. If the operator is Exists, the
-                                        value should be empty, otherwise just a regular
-                                        string.
+                                      description: |-
+                                        Value is the taint value the toleration matches to.
+                                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                                       type: string
                                   type: object
                                 type: array
                               topologySpreadConstraints:
-                                description: TopologySpreadConstraints describes how
-                                  a group of pods ought to spread across topology
-                                  domains. Scheduler will schedule pods in a way which
-                                  abides by the constraints. All topologySpreadConstraints
-                                  are ANDed.
+                                description: |-
+                                  TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                  domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                  All topologySpreadConstraints are ANDed.
                                 items:
                                   description: TopologySpreadConstraint specifies
                                     how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching
-                                        pods. Pods that match this label selector
-                                        are counted to determine the number of pods
+                                      description: |-
+                                        LabelSelector is used to find matching pods.
+                                        Pods that match this label selector are counted to determine the number of pods
                                         in their corresponding topology domain.
                                       properties:
                                         matchExpressions:
@@ -6625,30 +5828,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -6660,158 +5858,134 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
-                                      description: "MatchLabelKeys is a set of pod
-                                        label keys to select the pods over which spreading
-                                        will be calculated. The keys are used to lookup
-                                        values from the incoming pod labels, those
-                                        key-value labels are ANDed with labelSelector
-                                        to select the group of existing pods over
-                                        which spreading will be calculated for the
-                                        incoming pod. The same key is forbidden to
-                                        exist in both MatchLabelKeys and LabelSelector.
-                                        MatchLabelKeys cannot be set when LabelSelector
-                                        isn't set. Keys that don't exist in the incoming
-                                        pod labels will be ignored. A null or empty
-                                        list means only match against labelSelector.
-                                        \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread
-                                        feature gate to be enabled (enabled by default)."
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                                        spreading will be calculated. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are ANDed with labelSelector
+                                        to select the group of existing pods over which spreading will be calculated
+                                        for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        Keys that don't exist in the incoming pod labels will
+                                        be ignored. A null or empty list means only match against labelSelector.
+
+
+                                        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     maxSkew:
-                                      description: 'MaxSkew describes the degree to
-                                        which pods may be unevenly distributed. When
-                                        `whenUnsatisfiable=DoNotSchedule`, it is the
-                                        maximum permitted difference between the number
-                                        of matching pods in the target topology and
-                                        the global minimum. The global minimum is
-                                        the minimum number of matching pods in an
-                                        eligible domain or zero if the number of eligible
-                                        domains is less than MinDomains. For example,
-                                        in a 3-zone cluster, MaxSkew is set to 1,
-                                        and pods with the same labelSelector spread
-                                        as 2/2/1: In this case, the global minimum
-                                        is 1. | zone1 | zone2 | zone3 | |  P P  |  P
-                                        P  |   P   | - if MaxSkew is 1, incoming pod
-                                        can only be scheduled to zone3 to become 2/2/2;
-                                        scheduling it onto zone1(zone2) would make
-                                        the ActualSkew(3-1) on zone1(zone2) violate
-                                        MaxSkew(1). - if MaxSkew is 2, incoming pod
-                                        can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                        it is used to give higher precedence to topologies
-                                        that satisfy it. It''s a required field. Default
-                                        value is 1 and 0 is not allowed.'
+                                      description: |-
+                                        MaxSkew describes the degree to which pods may be unevenly distributed.
+                                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                        between the number of matching pods in the target topology and the global minimum.
+                                        The global minimum is the minimum number of matching pods in an eligible domain
+                                        or zero if the number of eligible domains is less than MinDomains.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 2/2/1:
+                                        In this case, the global minimum is 1.
+                                        | zone1 | zone2 | zone3 |
+                                        |  P P  |  P P  |   P   |
+                                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                        scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                        violate MaxSkew(1).
+                                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                        to topologies that satisfy it.
+                                        It's a required field. Default value is 1 and 0 is not allowed.
                                       format: int32
                                       type: integer
                                     minDomains:
-                                      description: "MinDomains indicates a minimum
-                                        number of eligible domains. When the number
-                                        of eligible domains with matching topology
-                                        keys is less than minDomains, Pod Topology
-                                        Spread treats \"global minimum\" as 0, and
-                                        then the calculation of Skew is performed.
-                                        And when the number of eligible domains with
-                                        matching topology keys equals or greater than
-                                        minDomains, this value has no effect on scheduling.
-                                        As a result, when the number of eligible domains
-                                        is less than minDomains, scheduler won't schedule
-                                        more than maxSkew Pods to those domains. If
-                                        value is nil, the constraint behaves as if
-                                        MinDomains is equal to 1. Valid values are
-                                        integers greater than 0. When value is not
-                                        nil, WhenUnsatisfiable must be DoNotSchedule.
-                                        \n For example, in a 3-zone cluster, MaxSkew
-                                        is set to 2, MinDomains is set to 5 and pods
-                                        with the same labelSelector spread as 2/2/2:
-                                        | zone1 | zone2 | zone3 | |  P P  |  P P  |
-                                        \ P P  | The number of domains is less than
-                                        5(MinDomains), so \"global minimum\" is treated
-                                        as 0. In this situation, new pod with the
-                                        same labelSelector cannot be scheduled, because
-                                        computed skew will be 3(3 - 0) if new Pod
-                                        is scheduled to any of the three zones, it
-                                        will violate MaxSkew. \n This is a beta field
-                                        and requires the MinDomainsInPodTopologySpread
-                                        feature gate to be enabled (enabled by default)."
+                                      description: |-
+                                        MinDomains indicates a minimum number of eligible domains.
+                                        When the number of eligible domains with matching topology keys is less than minDomains,
+                                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                        And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                        this value has no effect on scheduling.
+                                        As a result, when the number of eligible domains is less than minDomains,
+                                        scheduler won't schedule more than maxSkew Pods to those domains.
+                                        If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                        Valid values are integers greater than 0.
+                                        When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                        labelSelector spread as 2/2/2:
+                                        | zone1 | zone2 | zone3 |
+                                        |  P P  |  P P  |  P P  |
+                                        The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                        In this situation, new pod with the same labelSelector cannot be scheduled,
+                                        because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                        it will violate MaxSkew.
+
+
+                                        This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                                       format: int32
                                       type: integer
                                     nodeAffinityPolicy:
-                                      description: "NodeAffinityPolicy indicates how
-                                        we will treat Pod's nodeAffinity/nodeSelector
-                                        when calculating pod topology spread skew.
-                                        Options are: - Honor: only nodes matching
-                                        nodeAffinity/nodeSelector are included in
-                                        the calculations. - Ignore: nodeAffinity/nodeSelector
-                                        are ignored. All nodes are included in the
-                                        calculations. \n If this value is nil, the
-                                        behavior is equivalent to the Honor policy.
-                                        This is a beta-level feature default enabled
-                                        by the NodeInclusionPolicyInPodTopologySpread
-                                        feature flag."
+                                      description: |-
+                                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                        when calculating pod topology spread skew. Options are:
+                                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                        If this value is nil, the behavior is equivalent to the Honor policy.
+                                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                       type: string
                                     nodeTaintsPolicy:
-                                      description: "NodeTaintsPolicy indicates how
-                                        we will treat node taints when calculating
-                                        pod topology spread skew. Options are: - Honor:
-                                        nodes without taints, along with tainted nodes
-                                        for which the incoming pod has a toleration,
-                                        are included. - Ignore: node taints are ignored.
-                                        All nodes are included. \n If this value is
-                                        nil, the behavior is equivalent to the Ignore
-                                        policy. This is a beta-level feature default
-                                        enabled by the NodeInclusionPolicyInPodTopologySpread
-                                        feature flag."
+                                      description: |-
+                                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                        pod topology spread skew. Options are:
+                                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                        has a toleration, are included.
+                                        - Ignore: node taints are ignored. All nodes are included.
+
+
+                                        If this value is nil, the behavior is equivalent to the Ignore policy.
+                                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                       type: string
                                     topologyKey:
-                                      description: TopologyKey is the key of node
-                                        labels. Nodes that have a label with this
-                                        key and identical values are considered to
-                                        be in the same topology. We consider each
-                                        <key, value> as a "bucket", and try to put
-                                        balanced number of pods into each bucket.
-                                        We define a domain as a particular instance
-                                        of a topology. Also, we define an eligible
-                                        domain as a domain whose nodes meet the requirements
-                                        of nodeAffinityPolicy and nodeTaintsPolicy.
-                                        e.g. If TopologyKey is "kubernetes.io/hostname",
-                                        each Node is a domain of that topology. And,
-                                        if TopologyKey is "topology.kubernetes.io/zone",
-                                        each zone is a domain of that topology. It's
-                                        a required field.
+                                      description: |-
+                                        TopologyKey is the key of node labels. Nodes that have a label with this key
+                                        and identical values are considered to be in the same topology.
+                                        We consider each <key, value> as a "bucket", and try to put balanced number
+                                        of pods into each bucket.
+                                        We define a domain as a particular instance of a topology.
+                                        Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                        nodeAffinityPolicy and nodeTaintsPolicy.
+                                        e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                        And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                        It's a required field.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: 'WhenUnsatisfiable indicates how
-                                        to deal with a pod if it doesn''t satisfy
-                                        the spread constraint. - DoNotSchedule (default)
-                                        tells the scheduler not to schedule it. -
-                                        ScheduleAnyway tells the scheduler to schedule
-                                        the pod in any location, but giving higher
-                                        precedence to topologies that would help reduce
-                                        the skew. A constraint is considered "Unsatisfiable"
-                                        for an incoming pod if and only if every possible
-                                        node assignment for that pod would violate
-                                        "MaxSkew" on some topology. For example, in
-                                        a 3-zone cluster, MaxSkew is set to 1, and
-                                        pods with the same labelSelector spread as
-                                        3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                                        If WhenUnsatisfiable is set to DoNotSchedule,
-                                        incoming pod can only be scheduled to zone2(zone3)
-                                        to become 3/2/1(3/1/2) as ActualSkew(2-1)
-                                        on zone2(zone3) satisfies MaxSkew(1). In other
-                                        words, the cluster can still be imbalanced,
-                                        but scheduler won''t make it *more* imbalanced.
-                                        It''s a required field.'
+                                      description: |-
+                                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                        the spread constraint.
+                                        - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                          but giving higher precedence to topologies that would help reduce the
+                                          skew.
+                                        A constraint is considered "Unsatisfiable" for an incoming pod
+                                        if and only if every possible node assignment for that pod would violate
+                                        "MaxSkew" on some topology.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 3/1/1:
+                                        | zone1 | zone2 | zone3 |
+                                        | P P P |   P   |   P   |
+                                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                        won't make it *more* imbalanced.
+                                        It's a required field.
                                       type: string
                                   required:
                                   - maxSkew
@@ -6830,41 +6004,36 @@ spec:
                                     the pod.
                                   properties:
                                     awsElasticBlockStore:
-                                      description: 'awsElasticBlockStore represents
-                                        an AWS Disk resource that is attached to a
-                                        kubelet''s host machine and then exposed to
-                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      description: |-
+                                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).'
+                                          description: |-
+                                            partition is the partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly value true will force
-                                            the readOnly setting in VolumeMounts.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          description: |-
+                                            readOnly value true will force the readOnly setting in VolumeMounts.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           type: boolean
                                         volumeID:
-                                          description: 'volumeID is unique ID of the
-                                            persistent disk resource in AWS (Amazon
-                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          description: |-
+                                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           type: string
                                       required:
                                       - volumeID
@@ -6887,11 +6056,10 @@ spec:
                                             disk in the blob storage
                                           type: string
                                         fsType:
-                                          description: fsType is Filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         kind:
                                           description: 'kind expected values are Shared:
@@ -6901,8 +6069,8 @@ spec:
                                             availability set). defaults to shared'
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly Defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                       required:
@@ -6915,8 +6083,8 @@ spec:
                                         the pod.
                                       properties:
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretName:
@@ -6937,9 +6105,9 @@ spec:
                                         on the host that shares a pod's lifetime
                                       properties:
                                         monitors:
-                                          description: 'monitors is Required: Monitors
-                                            is a collection of Ceph monitors More
-                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            monitors is Required: Monitors is a collection of Ceph monitors
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           items:
                                             type: string
                                           type: array
@@ -6949,73 +6117,72 @@ spec:
                                             Ceph tree, default is /'
                                           type: string
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: boolean
                                         secretFile:
-                                          description: 'secretFile is Optional: SecretFile
-                                            is the path to key ring for User, default
-                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: string
                                         secretRef:
-                                          description: 'secretRef is Optional: SecretRef
-                                            is reference to the authentication secret
-                                            for User, default is empty. More info:
-                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is optional: User is
-                                            the rados user name, default is admin
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            user is optional: User is the rados user name, default is admin
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: string
                                       required:
                                       - monitors
                                       type: object
                                     cinder:
-                                      description: 'cinder represents a cinder volume
-                                        attached and mounted on kubelets host machine.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      description: |-
+                                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Examples:
-                                            "ext4", "xfs", "ntfs". Implicitly inferred
-                                            to be "ext4" if unspecified. More info:
-                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: string
                                         readOnly:
-                                          description: 'readOnly defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is optional: points
-                                            to a secret object containing parameters
-                                            used to connect to OpenStack.'
+                                          description: |-
+                                            secretRef is optional: points to a secret object containing parameters used to connect
+                                            to OpenStack.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeID:
-                                          description: 'volumeID used to identify
-                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          description: |-
+                                            volumeID used to identify the volume in cinder.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: string
                                       required:
                                       - volumeID
@@ -7025,34 +6192,25 @@ spec:
                                         that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: |-
+                                            defaultMode is optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items if unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced ConfigMap will be projected
-                                            into the volume as a file whose name is
-                                            the key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the ConfigMap,
-                                            the volume setup will error unless it
-                                            is marked optional. Paths must be relative
-                                            and may not contain the '..' path or start
-                                            with '..'.
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the ConfigMap,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
                                           items:
                                             description: Maps a string key to a path
                                               within a volume.
@@ -7061,28 +6219,21 @@ spec:
                                                 description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
                                                 type: string
                                             required:
                                             - key
@@ -7090,10 +6241,10 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description: optional specify whether the
@@ -7107,49 +6258,43 @@ spec:
                                         by certain external CSI drivers (Beta feature).
                                       properties:
                                         driver:
-                                          description: driver is the name of the CSI
-                                            driver that handles this volume. Consult
-                                            with your admin for the correct name as
-                                            registered in the cluster.
+                                          description: |-
+                                            driver is the name of the CSI driver that handles this volume.
+                                            Consult with your admin for the correct name as registered in the cluster.
                                           type: string
                                         fsType:
-                                          description: fsType to mount. Ex. "ext4",
-                                            "xfs", "ntfs". If not provided, the empty
-                                            value is passed to the associated CSI
-                                            driver which will determine the default
-                                            filesystem to apply.
+                                          description: |-
+                                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                            If not provided, the empty value is passed to the associated CSI driver
+                                            which will determine the default filesystem to apply.
                                           type: string
                                         nodePublishSecretRef:
-                                          description: nodePublishSecretRef is a reference
-                                            to the secret object containing sensitive
-                                            information to pass to the CSI driver
-                                            to complete the CSI NodePublishVolume
-                                            and NodeUnpublishVolume calls. This field
-                                            is optional, and  may be empty if no secret
-                                            is required. If the secret object contains
-                                            more than one secret, all secret references
-                                            are passed.
+                                          description: |-
+                                            nodePublishSecretRef is a reference to the secret object containing
+                                            sensitive information to pass to the CSI driver to complete the CSI
+                                            NodePublishVolume and NodeUnpublishVolume calls.
+                                            This field is optional, and  may be empty if no secret is required. If the
+                                            secret object contains more than one secret, all secret references are passed.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         readOnly:
-                                          description: readOnly specifies a read-only
-                                            configuration for the volume. Defaults
-                                            to false (read/write).
+                                          description: |-
+                                            readOnly specifies a read-only configuration for the volume.
+                                            Defaults to false (read/write).
                                           type: boolean
                                         volumeAttributes:
                                           additionalProperties:
                                             type: string
-                                          description: volumeAttributes stores driver-specific
-                                            properties that are passed to the CSI
-                                            driver. Consult your driver's documentation
-                                            for supported values.
+                                          description: |-
+                                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                                            driver. Consult your driver's documentation for supported values.
                                           type: object
                                       required:
                                       - driver
@@ -7160,20 +6305,15 @@ spec:
                                         volume
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits to use
-                                            on created files by default. Must be a
-                                            Optional: mode bits used to set permissions
-                                            on created files by default. Must be an
-                                            octal value between 0000 and 0777 or a
-                                            decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. Defaults to 0644. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.'
+                                          description: |-
+                                            Optional: mode bits to use on created files by default. Must be a
+                                            Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
@@ -7204,19 +6344,13 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file, must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
@@ -7229,11 +6363,9 @@ spec:
                                                   with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  requests.cpu and requests.memory)
-                                                  are currently supported.'
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                 properties:
                                                   containerName:
                                                     description: 'Container name:
@@ -7263,138 +6395,125 @@ spec:
                                           type: array
                                       type: object
                                     emptyDir:
-                                      description: 'emptyDir represents a temporary
-                                        directory that shares a pod''s lifetime. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: |-
+                                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       properties:
                                         medium:
-                                          description: 'medium represents what type
-                                            of storage medium should back this directory.
-                                            The default is "" which means to use the
-                                            node''s default medium. Must be an empty
-                                            string (default) or Memory. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: |-
+                                            medium represents what type of storage medium should back this directory.
+                                            The default is "" which means to use the node's default medium.
+                                            Must be an empty string (default) or Memory.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: 'sizeLimit is the total amount
-                                            of local storage required for this EmptyDir
-                                            volume. The size limit is also applicable
-                                            for memory medium. The maximum usage on
-                                            memory medium EmptyDir would be the minimum
-                                            value between the SizeLimit specified
-                                            here and the sum of memory limits of all
-                                            containers in a pod. The default is nil
-                                            which means that the limit is undefined.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: |-
+                                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                            The size limit is also applicable for memory medium.
+                                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                            The default is nil which means that the limit is undefined.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     ephemeral:
-                                      description: "ephemeral represents a volume
-                                        that is handled by a cluster storage driver.
-                                        The volume's lifecycle is tied to the pod
-                                        that defines it - it will be created before
-                                        the pod starts, and deleted when the pod is
-                                        removed. \n Use this if: a) the volume is
-                                        only needed while the pod runs, b) features
-                                        of normal volumes like restoring from snapshot
-                                        or capacity tracking are needed, c) the storage
-                                        driver is specified through a storage class,
-                                        and d) the storage driver supports dynamic
-                                        volume provisioning through a PersistentVolumeClaim
-                                        (see EphemeralVolumeSource for more information
-                                        on the connection between this volume type
-                                        and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                        or one of the vendor-specific APIs for volumes
-                                        that persist for longer than the lifecycle
-                                        of an individual pod. \n Use CSI for light-weight
-                                        local ephemeral volumes if the CSI driver
-                                        is meant to be used that way - see the documentation
-                                        of the driver for more information. \n A pod
-                                        can use both types of ephemeral volumes and
-                                        persistent volumes at the same time."
+                                      description: |-
+                                        ephemeral represents a volume that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                        and deleted when the pod is removed.
+
+
+                                        Use this if:
+                                        a) the volume is only needed while the pod runs,
+                                        b) features of normal volumes like restoring from snapshot or capacity
+                                           tracking are needed,
+                                        c) the storage driver is specified through a storage class, and
+                                        d) the storage driver supports dynamic volume provisioning through
+                                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                           information on the connection between this volume type
+                                           and PersistentVolumeClaim).
+
+
+                                        Use PersistentVolumeClaim or one of the vendor-specific
+                                        APIs for volumes that persist for longer than the lifecycle
+                                        of an individual pod.
+
+
+                                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                        be used that way - see the documentation of the driver for
+                                        more information.
+
+
+                                        A pod can use both types of ephemeral volumes and
+                                        persistent volumes at the same time.
                                       properties:
                                         volumeClaimTemplate:
-                                          description: "Will be used to create a stand-alone
-                                            PVC to provision the volume. The pod in
-                                            which this EphemeralVolumeSource is embedded
-                                            will be the owner of the PVC, i.e. the
-                                            PVC will be deleted together with the
-                                            pod.  The name of the PVC will be `<pod
-                                            name>-<volume name>` where `<volume name>`
-                                            is the name from the `PodSpec.Volumes`
-                                            array entry. Pod validation will reject
-                                            the pod if the concatenated name is not
-                                            valid for a PVC (for example, too long).
-                                            \n An existing PVC with that name that
-                                            is not owned by the pod will *not* be
-                                            used for the pod to avoid using an unrelated
-                                            volume by mistake. Starting the pod is
-                                            then blocked until the unrelated PVC is
-                                            removed. If such a pre-created PVC is
-                                            meant to be used by the pod, the PVC has
-                                            to updated with an owner reference to
-                                            the pod once the pod exists. Normally
-                                            this should not be necessary, but it may
-                                            be useful when manually reconstructing
-                                            a broken cluster. \n This field is read-only
-                                            and no changes will be made by Kubernetes
+                                          description: |-
+                                            Will be used to create a stand-alone PVC to provision the volume.
+                                            The pod in which this EphemeralVolumeSource is embedded will be the
+                                            owner of the PVC, i.e. the PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                                            entry. Pod validation will reject the pod if the concatenated name
+                                            is not valid for a PVC (for example, too long).
+
+
+                                            An existing PVC with that name that is not owned by the pod
+                                            will *not* be used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is then blocked until
+                                            the unrelated PVC is removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has to updated with an
+                                            owner reference to the pod once the pod exists. Normally
+                                            this should not be necessary, but it may be useful when
+                                            manually reconstructing a broken cluster.
+
+
+                                            This field is read-only and no changes will be made by Kubernetes
                                             to the PVC after it has been created.
-                                            \n Required, must not be nil."
+
+
+                                            Required, must not be nil.
                                           properties:
                                             metadata:
-                                              description: May contain labels and
-                                                annotations that will be copied into
-                                                the PVC when creating it. No other
-                                                fields are allowed and will be rejected
-                                                during validation.
+                                              description: |-
+                                                May contain labels and annotations that will be copied into the PVC
+                                                when creating it. No other fields are allowed and will be rejected during
+                                                validation.
                                               type: object
                                             spec:
-                                              description: The specification for the
-                                                PersistentVolumeClaim. The entire
-                                                content is copied unchanged into the
-                                                PVC that gets created from this template.
-                                                The same fields as in a PersistentVolumeClaim
+                                              description: |-
+                                                The specification for the PersistentVolumeClaim. The entire content is
+                                                copied unchanged into the PVC that gets created from this
+                                                template. The same fields as in a PersistentVolumeClaim
                                                 are also valid here.
                                               properties:
                                                 accessModes:
-                                                  description: 'accessModes contains
-                                                    the desired access modes the volume
-                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  description: |-
+                                                    accessModes contains the desired access modes the volume should have.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                   items:
                                                     type: string
                                                   type: array
                                                 dataSource:
-                                                  description: 'dataSource field can
-                                                    be used to specify either: * An
-                                                    existing VolumeSnapshot object
-                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  description: |-
+                                                    dataSource field can be used to specify either:
+                                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                     * An existing PVC (PersistentVolumeClaim)
-                                                    If the provisioner or an external
-                                                    controller can support the specified
-                                                    data source, it will create a
-                                                    new volume based on the contents
-                                                    of the specified data source.
-                                                    When the AnyVolumeDataSource feature
-                                                    gate is enabled, dataSource contents
-                                                    will be copied to dataSourceRef,
-                                                    and dataSourceRef contents will
-                                                    be copied to dataSource when dataSourceRef.namespace
-                                                    is not specified. If the namespace
-                                                    is specified, then dataSourceRef
-                                                    will not be copied to dataSource.'
+                                                    If the provisioner or an external controller can support the specified data source,
+                                                    it will create a new volume based on the contents of the specified data source.
+                                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
+                                                      description: |-
+                                                        APIGroup is the group for the resource being referenced.
+                                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                        For any other third-party types, APIGroup is required.
                                                       type: string
                                                     kind:
                                                       description: Kind is the type
@@ -7410,59 +6529,36 @@ spec:
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 dataSourceRef:
-                                                  description: 'dataSourceRef specifies
-                                                    the object from which to populate
-                                                    the volume with data, if a non-empty
-                                                    volume is desired. This may be
-                                                    any object from a non-empty API
-                                                    group (non core object) or a PersistentVolumeClaim
-                                                    object. When this field is specified,
-                                                    volume binding will only succeed
-                                                    if the type of the specified object
-                                                    matches some installed volume
-                                                    populator or dynamic provisioner.
-                                                    This field will replace the functionality
-                                                    of the dataSource field and as
-                                                    such if both fields are non-empty,
-                                                    they must have the same value.
-                                                    For backwards compatibility, when
-                                                    namespace isn''t specified in
-                                                    dataSourceRef, both fields (dataSource
-                                                    and dataSourceRef) will be set
-                                                    to the same value automatically
-                                                    if one of them is empty and the
-                                                    other is non-empty. When namespace
-                                                    is specified in dataSourceRef,
-                                                    dataSource isn''t set to the same
-                                                    value and must be empty. There
-                                                    are three important differences
-                                                    between dataSource and dataSourceRef:
-                                                    * While dataSource only allows
-                                                    two specific types of objects,
-                                                    dataSourceRef allows any non-core
-                                                    object, as well as PersistentVolumeClaim
-                                                    objects. * While dataSource ignores
-                                                    disallowed values (dropping them),
-                                                    dataSourceRef preserves all values,
-                                                    and generates an error if a disallowed
-                                                    value is specified. * While dataSource
-                                                    only allows local objects, dataSourceRef
-                                                    allows objects in any namespaces.
-                                                    (Beta) Using this field requires
-                                                    the AnyVolumeDataSource feature
-                                                    gate to be enabled. (Alpha) Using
-                                                    the namespace field of dataSourceRef
-                                                    requires the CrossNamespaceVolumeDataSource
-                                                    feature gate to be enabled.'
+                                                  description: |-
+                                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                    volume is desired. This may be any object from a non-empty API group (non
+                                                    core object) or a PersistentVolumeClaim object.
+                                                    When this field is specified, volume binding will only succeed if the type of
+                                                    the specified object matches some installed volume populator or dynamic
+                                                    provisioner.
+                                                    This field will replace the functionality of the dataSource field and as such
+                                                    if both fields are non-empty, they must have the same value. For backwards
+                                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                                    value automatically if one of them is empty and the other is non-empty.
+                                                    When namespace is specified in dataSourceRef,
+                                                    dataSource isn't set to the same value and must be empty.
+                                                    There are three important differences between dataSource and dataSourceRef:
+                                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                      preserves all values, and generates an error if a disallowed value is
+                                                      specified.
+                                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                                      in any namespaces.
+                                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
+                                                      description: |-
+                                                        APIGroup is the group for the resource being referenced.
+                                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                        For any other third-party types, APIGroup is required.
                                                       type: string
                                                     kind:
                                                       description: Kind is the type
@@ -7473,35 +6569,22 @@ spec:
                                                         of resource being referenced
                                                       type: string
                                                     namespace:
-                                                      description: Namespace is the
-                                                        namespace of resource being
-                                                        referenced Note that when
-                                                        a namespace is specified,
-                                                        a gateway.networking.k8s.io/ReferenceGrant
-                                                        object is required in the
-                                                        referent namespace to allow
-                                                        that namespace's owner to
-                                                        accept the reference. See
-                                                        the ReferenceGrant documentation
-                                                        for details. (Alpha) This
-                                                        field requires the CrossNamespaceVolumeDataSource
-                                                        feature gate to be enabled.
+                                                      description: |-
+                                                        Namespace is the namespace of resource being referenced
+                                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                       type: string
                                                   required:
                                                   - kind
                                                   - name
                                                   type: object
                                                 resources:
-                                                  description: 'resources represents
-                                                    the minimum resources the volume
-                                                    should have. If RecoverVolumeExpansionFailure
-                                                    feature is enabled users are allowed
-                                                    to specify resource requirements
-                                                    that are lower than previous value
-                                                    but must still be higher than
-                                                    capacity recorded in the status
-                                                    field of the claim. More info:
-                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  description: |-
+                                                    resources represents the minimum resources the volume should have.
+                                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                                    status field of the claim.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                   properties:
                                                     limits:
                                                       additionalProperties:
@@ -7510,10 +6593,9 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Limits describes
-                                                        the maximum amount of compute
-                                                        resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      description: |-
+                                                        Limits describes the maximum amount of compute resources allowed.
+                                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -7522,15 +6604,11 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Requests describes
-                                                        the minimum amount of compute
-                                                        resources required. If Requests
-                                                        is omitted for a container,
-                                                        it defaults to Limits if that
-                                                        is explicitly specified, otherwise
-                                                        to an implementation-defined
-                                                        value. Requests cannot exceed
-                                                        Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      description: |-
+                                                        Requests describes the minimum amount of compute resources required.
+                                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                       type: object
                                                   type: object
                                                 selector:
@@ -7544,10 +6622,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -7556,24 +6632,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -7586,59 +6653,37 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 storageClassName:
-                                                  description: 'storageClassName is
-                                                    the name of the StorageClass required
-                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  description: |-
+                                                    storageClassName is the name of the StorageClass required by the claim.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                                   type: string
                                                 volumeAttributesClassName:
-                                                  description: 'volumeAttributesClassName
-                                                    may be used to set the VolumeAttributesClass
-                                                    used by this claim. If specified,
-                                                    the CSI driver will create or
-                                                    update the volume with the attributes
-                                                    defined in the corresponding VolumeAttributesClass.
-                                                    This has a different purpose than
-                                                    storageClassName, it can be changed
-                                                    after the claim is created. An
-                                                    empty string value means that
-                                                    no VolumeAttributesClass will
-                                                    be applied to the claim but it''s
-                                                    not allowed to reset this field
-                                                    to empty string once it is set.
-                                                    If unspecified and the PersistentVolumeClaim
-                                                    is unbound, the default VolumeAttributesClass
-                                                    will be set by the persistentvolume
-                                                    controller if it exists. If the
-                                                    resource referred to by volumeAttributesClass
-                                                    does not exist, this PersistentVolumeClaim
-                                                    will be set to a Pending state,
-                                                    as reflected by the modifyVolumeStatus
-                                                    field, until such as a resource
-                                                    exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                                    (Alpha) Using this field requires
-                                                    the VolumeAttributesClass feature
-                                                    gate to be enabled.'
+                                                  description: |-
+                                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                                    will be set by the persistentvolume controller if it exists.
+                                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                    exists.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                                   type: string
                                                 volumeMode:
-                                                  description: volumeMode defines
-                                                    what type of volume is required
-                                                    by the claim. Value of Filesystem
-                                                    is implied when not included in
-                                                    claim spec.
+                                                  description: |-
+                                                    volumeMode defines what type of volume is required by the claim.
+                                                    Value of Filesystem is implied when not included in claim spec.
                                                   type: string
                                                 volumeName:
                                                   description: volumeName is the binding
@@ -7656,13 +6701,11 @@ spec:
                                         and then exposed to the pod.
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. TODO: how do
-                                            we prevent errors in the filesystem from
-                                            compromising the machine'
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         lun:
                                           description: 'lun is Optional: FC target
@@ -7670,9 +6713,9 @@ spec:
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'readOnly is Optional: Defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
+                                          description: |-
+                                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         targetWWNs:
                                           description: 'targetWWNs is Optional: FC
@@ -7681,29 +6724,27 @@ spec:
                                             type: string
                                           type: array
                                         wwids:
-                                          description: 'wwids Optional: FC volume
-                                            world wide identifiers (wwids) Either
-                                            wwids or combination of targetWWNs and
-                                            lun must be set, but not both simultaneously.'
+                                          description: |-
+                                            wwids Optional: FC volume world wide identifiers (wwids)
+                                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     flexVolume:
-                                      description: flexVolume represents a generic
-                                        volume resource that is provisioned/attached
-                                        using an exec based plugin.
+                                      description: |-
+                                        flexVolume represents a generic volume resource that is
+                                        provisioned/attached using an exec based plugin.
                                       properties:
                                         driver:
                                           description: driver is the name of the driver
                                             to use for this volume.
                                           type: string
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". The default filesystem
-                                            depends on FlexVolume script.
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                           type: string
                                         options:
                                           additionalProperties:
@@ -7712,24 +6753,23 @@ spec:
                                             field holds extra command options if any.'
                                           type: object
                                         readOnly:
-                                          description: 'readOnly is Optional: defaults
-                                            to false (read/write). ReadOnly here will
-                                            force the ReadOnly setting in VolumeMounts.'
+                                          description: |-
+                                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is Optional: secretRef
-                                            is reference to the secret object containing
-                                            sensitive information to pass to the plugin
-                                            scripts. This may be empty if no secret
-                                            object is specified. If the secret object
-                                            contains more than one secret, all secrets
-                                            are passed to the plugin scripts.'
+                                          description: |-
+                                            secretRef is Optional: secretRef is reference to the secret object containing
+                                            sensitive information to pass to the plugin scripts. This may be
+                                            empty if no secret object is specified. If the secret object
+                                            contains more than one secret, all secrets are passed to the plugin
+                                            scripts.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -7743,10 +6783,9 @@ spec:
                                         running
                                       properties:
                                         datasetName:
-                                          description: datasetName is Name of the
-                                            dataset stored as metadata -> name on
-                                            the dataset for Flocker should be considered
-                                            as deprecated
+                                          description: |-
+                                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                            should be considered as deprecated
                                           type: string
                                         datasetUUID:
                                           description: datasetUUID is the UUID of
@@ -7755,62 +6794,55 @@ spec:
                                           type: string
                                       type: object
                                     gcePersistentDisk:
-                                      description: 'gcePersistentDisk represents a
-                                        GCE Disk resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      description: |-
+                                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       properties:
                                         fsType:
-                                          description: 'fsType is filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         partition:
-                                          description: 'partition is the partition
-                                            in the volume that you want to mount.
-                                            If omitted, the default is to mount by
-                                            volume name. Examples: For volume /dev/sda1,
-                                            you specify the partition as "1". Similarly,
-                                            the volume partition for /dev/sda is "0"
-                                            (or you can leave the property empty).
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            partition is the partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           format: int32
                                           type: integer
                                         pdName:
-                                          description: 'pdName is unique name of the
-                                            PD resource in GCE. Used to identify the
-                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           type: boolean
                                       required:
                                       - pdName
                                       type: object
                                     gitRepo:
-                                      description: 'gitRepo represents a git repository
-                                        at a particular revision. DEPRECATED: GitRepo
-                                        is deprecated. To provision a container with
-                                        a git repo, mount an EmptyDir into an InitContainer
-                                        that clones the repo using git, then mount
-                                        the EmptyDir into the Pod''s container.'
+                                      description: |-
+                                        gitRepo represents a git repository at a particular revision.
+                                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                        into the Pod's container.
                                       properties:
                                         directory:
-                                          description: directory is the target directory
-                                            name. Must not contain or start with '..'.  If
-                                            '.' is supplied, the volume directory
-                                            will be the git repository.  Otherwise,
-                                            if specified, the volume will contain
-                                            the git repository in the subdirectory
-                                            with the given name.
+                                          description: |-
+                                            directory is the target directory name.
+                                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                            the subdirectory with the given name.
                                           type: string
                                         repository:
                                           description: repository is the URL
@@ -7823,59 +6855,61 @@ spec:
                                       - repository
                                       type: object
                                     glusterfs:
-                                      description: 'glusterfs represents a Glusterfs
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      description: |-
+                                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                       properties:
                                         endpoints:
-                                          description: 'endpoints is the endpoint
-                                            name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            endpoints is the endpoint name that details Glusterfs topology.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: string
                                         path:
-                                          description: 'path is the Glusterfs volume
-                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            path is the Glusterfs volume path.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            Glusterfs volume to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: boolean
                                       required:
                                       - endpoints
                                       - path
                                       type: object
                                     hostPath:
-                                      description: 'hostPath represents a pre-existing
-                                        file or directory on the host machine that
-                                        is directly exposed to the container. This
-                                        is generally used for system agents or other
-                                        privileged things that are allowed to see
-                                        the host machine. Most containers will NOT
-                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                        --- TODO(jonesdl) We need to restrict who
-                                        can use host directory mounts and who can/can
-                                        not mount host directories as read/write.'
+                                      description: |-
+                                        hostPath represents a pre-existing file or directory on the host
+                                        machine that is directly exposed to the container. This is generally
+                                        used for system agents or other privileged things that are allowed
+                                        to see the host machine. Most containers will NOT need this.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        ---
+                                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                        mount host directories as read/write.
                                       properties:
                                         path:
-                                          description: 'path of the directory on the
-                                            host. If the path is a symlink, it will
-                                            follow the link to the real path. More
-                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: |-
+                                            path of the directory on the host.
+                                            If the path is a symlink, it will follow the link to the real path.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                           type: string
                                         type:
-                                          description: 'type for HostPath Volume Defaults
-                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: |-
+                                            type for HostPath Volume
+                                            Defaults to ""
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                           type: string
                                       required:
                                       - path
                                       type: object
                                     iscsi:
-                                      description: 'iscsi represents an ISCSI Disk
-                                        resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      description: |-
+                                        iscsi represents an ISCSI Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                                       properties:
                                         chapAuthDiscovery:
                                           description: chapAuthDiscovery defines whether
@@ -7886,31 +6920,27 @@ spec:
                                             support iSCSI Session CHAP authentication
                                           type: boolean
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         initiatorName:
-                                          description: initiatorName is the custom
-                                            iSCSI Initiator Name. If initiatorName
-                                            is specified with iscsiInterface simultaneously,
-                                            new iSCSI interface <target portal>:<volume
-                                            name> will be created for the connection.
+                                          description: |-
+                                            initiatorName is the custom iSCSI Initiator Name.
+                                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                            <target portal>:<volume name> will be created for the connection.
                                           type: string
                                         iqn:
                                           description: iqn is the target iSCSI Qualified
                                             Name.
                                           type: string
                                         iscsiInterface:
-                                          description: iscsiInterface is the interface
-                                            Name that uses an iSCSI transport. Defaults
-                                            to 'default' (tcp).
+                                          description: |-
+                                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                                            Defaults to 'default' (tcp).
                                           type: string
                                         lun:
                                           description: lun represents iSCSI Target
@@ -7918,35 +6948,33 @@ spec:
                                           format: int32
                                           type: integer
                                         portals:
-                                          description: portals is the iSCSI Target
-                                            Portal List. The portal is either an IP
-                                            or ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
+                                          description: |-
+                                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
                                           items:
                                             type: string
                                           type: array
                                         readOnly:
-                                          description: readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false.
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
                                           type: boolean
                                         secretRef:
                                           description: secretRef is the CHAP Secret
                                             for iSCSI target and initiator authentication
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         targetPortal:
-                                          description: targetPortal is iSCSI Target
-                                            Portal. The Portal is either an IP or
-                                            ip_addr:port if the port is other than
-                                            default (typically TCP ports 860 and 3260).
+                                          description: |-
+                                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
                                           type: string
                                       required:
                                       - iqn
@@ -7954,48 +6982,51 @@ spec:
                                       - targetPortal
                                       type: object
                                     name:
-                                      description: 'name of the volume. Must be a
-                                        DNS_LABEL and unique within the pod. More
-                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      description: |-
+                                        name of the volume.
+                                        Must be a DNS_LABEL and unique within the pod.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     nfs:
-                                      description: 'nfs represents an NFS mount on
-                                        the host that shares a pod''s lifetime More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      description: |-
+                                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       properties:
                                         path:
-                                          description: 'path that is exported by the
-                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            path that is exported by the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            NFS export to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: boolean
                                         server:
-                                          description: 'server is the hostname or
-                                            IP address of the NFS server. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            server is the hostname or IP address of the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: string
                                       required:
                                       - path
                                       - server
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'persistentVolumeClaimVolumeSource
-                                        represents a reference to a PersistentVolumeClaim
-                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: |-
+                                        persistentVolumeClaimVolumeSource represents a reference to a
+                                        PersistentVolumeClaim in the same namespace.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                       properties:
                                         claimName:
-                                          description: 'claimName is the name of a
-                                            PersistentVolumeClaim in the same namespace
-                                            as the pod using this volume. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          description: |-
+                                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                           type: string
                                         readOnly:
-                                          description: readOnly Will force the ReadOnly
-                                            setting in VolumeMounts. Default false.
+                                          description: |-
+                                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                                            Default false.
                                           type: boolean
                                       required:
                                       - claimName
@@ -8006,11 +7037,10 @@ spec:
                                         and mounted on kubelets host machine
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         pdID:
                                           description: pdID is the ID that identifies
@@ -8025,15 +7055,14 @@ spec:
                                         machine
                                       properties:
                                         fsType:
-                                          description: fSType represents the filesystem
-                                            type to mount Must be a filesystem type
-                                            supported by the host operating system.
-                                            Ex. "ext4", "xfs". Implicitly inferred
-                                            to be "ext4" if unspecified.
+                                          description: |-
+                                            fSType represents the filesystem type to mount
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         volumeID:
@@ -8049,18 +7078,13 @@ spec:
                                         API
                                       properties:
                                         defaultMode:
-                                          description: defaultMode are the mode bits
-                                            used to set permissions on created files
-                                            by default. Must be an octal value between
-                                            0000 and 0777 or a decimal value between
-                                            0 and 511. YAML accepts both octal and
-                                            decimal values, JSON requires decimal
-                                            values for mode bits. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.
+                                          description: |-
+                                            defaultMode are the mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         sources:
@@ -8071,33 +7095,29 @@ spec:
                                               along with other supported volume types
                                             properties:
                                               clusterTrustBundle:
-                                                description: "ClusterTrustBundle allows
-                                                  a pod to access the `.spec.trustBundle`
-                                                  field of ClusterTrustBundle objects
-                                                  in an auto-updating file. \n Alpha,
-                                                  gated by the ClusterTrustBundleProjection
-                                                  feature gate. \n ClusterTrustBundle
-                                                  objects can either be selected by
-                                                  name, or by the combination of signer
-                                                  name and a label selector. \n Kubelet
-                                                  performs aggressive normalization
-                                                  of the PEM contents written into
-                                                  the pod filesystem.  Esoteric PEM
-                                                  features such as inter-block comments
-                                                  and block headers are stripped.
-                                                  \ Certificates are deduplicated.
-                                                  The ordering of certificates within
-                                                  the file is arbitrary, and Kubelet
-                                                  may change the order over time."
+                                                description: |-
+                                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                                  of ClusterTrustBundle objects in an auto-updating file.
+
+
+                                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+
+                                                  ClusterTrustBundle objects can either be selected by name, or by the
+                                                  combination of signer name and a label selector.
+
+
+                                                  Kubelet performs aggressive normalization of the PEM contents written
+                                                  into the pod filesystem.  Esoteric PEM features such as inter-block
+                                                  comments and block headers are stripped.  Certificates are deduplicated.
+                                                  The ordering of certificates within the file is arbitrary, and Kubelet
+                                                  may change the order over time.
                                                 properties:
                                                   labelSelector:
-                                                    description: Select all ClusterTrustBundles
-                                                      that match this label selector.  Only
-                                                      has effect if signerName is
-                                                      set.  Mutually-exclusive with
-                                                      name.  If unset, interpreted
-                                                      as "match nothing".  If set
-                                                      but empty, interpreted as "match
+                                                    description: |-
+                                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                      interpreted as "match nothing".  If set but empty, interpreted as "match
                                                       everything".
                                                     properties:
                                                       matchExpressions:
@@ -8106,12 +7126,9 @@ spec:
                                                           requirements. The requirements
                                                           are ANDed.
                                                         items:
-                                                          description: A label selector
-                                                            requirement is a selector
-                                                            that contains values,
-                                                            a key, and an operator
-                                                            that relates the key and
-                                                            values.
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
                                                           properties:
                                                             key:
                                                               description: key is
@@ -8120,28 +7137,16 @@ spec:
                                                                 to.
                                                               type: string
                                                             operator:
-                                                              description: operator
-                                                                represents a key's
-                                                                relationship to a
-                                                                set of values. Valid
-                                                                operators are In,
-                                                                NotIn, Exists and
-                                                                DoesNotExist.
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                                               type: string
                                                             values:
-                                                              description: values
-                                                                is an array of string
-                                                                values. If the operator
-                                                                is In or NotIn, the
-                                                                values array must
-                                                                be non-empty. If the
-                                                                operator is Exists
-                                                                or DoesNotExist, the
-                                                                values array must
-                                                                be empty. This array
-                                                                is replaced during
-                                                                a strategic merge
-                                                                patch.
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
                                                               items:
                                                                 type: string
                                                               type: array
@@ -8153,34 +7158,25 @@ spec:
                                                       matchLabels:
                                                         additionalProperties:
                                                           type: string
-                                                        description: matchLabels is
-                                                          a map of {key,value} pairs.
-                                                          A single {key,value} in
-                                                          the matchLabels map is equivalent
-                                                          to an element of matchExpressions,
-                                                          whose key field is "key",
-                                                          the operator is "In", and
-                                                          the values array contains
-                                                          only "value". The requirements
-                                                          are ANDed.
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   name:
-                                                    description: Select a single ClusterTrustBundle
-                                                      by object name.  Mutually-exclusive
+                                                    description: |-
+                                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
                                                       with signerName and labelSelector.
                                                     type: string
                                                   optional:
-                                                    description: If true, don't block
-                                                      pod startup if the referenced
-                                                      ClusterTrustBundle(s) aren't
-                                                      available.  If using name, then
-                                                      the named ClusterTrustBundle
-                                                      is allowed not to exist.  If
-                                                      using signerName, then the combination
-                                                      of signerName and labelSelector
-                                                      is allowed to match zero ClusterTrustBundles.
+                                                    description: |-
+                                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                      aren't available.  If using name, then the named ClusterTrustBundle is
+                                                      allowed not to exist.  If using signerName, then the combination of
+                                                      signerName and labelSelector is allowed to match zero
+                                                      ClusterTrustBundles.
                                                     type: boolean
                                                   path:
                                                     description: Relative path from
@@ -8188,11 +7184,10 @@ spec:
                                                       bundle.
                                                     type: string
                                                   signerName:
-                                                    description: Select all ClusterTrustBundles
-                                                      that match this signer name.
-                                                      Mutually-exclusive with name.  The
-                                                      contents of all selected ClusterTrustBundles
-                                                      will be unified and deduplicated.
+                                                    description: |-
+                                                      Select all ClusterTrustBundles that match this signer name.
+                                                      Mutually-exclusive with name.  The contents of all selected
+                                                      ClusterTrustBundles will be unified and deduplicated.
                                                     type: string
                                                 required:
                                                 - path
@@ -8202,23 +7197,14 @@ spec:
                                                   about the configMap data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced ConfigMap
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the ConfigMap, the volume
-                                                      setup will error unless it is
-                                                      marked optional. Paths must
-                                                      be relative and may not contain
-                                                      the '..' path or start with
-                                                      '..'.
+                                                    description: |-
+                                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                                      ConfigMap will be projected into the volume as a file whose name is the
+                                                      key and content is the value. If specified, the listed keys will be
+                                                      projected into the specified paths, and unlisted keys will not be
+                                                      present. If a key is specified which is not present in the ConfigMap,
+                                                      the volume setup will error unless it is marked optional. Paths must be
+                                                      relative and may not contain the '..' path or start with '..'.
                                                     items:
                                                       description: Maps a string key
                                                         to a path within a volume.
@@ -8228,35 +7214,21 @@ spec:
                                                             key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
+                                                          description: |-
+                                                            mode is Optional: mode bits used to set permissions on this file.
+                                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
+                                                          description: |-
+                                                            path is the relative path of the file to map the key to.
+                                                            May not be an absolute path.
+                                                            May not contain the path element '..'.
+                                                            May not start with the string '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -8264,10 +7236,10 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: optional specify
@@ -8314,24 +7286,13 @@ spec:
                                                           type: object
                                                           x-kubernetes-map-type: atomic
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file,
-                                                            must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
+                                                          description: |-
+                                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
                                                           format: int32
                                                           type: integer
                                                         path:
@@ -8347,13 +7308,9 @@ spec:
                                                             ''..'''
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a
-                                                            resource of the container:
-                                                            only resources limits
-                                                            and requests (limits.cpu,
-                                                            limits.memory, requests.cpu
-                                                            and requests.memory) are
-                                                            currently supported.'
+                                                          description: |-
+                                                            Selects a resource of the container: only resources limits and requests
+                                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                           properties:
                                                             containerName:
                                                               description: 'Container
@@ -8389,22 +7346,14 @@ spec:
                                                   the secret data to project
                                                 properties:
                                                   items:
-                                                    description: items if unspecified,
-                                                      each key-value pair in the Data
-                                                      field of the referenced Secret
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the Secret, the volume setup
-                                                      will error unless it is marked
-                                                      optional. Paths must be relative
-                                                      and may not contain the '..'
-                                                      path or start with '..'.
+                                                    description: |-
+                                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                                      Secret will be projected into the volume as a file whose name is the
+                                                      key and content is the value. If specified, the listed keys will be
+                                                      projected into the specified paths, and unlisted keys will not be
+                                                      present. If a key is specified which is not present in the Secret,
+                                                      the volume setup will error unless it is marked optional. Paths must be
+                                                      relative and may not contain the '..' path or start with '..'.
                                                     items:
                                                       description: Maps a string key
                                                         to a path within a volume.
@@ -8414,35 +7363,21 @@ spec:
                                                             key to project.
                                                           type: string
                                                         mode:
-                                                          description: 'mode is Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
+                                                          description: |-
+                                                            mode is Optional: mode bits used to set permissions on this file.
+                                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: path is the
-                                                            relative path of the file
-                                                            to map the key to. May
-                                                            not be an absolute path.
-                                                            May not contain the path
-                                                            element '..'. May not
-                                                            start with the string
-                                                            '..'.
+                                                          description: |-
+                                                            path is the relative path of the file to map the key to.
+                                                            May not be an absolute path.
+                                                            May not contain the path element '..'.
+                                                            May not start with the string '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -8450,10 +7385,10 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: optional field specify
@@ -8468,37 +7403,26 @@ spec:
                                                   data to project
                                                 properties:
                                                   audience:
-                                                    description: audience is the intended
-                                                      audience of the token. A recipient
-                                                      of a token must identify itself
-                                                      with an identifier specified
-                                                      in the audience of the token,
-                                                      and otherwise should reject
-                                                      the token. The audience defaults
-                                                      to the identifier of the apiserver.
+                                                    description: |-
+                                                      audience is the intended audience of the token. A recipient of a token
+                                                      must identify itself with an identifier specified in the audience of the
+                                                      token, and otherwise should reject the token. The audience defaults to the
+                                                      identifier of the apiserver.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: expirationSeconds
-                                                      is the requested duration of
-                                                      validity of the service account
-                                                      token. As the token approaches
-                                                      expiration, the kubelet volume
-                                                      plugin will proactively rotate
-                                                      the service account token. The
-                                                      kubelet will start trying to
-                                                      rotate the token if the token
-                                                      is older than 80 percent of
-                                                      its time to live or if the token
-                                                      is older than 24 hours.Defaults
-                                                      to 1 hour and must be at least
-                                                      10 minutes.
+                                                    description: |-
+                                                      expirationSeconds is the requested duration of validity of the service
+                                                      account token. As the token approaches expiration, the kubelet volume
+                                                      plugin will proactively rotate the service account token. The kubelet will
+                                                      start trying to rotate the token if the token is older than 80 percent of
+                                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                      and must be at least 10 minutes.
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: path is the path
-                                                      relative to the mount point
-                                                      of the file to project the token
-                                                      into.
+                                                    description: |-
+                                                      path is the path relative to the mount point of the file to project the
+                                                      token into.
                                                     type: string
                                                 required:
                                                 - path
@@ -8511,30 +7435,29 @@ spec:
                                         on the host that shares a pod's lifetime
                                       properties:
                                         group:
-                                          description: group to map volume access
-                                            to Default is no group
+                                          description: |-
+                                            group to map volume access to
+                                            Default is no group
                                           type: string
                                         readOnly:
-                                          description: readOnly here will force the
-                                            Quobyte volume to be mounted with read-only
-                                            permissions. Defaults to false.
+                                          description: |-
+                                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                            Defaults to false.
                                           type: boolean
                                         registry:
-                                          description: registry represents a single
-                                            or multiple Quobyte Registry services
-                                            specified as a string as host:port pair
-                                            (multiple entries are separated with commas)
-                                            which acts as the central registry for
-                                            volumes
+                                          description: |-
+                                            registry represents a single or multiple Quobyte Registry services
+                                            specified as a string as host:port pair (multiple entries are separated with commas)
+                                            which acts as the central registry for volumes
                                           type: string
                                         tenant:
-                                          description: tenant owning the given Quobyte
-                                            volume in the Backend Used with dynamically
-                                            provisioned Quobyte volumes, value is
-                                            set by the plugin
+                                          description: |-
+                                            tenant owning the given Quobyte volume in the Backend
+                                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                           type: string
                                         user:
-                                          description: user to map volume access to
+                                          description: |-
+                                            user to map volume access to
                                             Defaults to serivceaccount user
                                           type: string
                                         volume:
@@ -8546,61 +7469,68 @@ spec:
                                       - volume
                                       type: object
                                     rbd:
-                                      description: 'rbd represents a Rados Block Device
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      description: |-
+                                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md
                                       properties:
                                         fsType:
-                                          description: 'fsType is the filesystem type
-                                            of the volume that you want to mount.
-                                            Tip: Ensure that the filesystem type is
-                                            supported by the host operating system.
-                                            Examples: "ext4", "xfs", "ntfs". Implicitly
-                                            inferred to be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         image:
-                                          description: 'image is the rados image name.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            image is the rados image name.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         keyring:
-                                          description: 'keyring is the path to key
-                                            ring for RBDUser. Default is /etc/ceph/keyring.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            keyring is the path to key ring for RBDUser.
+                                            Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         monitors:
-                                          description: 'monitors is a collection of
-                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            monitors is a collection of Ceph monitors.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           items:
                                             type: string
                                           type: array
                                         pool:
-                                          description: 'pool is the rados pool name.
-                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            pool is the rados pool name.
+                                            Default is rbd.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         readOnly:
-                                          description: 'readOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: boolean
                                         secretRef:
-                                          description: 'secretRef is name of the authentication
-                                            secret for RBDUser. If provided overrides
-                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            secretRef is name of the authentication secret for RBDUser. If provided
+                                            overrides keyring.
+                                            Default is nil.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         user:
-                                          description: 'user is the rados user name.
-                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            user is the rados user name.
+                                            Default is admin.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                       required:
                                       - image
@@ -8612,10 +7542,11 @@ spec:
                                         nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Default is "xfs".
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs".
+                                            Default is "xfs".
                                           type: string
                                         gateway:
                                           description: gateway is the host address
@@ -8627,21 +7558,20 @@ spec:
                                             configured storage.
                                           type: string
                                         readOnly:
-                                          description: readOnly Defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly Defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef references to the
-                                            secret for ScaleIO user and other sensitive
-                                            information. If this is not provided,
-                                            Login operation will fail.
+                                          description: |-
+                                            secretRef references to the secret for ScaleIO user and other
+                                            sensitive information. If this is not provided, Login operation will fail.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -8651,9 +7581,9 @@ spec:
                                             false
                                           type: boolean
                                         storageMode:
-                                          description: storageMode indicates whether
-                                            the storage for a volume should be ThickProvisioned
-                                            or ThinProvisioned. Default is ThinProvisioned.
+                                          description: |-
+                                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                            Default is ThinProvisioned.
                                           type: string
                                         storagePool:
                                           description: storagePool is the ScaleIO
@@ -8665,10 +7595,9 @@ spec:
                                             system as configured in ScaleIO.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the name of a
-                                            volume already created in the ScaleIO
-                                            system that is associated with this volume
-                                            source.
+                                          description: |-
+                                            volumeName is the name of a volume already created in the ScaleIO system
+                                            that is associated with this volume source.
                                           type: string
                                       required:
                                       - gateway
@@ -8676,38 +7605,30 @@ spec:
                                       - system
                                       type: object
                                     secret:
-                                      description: 'secret represents a secret that
-                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: |-
+                                        secret represents a secret that should populate this volume.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                       properties:
                                         defaultMode:
-                                          description: 'defaultMode is Optional: mode
-                                            bits used to set permissions on created
-                                            files by default. Must be an octal value
-                                            between 0000 and 0777 or a decimal value
-                                            between 0 and 511. YAML accepts both octal
-                                            and decimal values, JSON requires decimal
-                                            values for mode bits. Defaults to 0644.
-                                            Directories within the path are not affected
-                                            by this setting. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: |-
+                                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values
+                                            for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
-                                          description: items If unspecified, each
-                                            key-value pair in the Data field of the
-                                            referenced Secret will be projected into
-                                            the volume as a file whose name is the
-                                            key and content is the value. If specified,
-                                            the listed keys will be projected into
-                                            the specified paths, and unlisted keys
-                                            will not be present. If a key is specified
-                                            which is not present in the Secret, the
-                                            volume setup will error unless it is marked
-                                            optional. Paths must be relative and may
-                                            not contain the '..' path or start with
-                                            '..'.
+                                          description: |-
+                                            items If unspecified, each key-value pair in the Data field of the referenced
+                                            Secret will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the Secret,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
                                           items:
                                             description: Maps a string key to a path
                                               within a volume.
@@ -8716,28 +7637,21 @@ spec:
                                                 description: key is the key to project.
                                                 type: string
                                               mode:
-                                                description: 'mode is Optional: mode
-                                                  bits used to set permissions on
-                                                  this file. Must be an octal value
-                                                  between 0000 and 0777 or a decimal
-                                                  value between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: path is the relative
-                                                  path of the file to map the key
-                                                  to. May not be an absolute path.
-                                                  May not contain the path element
-                                                  '..'. May not start with the string
-                                                  '..'.
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
                                                 type: string
                                             required:
                                             - key
@@ -8749,9 +7663,9 @@ spec:
                                             the Secret or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'secretName is the name of
-                                            the secret in the pod''s namespace to
-                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          description: |-
+                                            secretName is the name of the secret in the pod's namespace to use.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                           type: string
                                       type: object
                                     storageos:
@@ -8760,48 +7674,42 @@ spec:
                                         nodes.
                                       properties:
                                         fsType:
-                                          description: fsType is the filesystem type
-                                            to mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: readOnly defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: secretRef specifies the secret
-                                            to use for obtaining the StorageOS API
-                                            credentials.  If not specified, default
-                                            values will be attempted.
+                                          description: |-
+                                            secretRef specifies the secret to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default values will be attempted.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         volumeName:
-                                          description: volumeName is the human-readable
-                                            name of the StorageOS volume.  Volume
+                                          description: |-
+                                            volumeName is the human-readable name of the StorageOS volume.  Volume
                                             names are only unique within a namespace.
                                           type: string
                                         volumeNamespace:
-                                          description: volumeNamespace specifies the
-                                            scope of the volume within StorageOS.  If
-                                            no namespace is specified then the Pod's
-                                            namespace will be used.  This allows the
-                                            Kubernetes name scoping to be mirrored
-                                            within StorageOS for tighter integration.
-                                            Set VolumeName to any name to override
-                                            the default behaviour. Set to "default"
-                                            if you are not using namespaces within
-                                            StorageOS. Namespaces that do not pre-exist
-                                            within StorageOS will be created.
+                                          description: |-
+                                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                            namespace is specified then the Pod's namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override the default behaviour.
+                                            Set to "default" if you are not using namespaces within StorageOS.
+                                            Namespaces that do not pre-exist within StorageOS will be created.
                                           type: string
                                       type: object
                                     vsphereVolume:
@@ -8810,11 +7718,10 @@ spec:
                                         machine
                                       properties:
                                         fsType:
-                                          description: fsType is filesystem type to
-                                            mount. Must be a filesystem type supported
-                                            by the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified.
+                                          description: |-
+                                            fsType is filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         storagePolicyID:
                                           description: storagePolicyID is the storage
@@ -8854,8 +7761,10 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be
@@ -8873,8 +7782,10 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be
@@ -8893,8 +7804,10 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be
@@ -8933,23 +7846,23 @@ spec:
                       to exist.
                     properties:
                       defaultBackend:
-                        description: defaultBackend is the backend that should handle
-                          requests that don't match any rule. If Rules are not specified,
-                          DefaultBackend must be specified. If DefaultBackend is not
-                          set, the handling of requests that do not match any of the
-                          rules will be up to the Ingress controller.
+                        description: |-
+                          defaultBackend is the backend that should handle requests that don't
+                          match any rule. If Rules are not specified, DefaultBackend must be specified.
+                          If DefaultBackend is not set, the handling of requests that do not match any
+                          of the rules will be up to the Ingress controller.
                         properties:
                           resource:
-                            description: resource is an ObjectRef to another Kubernetes
-                              resource in the namespace of the Ingress object. If
-                              resource is specified, a service.Name and service.Port
-                              must not be specified. This is a mutually exclusive
-                              setting with "Service".
+                            description: |-
+                              resource is an ObjectRef to another Kubernetes resource in the namespace
+                              of the Ingress object. If resource is specified, a service.Name and
+                              service.Port must not be specified.
+                              This is a mutually exclusive setting with "Service".
                             properties:
                               apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified,
-                                  the specified Kind must be in the core API group.
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
                                   For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
@@ -8964,27 +7877,29 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           service:
-                            description: service references a service as a backend.
+                            description: |-
+                              service references a service as a backend.
                               This is a mutually exclusive setting with "Resource".
                             properties:
                               name:
-                                description: name is the referenced service. The service
-                                  must exist in the same namespace as the Ingress
-                                  object.
+                                description: |-
+                                  name is the referenced service. The service must exist in
+                                  the same namespace as the Ingress object.
                                 type: string
                               port:
-                                description: port of the referenced service. A port
-                                  name or port number is required for a IngressServiceBackend.
+                                description: |-
+                                  port of the referenced service. A port name or port number
+                                  is required for a IngressServiceBackend.
                                 properties:
                                   name:
-                                    description: name is the name of the port on the
-                                      Service. This is a mutually exclusive setting
-                                      with "Number".
+                                    description: |-
+                                      name is the name of the port on the Service.
+                                      This is a mutually exclusive setting with "Number".
                                     type: string
                                   number:
-                                    description: number is the numerical port number
-                                      (e.g. 80) on the Service. This is a mutually
-                                      exclusive setting with "Name".
+                                    description: |-
+                                      number is the numerical port number (e.g. 80) on the Service.
+                                      This is a mutually exclusive setting with "Name".
                                     format: int32
                                     type: integer
                                 type: object
@@ -8993,96 +7908,90 @@ spec:
                             type: object
                         type: object
                       ingressClassName:
-                        description: ingressClassName is the name of an IngressClass
-                          cluster resource. Ingress controller implementations use
-                          this field to know whether they should be serving this Ingress
-                          resource, by a transitive connection (controller -> IngressClass
-                          -> Ingress resource). Although the `kubernetes.io/ingress.class`
-                          annotation (simple constant name) was never formally defined,
-                          it was widely supported by Ingress controllers to create
-                          a direct binding between Ingress controller and Ingress
-                          resources. Newly created Ingress resources should prefer
-                          using the field. However, even though the annotation is
-                          officially deprecated, for backwards compatibility reasons,
-                          ingress controllers should still honor that annotation if
-                          present.
+                        description: |-
+                          ingressClassName is the name of an IngressClass cluster resource. Ingress
+                          controller implementations use this field to know whether they should be
+                          serving this Ingress resource, by a transitive connection
+                          (controller -> IngressClass -> Ingress resource). Although the
+                          `kubernetes.io/ingress.class` annotation (simple constant name) was never
+                          formally defined, it was widely supported by Ingress controllers to create
+                          a direct binding between Ingress controller and Ingress resources. Newly
+                          created Ingress resources should prefer using the field. However, even
+                          though the annotation is officially deprecated, for backwards compatibility
+                          reasons, ingress controllers should still honor that annotation if present.
                         type: string
                       rules:
-                        description: rules is a list of host rules used to configure
-                          the Ingress. If unspecified, or no rule matches, all traffic
-                          is sent to the default backend.
+                        description: |-
+                          rules is a list of host rules used to configure the Ingress. If unspecified,
+                          or no rule matches, all traffic is sent to the default backend.
                         items:
-                          description: IngressRule represents the rules mapping the
-                            paths under a specified host to the related backend services.
-                            Incoming requests are first evaluated for a host match,
-                            then routed to the backend associated with the matching
-                            IngressRuleValue.
+                          description: |-
+                            IngressRule represents the rules mapping the paths under a specified host to
+                            the related backend services. Incoming requests are first evaluated for a host
+                            match, then routed to the backend associated with the matching IngressRuleValue.
                           properties:
                             host:
                               description: "host is the fully qualified domain name
-                                of a network host, as defined by RFC 3986. Note the
-                                following deviations from the \"host\" part of the
-                                URI as defined in RFC 3986: 1. IPs are not allowed.
-                                Currently an IngressRuleValue can only apply to the
-                                IP in the Spec of the parent Ingress. 2. The `:` delimiter
-                                is not respected because ports are not allowed. Currently
-                                the port of an Ingress is implicitly :80 for http
-                                and :443 for https. Both these may change in the future.
-                                Incoming requests are matched against the host before
-                                the IngressRuleValue. If the host is unspecified,
-                                the Ingress routes all traffic based on the specified
-                                IngressRuleValue. \n host can be \"precise\" which
-                                is a domain name without the terminating dot of a
-                                network host (e.g. \"foo.bar.com\") or \"wildcard\",
-                                which is a domain name prefixed with a single wildcard
-                                label (e.g. \"*.foo.com\"). The wildcard character
-                                '*' must appear by itself as the first DNS label and
-                                matches only a single label. You cannot have a wildcard
-                                label by itself (e.g. Host == \"*\"). Requests will
-                                be matched against the Host field in the following
-                                way: 1. If host is precise, the request matches this
-                                rule if the http host header is equal to Host. 2.
-                                If host is a wildcard, then the request matches this
-                                rule if the http host header is to equal to the suffix
-                                (removing the first label) of the wildcard rule."
+                                of a network host, as defined by RFC 3986.\nNote the
+                                following deviations from the \"host\" part of the\nURI
+                                as defined in RFC 3986:\n1. IPs are not allowed. Currently
+                                an IngressRuleValue can only apply to\n   the IP in
+                                the Spec of the parent Ingress.\n2. The `:` delimiter
+                                is not respected because ports are not allowed.\n\t
+                                \ Currently the port of an Ingress is implicitly :80
+                                for http and\n\t  :443 for https.\nBoth these may
+                                change in the future.\nIncoming requests are matched
+                                against the host before the\nIngressRuleValue. If
+                                the host is unspecified, the Ingress routes all\ntraffic
+                                based on the specified IngressRuleValue.\n\n\nhost
+                                can be \"precise\" which is a domain name without
+                                the terminating dot of\na network host (e.g. \"foo.bar.com\")
+                                or \"wildcard\", which is a domain name\nprefixed
+                                with a single wildcard label (e.g. \"*.foo.com\").\nThe
+                                wildcard character '*' must appear by itself as the
+                                first DNS label and\nmatches only a single label.
+                                You cannot have a wildcard label by itself (e.g. Host
+                                == \"*\").\nRequests will be matched against the Host
+                                field in the following way:\n1. If host is precise,
+                                the request matches this rule if the http host header
+                                is equal to Host.\n2. If host is a wildcard, then
+                                the request matches this rule if the http host header\nis
+                                to equal to the suffix (removing the first label)
+                                of the wildcard rule."
                               type: string
                             http:
-                              description: 'HTTPIngressRuleValue is a list of http
-                                selectors pointing to backends. In the example: http://<host>/<path>?<searchpart>
-                                -> backend where where parts of the url correspond
-                                to RFC 3986, this resource will be used to match against
-                                everything after the last ''/'' and before the first
-                                ''?'' or ''#''.'
+                              description: |-
+                                HTTPIngressRuleValue is a list of http selectors pointing to backends.
+                                In the example: http://<host>/<path>?<searchpart> -> backend where
+                                where parts of the url correspond to RFC 3986, this resource will be used
+                                to match against everything after the last '/' and before the first '?'
+                                or '#'.
                               properties:
                                 paths:
                                   description: paths is a collection of paths that
                                     map requests to backends.
                                   items:
-                                    description: HTTPIngressPath associates a path
-                                      with a backend. Incoming urls matching the path
-                                      are forwarded to the backend.
+                                    description: |-
+                                      HTTPIngressPath associates a path with a backend. Incoming urls matching the
+                                      path are forwarded to the backend.
                                     properties:
                                       backend:
-                                        description: backend defines the referenced
-                                          service endpoint to which the traffic will
-                                          be forwarded to.
+                                        description: |-
+                                          backend defines the referenced service endpoint to which the traffic
+                                          will be forwarded to.
                                         properties:
                                           resource:
-                                            description: resource is an ObjectRef
-                                              to another Kubernetes resource in the
-                                              namespace of the Ingress object. If
-                                              resource is specified, a service.Name
-                                              and service.Port must not be specified.
-                                              This is a mutually exclusive setting
-                                              with "Service".
+                                            description: |-
+                                              resource is an ObjectRef to another Kubernetes resource in the namespace
+                                              of the Ingress object. If resource is specified, a service.Name and
+                                              service.Port must not be specified.
+                                              This is a mutually exclusive setting with "Service".
                                             properties:
                                               apiGroup:
-                                                description: APIGroup is the group
-                                                  for the resource being referenced.
-                                                  If APIGroup is not specified, the
-                                                  specified Kind must be in the core
-                                                  API group. For any other third-party
-                                                  types, APIGroup is required.
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
                                                 type: string
                                               kind:
                                                 description: Kind is the type of resource
@@ -9098,32 +8007,29 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           service:
-                                            description: service references a service
-                                              as a backend. This is a mutually exclusive
-                                              setting with "Resource".
+                                            description: |-
+                                              service references a service as a backend.
+                                              This is a mutually exclusive setting with "Resource".
                                             properties:
                                               name:
-                                                description: name is the referenced
-                                                  service. The service must exist
-                                                  in the same namespace as the Ingress
-                                                  object.
+                                                description: |-
+                                                  name is the referenced service. The service must exist in
+                                                  the same namespace as the Ingress object.
                                                 type: string
                                               port:
-                                                description: port of the referenced
-                                                  service. A port name or port number
+                                                description: |-
+                                                  port of the referenced service. A port name or port number
                                                   is required for a IngressServiceBackend.
                                                 properties:
                                                   name:
-                                                    description: name is the name
-                                                      of the port on the Service.
-                                                      This is a mutually exclusive
-                                                      setting with "Number".
+                                                    description: |-
+                                                      name is the name of the port on the Service.
+                                                      This is a mutually exclusive setting with "Number".
                                                     type: string
                                                   number:
-                                                    description: number is the numerical
-                                                      port number (e.g. 80) on the
-                                                      Service. This is a mutually
-                                                      exclusive setting with "Name".
+                                                    description: |-
+                                                      number is the numerical port number (e.g. 80) on the Service.
+                                                      This is a mutually exclusive setting with "Name".
                                                     format: int32
                                                     type: integer
                                                 type: object
@@ -9132,36 +8038,28 @@ spec:
                                             type: object
                                         type: object
                                       path:
-                                        description: path is matched against the path
-                                          of an incoming request. Currently it can
-                                          contain characters disallowed from the conventional
-                                          "path" part of a URL as defined by RFC 3986.
-                                          Paths must begin with a '/' and must be
-                                          present when using PathType with value "Exact"
-                                          or "Prefix".
+                                        description: |-
+                                          path is matched against the path of an incoming request. Currently it can
+                                          contain characters disallowed from the conventional "path" part of a URL
+                                          as defined by RFC 3986. Paths must begin with a '/' and must be present
+                                          when using PathType with value "Exact" or "Prefix".
                                         type: string
                                       pathType:
-                                        description: 'pathType determines the interpretation
-                                          of the path matching. PathType can be one
-                                          of the following values: * Exact: Matches
-                                          the URL path exactly. * Prefix: Matches
-                                          based on a URL path prefix split by ''/''.
-                                          Matching is done on a path element by element
-                                          basis. A path element refers is the list
-                                          of labels in the path split by the ''/''
-                                          separator. A request is a match for path
-                                          p if every p is an element-wise prefix of
-                                          p of the request path. Note that if the
-                                          last element of the path is a substring
-                                          of the last element in request path, it
-                                          is not a match (e.g. /foo/bar matches /foo/bar/baz,
-                                          but does not match /foo/barbaz). * ImplementationSpecific:
-                                          Interpretation of the Path matching is up
-                                          to the IngressClass. Implementations can
-                                          treat this as a separate PathType or treat
-                                          it identically to Prefix or Exact path types.
-                                          Implementations are required to support
-                                          all path types.'
+                                        description: |-
+                                          pathType determines the interpretation of the path matching. PathType can
+                                          be one of the following values:
+                                          * Exact: Matches the URL path exactly.
+                                          * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                            done on a path element by element basis. A path element refers is the
+                                            list of labels in the path split by the '/' separator. A request is a
+                                            match for path p if every p is an element-wise prefix of p of the
+                                            request path. Note that if the last element of the path is a substring
+                                            of the last element in request path, it is not a match (e.g. /foo/bar
+                                            matches /foo/bar/baz, but does not match /foo/barbaz).
+                                          * ImplementationSpecific: Interpretation of the Path matching is up to
+                                            the IngressClass. Implementations can treat this as a separate PathType
+                                            or treat it identically to Prefix or Exact path types.
+                                          Implementations are required to support all path types.
                                         type: string
                                     required:
                                     - backend
@@ -9176,34 +8074,33 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       tls:
-                        description: tls represents the TLS configuration. Currently
-                          the Ingress only supports a single TLS port, 443. If multiple
-                          members of this list specify different hosts, they will
-                          be multiplexed on the same port according to the hostname
-                          specified through the SNI TLS extension, if the ingress
-                          controller fulfilling the ingress supports SNI.
+                        description: |-
+                          tls represents the TLS configuration. Currently the Ingress only supports a
+                          single TLS port, 443. If multiple members of this list specify different hosts,
+                          they will be multiplexed on the same port according to the hostname specified
+                          through the SNI TLS extension, if the ingress controller fulfilling the
+                          ingress supports SNI.
                         items:
                           description: IngressTLS describes the transport layer security
                             associated with an ingress.
                           properties:
                             hosts:
-                              description: hosts is a list of hosts included in the
-                                TLS certificate. The values in this list must match
-                                the name/s used in the tlsSecret. Defaults to the
-                                wildcard host setting for the loadbalancer controller
-                                fulfilling this Ingress, if left unspecified.
+                              description: |-
+                                hosts is a list of hosts included in the TLS certificate. The values in
+                                this list must match the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller fulfilling this
+                                Ingress, if left unspecified.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             secretName:
-                              description: secretName is the name of the secret used
-                                to terminate TLS traffic on port 443. Field is left
-                                optional to allow TLS routing based on SNI hostname
-                                alone. If the SNI host in a listener conflicts with
-                                the "Host" header field used by an IngressRule, the
-                                SNI host is used for termination and value of the
-                                "Host" header is used for routing.
+                              description: |-
+                                secretName is the name of the secret used to terminate TLS traffic on
+                                port 443. Field is left optional to allow TLS routing based on SNI
+                                hostname alone. If the SNI host in a listener conflicts with the "Host"
+                                header field used by an IngressRule, the SNI host is used for termination
+                                and value of the "Host" header is used for routing.
                               type: string
                           type: object
                         type: array
@@ -9213,34 +8110,34 @@ spec:
               jsonnet:
                 properties:
                   libraryLabelSelector:
-                    description: A label selector is a label query over a set of resources.
-                      The result of matchLabels and matchExpressions are ANDed. An
-                      empty label selector matches all objects. A null label selector
-                      matches no objects.
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -9252,11 +8149,10 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -9285,15 +8181,15 @@ spec:
                           type: string
                         type: array
                       dataSource:
-                        description: TypedLocalObjectReference contains enough information
-                          to let you locate the typed referenced object inside the
-                          same namespace.
+                        description: |-
+                          TypedLocalObjectReference contains enough information to let you locate the
+                          typed referenced object inside the same namespace.
                         properties:
                           apiGroup:
-                            description: APIGroup is the group for the resource being
-                              referenced. If APIGroup is not specified, the specified
-                              Kind must be in the core API group. For any other third-party
-                              types, APIGroup is required.
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
                             type: string
                           kind:
                             description: Kind is the type of resource being referenced
@@ -9307,15 +8203,15 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       dataSourceRef:
-                        description: TypedLocalObjectReference contains enough information
-                          to let you locate the typed referenced object inside the
-                          same namespace.
+                        description: |-
+                          TypedLocalObjectReference contains enough information to let you locate the
+                          typed referenced object inside the same namespace.
                         properties:
                           apiGroup:
-                            description: APIGroup is the group for the resource being
-                              referenced. If APIGroup is not specified, the specified
-                              Kind must be in the core API group. For any other third-party
-                              types, APIGroup is required.
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
                             type: string
                           kind:
                             description: Kind is the type of resource being referenced
@@ -9333,18 +8229,23 @@ spec:
                           requirements.
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                              in spec.resourceClaims, that are used by this container.
-                              \n This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate. \n This field
-                              is immutable. It can only be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -9361,8 +8262,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -9371,25 +8273,25 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       selector:
-                        description: A label selector is a label query over a set
-                          of resources. The result of matchLabels and matchExpressions
-                          are ANDed. An empty label selector matches all objects.
-                          A null label selector matches no objects.
+                        description: |-
+                          A label selector is a label query over a set of resources. The result of matchLabels and
+                          matchExpressions are ANDed. An empty label selector matches all objects. A null
+                          label selector matches no objects.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
@@ -9397,17 +8299,16 @@ spec:
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -9419,11 +8320,10 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -9466,9 +8366,9 @@ spec:
                     properties:
                       alternateBackends:
                         items:
-                          description: RouteTargetReference specifies the target that
-                            resolve into endpoints. Only the 'Service' kind is allowed.
-                            Use 'weight' field to emphasize one over others.
+                          description: |-
+                            RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service'
+                            kind is allowed. Use 'weight' field to emphasize one over others.
                           properties:
                             kind:
                               description: The kind of target that the route is referring
@@ -9479,10 +8379,9 @@ spec:
                                 referred to. e.g. name of the service
                               type: string
                             weight:
-                              description: weight as an integer between 0 and 256,
-                                default 100, that specifies the target's relative
-                                weight against other target reference objects. 0 suppresses
-                                requests to this backend.
+                              description: |-
+                                weight as an integer between 0 and 256, default 100, that specifies the target's relative weight
+                                against other target reference objects. 0 suppresses requests to this backend.
                               format: int32
                               type: integer
                           required:
@@ -9503,10 +8402,10 @@ spec:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: The target port on pods selected by the service
-                              this route points to. If this is a string, it will be
-                              looked up as a named port in the target endpoints port
-                              list. Required
+                            description: |-
+                              The target port on pods selected by the service this route points to.
+                              If this is a string, it will be looked up as a named port in the target
+                              endpoints port list. Required
                             x-kubernetes-int-or-string: true
                         required:
                         - targetPort
@@ -9523,25 +8422,22 @@ spec:
                             description: certificate provides certificate contents
                             type: string
                           destinationCACertificate:
-                            description: destinationCACertificate provides the contents
-                              of the ca certificate of the final destination.  When
-                              using reencrypt termination this file should be provided
-                              in order to have routers use it for health checks on
-                              the secure connection. If this field is not specified,
-                              the router may provide its own destination CA and perform
-                              hostname validation using the short service name (service.namespace.svc),
-                              which allows infrastructure generated certificates to
-                              automatically verify.
+                            description: |-
+                              destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt
+                              termination this file should be provided in order to have routers use it for health checks on the secure connection.
+                              If this field is not specified, the router may provide its own destination CA and perform hostname validation using
+                              the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically
+                              verify.
                             type: string
                           insecureEdgeTerminationPolicy:
-                            description: "insecureEdgeTerminationPolicy indicates
-                              the desired behavior for insecure connections to a route.
-                              While each router may make its own decisions on which
-                              ports to expose, this is normally port 80. \n * Allow
-                              - traffic is sent to the server on the insecure port
-                              (default) * Disable - no traffic is allowed on the insecure
-                              port. * Redirect - clients are redirected to the secure
-                              port."
+                            description: |-
+                              insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
+                              each router may make its own decisions on which ports to expose, this is normally port 80.
+
+
+                              * Allow - traffic is sent to the server on the insecure port (default)
+                              * Disable - no traffic is allowed on the insecure port.
+                              * Redirect - clients are redirected to the secure port.
                             type: string
                           key:
                             description: key provides key file contents
@@ -9553,9 +8449,9 @@ spec:
                         - termination
                         type: object
                       to:
-                        description: RouteTargetReference specifies the target that
-                          resolve into endpoints. Only the 'Service' kind is allowed.
-                          Use 'weight' field to emphasize one over others.
+                        description: |-
+                          RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service'
+                          kind is allowed. Use 'weight' field to emphasize one over others.
                         properties:
                           kind:
                             description: The kind of target that the route is referring
@@ -9566,10 +8462,9 @@ spec:
                               referred to. e.g. name of the service
                             type: string
                           weight:
-                            description: weight as an integer between 0 and 256, default
-                              100, that specifies the target's relative weight against
-                              other target reference objects. 0 suppresses requests
-                              to this backend.
+                            description: |-
+                              weight as an integer between 0 and 256, default 100, that specifies the target's relative weight
+                              against other target reference objects. 0 suppresses requests to this backend.
                             format: int32
                             type: integer
                         required:
@@ -9605,245 +8500,236 @@ spec:
                       creates on a service.
                     properties:
                       allocateLoadBalancerNodePorts:
-                        description: allocateLoadBalancerNodePorts defines if NodePorts
-                          will be automatically allocated for services with type LoadBalancer.  Default
-                          is "true". It may be set to "false" if the cluster load-balancer
-                          does not rely on NodePorts.  If the caller requests specific
-                          NodePorts (by specifying a value), those requests will be
-                          respected, regardless of this field. This field may only
-                          be set for services with type LoadBalancer and will be cleared
-                          if the type is changed to any other type.
+                        description: |-
+                          allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                          allocated for services with type LoadBalancer.  Default is "true". It
+                          may be set to "false" if the cluster load-balancer does not rely on
+                          NodePorts.  If the caller requests specific NodePorts (by specifying a
+                          value), those requests will be respected, regardless of this field.
+                          This field may only be set for services with type LoadBalancer and will
+                          be cleared if the type is changed to any other type.
                         type: boolean
                       clusterIP:
-                        description: 'clusterIP is the IP address of the service and
-                          is usually assigned randomly. If an address is specified
-                          manually, is in-range (as per system configuration), and
-                          is not in use, it will be allocated to the service; otherwise
-                          creation of the service will fail. This field may not be
-                          changed through updates unless the type field is also being
-                          changed to ExternalName (which requires this field to be
-                          blank) or the type field is being changed from ExternalName
-                          (in which case this field may optionally be specified, as
-                          describe above).  Valid values are "None", empty string
-                          (""), or a valid IP address. Setting this to "None" makes
-                          a "headless service" (no virtual IP), which is useful when
-                          direct endpoint connections are preferred and proxying is
-                          not required.  Only applies to types ClusterIP, NodePort,
-                          and LoadBalancer. If this field is specified when creating
-                          a Service of type ExternalName, creation will fail. This
+                        description: |-
+                          clusterIP is the IP address of the service and is usually assigned
+                          randomly. If an address is specified manually, is in-range (as per
+                          system configuration), and is not in use, it will be allocated to the
+                          service; otherwise creation of the service will fail. This field may not
+                          be changed through updates unless the type field is also being changed
+                          to ExternalName (which requires this field to be blank) or the type
+                          field is being changed from ExternalName (in which case this field may
+                          optionally be specified, as describe above).  Valid values are "None",
+                          empty string (""), or a valid IP address. Setting this to "None" makes a
+                          "headless service" (no virtual IP), which is useful when direct endpoint
+                          connections are preferred and proxying is not required.  Only applies to
+                          types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                          when creating a Service of type ExternalName, creation will fail. This
                           field will be wiped when updating a Service to type ExternalName.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                         type: string
                       clusterIPs:
-                        description: "ClusterIPs is a list of IP addresses assigned
-                          to this service, and are usually assigned randomly.  If
-                          an address is specified manually, is in-range (as per system
-                          configuration), and is not in use, it will be allocated
-                          to the service; otherwise creation of the service will fail.
-                          This field may not be changed through updates unless the
-                          type field is also being changed to ExternalName (which
-                          requires this field to be empty) or the type field is being
-                          changed from ExternalName (in which case this field may
-                          optionally be specified, as describe above).  Valid values
-                          are \"None\", empty string (\"\"), or a valid IP address.
-                          \ Setting this to \"None\" makes a \"headless service\"
-                          (no virtual IP), which is useful when direct endpoint connections
-                          are preferred and proxying is not required.  Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. If this
-                          field is specified when creating a Service of type ExternalName,
-                          creation will fail. This field will be wiped when updating
-                          a Service to type ExternalName.  If this field is not specified,
-                          it will be initialized from the clusterIP field.  If this
-                          field is specified, clients must ensure that clusterIPs[0]
-                          and clusterIP have the same value. \n This field may hold
-                          a maximum of two entries (dual-stack IPs, in either order).
-                          These IPs must correspond to the values of the ipFamilies
-                          field. Both clusterIPs and ipFamilies are governed by the
-                          ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                        description: |-
+                          ClusterIPs is a list of IP addresses assigned to this service, and are
+                          usually assigned randomly.  If an address is specified manually, is
+                          in-range (as per system configuration), and is not in use, it will be
+                          allocated to the service; otherwise creation of the service will fail.
+                          This field may not be changed through updates unless the type field is
+                          also being changed to ExternalName (which requires this field to be
+                          empty) or the type field is being changed from ExternalName (in which
+                          case this field may optionally be specified, as describe above).  Valid
+                          values are "None", empty string (""), or a valid IP address.  Setting
+                          this to "None" makes a "headless service" (no virtual IP), which is
+                          useful when direct endpoint connections are preferred and proxying is
+                          not required.  Only applies to types ClusterIP, NodePort, and
+                          LoadBalancer. If this field is specified when creating a Service of type
+                          ExternalName, creation will fail. This field will be wiped when updating
+                          a Service to type ExternalName.  If this field is not specified, it will
+                          be initialized from the clusterIP field.  If this field is specified,
+                          clients must ensure that clusterIPs[0] and clusterIP have the same
+                          value.
+
+
+                          This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                          These IPs must correspond to the values of the ipFamilies field. Both
+                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       externalIPs:
-                        description: externalIPs is a list of IP addresses for which
-                          nodes in the cluster will also accept traffic for this service.  These
-                          IPs are not managed by Kubernetes.  The user is responsible
-                          for ensuring that traffic arrives at a node with this IP.  A
-                          common example is external load-balancers that are not part
-                          of the Kubernetes system.
+                        description: |-
+                          externalIPs is a list of IP addresses for which nodes in the cluster
+                          will also accept traffic for this service.  These IPs are not managed by
+                          Kubernetes.  The user is responsible for ensuring that traffic arrives
+                          at a node with this IP.  A common example is external load-balancers
+                          that are not part of the Kubernetes system.
                         items:
                           type: string
                         type: array
                       externalName:
-                        description: externalName is the external reference that discovery
-                          mechanisms will return as an alias for this service (e.g.
-                          a DNS CNAME record). No proxying will be involved.  Must
-                          be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
-                          and requires `type` to be "ExternalName".
+                        description: |-
+                          externalName is the external reference that discovery mechanisms will
+                          return as an alias for this service (e.g. a DNS CNAME record). No
+                          proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                          (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                         type: string
                       externalTrafficPolicy:
-                        description: externalTrafficPolicy describes how nodes distribute
-                          service traffic they receive on one of the Service's "externally-facing"
-                          addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
-                          If set to "Local", the proxy will configure the service
-                          in a way that assumes that external load balancers will
-                          take care of balancing the service traffic between nodes,
-                          and so each node will deliver traffic only to the node-local
-                          endpoints of the service, without masquerading the client
-                          source IP. (Traffic mistakenly sent to a node with no endpoints
-                          will be dropped.) The default value, "Cluster", uses the
-                          standard behavior of routing to all endpoints evenly (possibly
-                          modified by topology and other features). Note that traffic
-                          sent to an External IP or LoadBalancer IP from within the
-                          cluster will always get "Cluster" semantics, but clients
-                          sending to a NodePort from within the cluster may need to
-                          take traffic policy into account when picking a node.
+                        description: |-
+                          externalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on one of the Service's "externally-facing" addresses (NodePorts,
+                          ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                          the service in a way that assumes that external load balancers will take care
+                          of balancing the service traffic between nodes, and so each node will deliver
+                          traffic only to the node-local endpoints of the service, without masquerading
+                          the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                          be dropped.) The default value, "Cluster", uses the standard behavior of
+                          routing to all endpoints evenly (possibly modified by topology and other
+                          features). Note that traffic sent to an External IP or LoadBalancer IP from
+                          within the cluster will always get "Cluster" semantics, but clients sending to
+                          a NodePort from within the cluster may need to take traffic policy into account
+                          when picking a node.
                         type: string
                       healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck
-                          nodePort for the service. This only applies when type is
-                          set to LoadBalancer and externalTrafficPolicy is set to
-                          Local. If a value is specified, is in-range, and is not
-                          in use, it will be used.  If not specified, a value will
-                          be automatically allocated.  External systems (e.g. load-balancers)
-                          can use this port to determine if a given node holds endpoints
-                          for this service or not.  If this field is specified when
-                          creating a Service which does not need it, creation will
-                          fail. This field will be wiped when updating a Service to
-                          no longer need it (e.g. changing type). This field cannot
-                          be updated once set.
+                        description: |-
+                          healthCheckNodePort specifies the healthcheck nodePort for the service.
+                          This only applies when type is set to LoadBalancer and
+                          externalTrafficPolicy is set to Local. If a value is specified, is
+                          in-range, and is not in use, it will be used.  If not specified, a value
+                          will be automatically allocated.  External systems (e.g. load-balancers)
+                          can use this port to determine if a given node holds endpoints for this
+                          service or not.  If this field is specified when creating a Service
+                          which does not need it, creation will fail. This field will be wiped
+                          when updating a Service to no longer need it (e.g. changing type).
+                          This field cannot be updated once set.
                         format: int32
                         type: integer
                       internalTrafficPolicy:
-                        description: InternalTrafficPolicy describes how nodes distribute
-                          service traffic they receive on the ClusterIP. If set to
-                          "Local", the proxy will assume that pods only want to talk
-                          to endpoints of the service on the same node as the pod,
-                          dropping the traffic if there are no local endpoints. The
-                          default value, "Cluster", uses the standard behavior of
-                          routing to all endpoints evenly (possibly modified by topology
-                          and other features).
+                        description: |-
+                          InternalTrafficPolicy describes how nodes distribute service traffic they
+                          receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                          only want to talk to endpoints of the service on the same node as the pod,
+                          dropping the traffic if there are no local endpoints. The default value,
+                          "Cluster", uses the standard behavior of routing to all endpoints evenly
+                          (possibly modified by topology and other features).
                         type: string
                       ipFamilies:
-                        description: "IPFamilies is a list of IP families (e.g. IPv4,
-                          IPv6) assigned to this service. This field is usually assigned
-                          automatically based on cluster configuration and the ipFamilyPolicy
-                          field. If this field is specified manually, the requested
-                          family is available in the cluster, and ipFamilyPolicy allows
-                          it, it will be used; otherwise creation of the service will
-                          fail. This field is conditionally mutable: it allows for
-                          adding or removing a secondary IP family, but it does not
-                          allow changing the primary IP family of the Service. Valid
-                          values are \"IPv4\" and \"IPv6\".  This field only applies
-                          to Services of types ClusterIP, NodePort, and LoadBalancer,
-                          and does apply to \"headless\" services. This field will
-                          be wiped when updating a Service to type ExternalName. \n
-                          This field may hold a maximum of two entries (dual-stack
-                          families, in either order).  These families must correspond
-                          to the values of the clusterIPs field, if specified. Both
-                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy
-                          field."
+                        description: |-
+                          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                          service. This field is usually assigned automatically based on cluster
+                          configuration and the ipFamilyPolicy field. If this field is specified
+                          manually, the requested family is available in the cluster,
+                          and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                          the service will fail. This field is conditionally mutable: it allows
+                          for adding or removing a secondary IP family, but it does not allow
+                          changing the primary IP family of the Service. Valid values are "IPv4"
+                          and "IPv6".  This field only applies to Services of types ClusterIP,
+                          NodePort, and LoadBalancer, and does apply to "headless" services.
+                          This field will be wiped when updating a Service to type ExternalName.
+
+
+                          This field may hold a maximum of two entries (dual-stack families, in
+                          either order).  These families must correspond to the values of the
+                          clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                          governed by the ipFamilyPolicy field.
                         items:
-                          description: IPFamily represents the IP Family (IPv4 or
-                            IPv6). This type is used to express the family of an IP
-                            expressed by a type (e.g. service.spec.ipFamilies).
+                          description: |-
+                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       ipFamilyPolicy:
-                        description: IPFamilyPolicy represents the dual-stack-ness
-                          requested or required by this Service. If there is no value
-                          provided, then this field will be set to SingleStack. Services
-                          can be "SingleStack" (a single IP family), "PreferDualStack"
-                          (two IP families on dual-stack configured clusters or a
-                          single IP family on single-stack clusters), or "RequireDualStack"
-                          (two IP families on dual-stack configured clusters, otherwise
-                          fail). The ipFamilies and clusterIPs fields depend on the
-                          value of this field. This field will be wiped when updating
-                          a service to type ExternalName.
+                        description: |-
+                          IPFamilyPolicy represents the dual-stack-ness requested or required by
+                          this Service. If there is no value provided, then this field will be set
+                          to SingleStack. Services can be "SingleStack" (a single IP family),
+                          "PreferDualStack" (two IP families on dual-stack configured clusters or
+                          a single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise fail). The
+                          ipFamilies and clusterIPs fields depend on the value of this field. This
+                          field will be wiped when updating a service to type ExternalName.
                         type: string
                       loadBalancerClass:
-                        description: loadBalancerClass is the class of the load balancer
-                          implementation this Service belongs to. If specified, the
-                          value of this field must be a label-style identifier, with
-                          an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
-                          Unprefixed names are reserved for end-users. This field
-                          can only be set when the Service type is 'LoadBalancer'.
-                          If not set, the default load balancer implementation is
-                          used, today this is typically done through the cloud provider
-                          integration, but should apply for any default implementation.
-                          If set, it is assumed that a load balancer implementation
-                          is watching for Services with a matching class. Any default
-                          load balancer implementation (e.g. cloud providers) should
-                          ignore Services that set this field. This field can only
-                          be set when creating or updating a Service to type 'LoadBalancer'.
-                          Once set, it can not be changed. This field will be wiped
-                          when a service is updated to a non 'LoadBalancer' type.
+                        description: |-
+                          loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                          If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                          e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                          This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                          balancer implementation is used, today this is typically done through the cloud provider integration,
+                          but should apply for any default implementation. If set, it is assumed that a load balancer
+                          implementation is watching for Services with a matching class. Any default load balancer
+                          implementation (e.g. cloud providers) should ignore Services that set this field.
+                          This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                          Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                         type: string
                       loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer.
-                          This feature depends on whether the underlying cloud-provider
-                          supports specifying the loadBalancerIP when a load balancer
-                          is created. This field will be ignored if the cloud-provider
-                          does not support the feature. Deprecated: This field was
-                          under-specified and its meaning varies across implementations.
+                        description: |-
+                          Only applies to Service Type: LoadBalancer.
+                          This feature depends on whether the underlying cloud-provider supports specifying
+                          the loadBalancerIP when a load balancer is created.
+                          This field will be ignored if the cloud-provider does not support the feature.
+                          Deprecated: This field was under-specified and its meaning varies across implementations.
                           Using it is non-portable and it may not support dual-stack.
-                          Users are encouraged to use implementation-specific annotations
-                          when available.'
+                          Users are encouraged to use implementation-specific annotations when available.
                         type: string
                       loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform,
-                          this will restrict traffic through the cloud-provider load-balancer
-                          will be restricted to the specified client IPs. This field
-                          will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                        description: |-
+                          If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                          load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                          cloud-provider does not support the feature."
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                         items:
                           type: string
                         type: array
                       ports:
-                        description: 'The list of ports that are exposed by this service.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: |-
+                          The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                         items:
                           description: ServicePort contains information on service's
                             port.
                           properties:
                             appProtocol:
-                              description: "The application protocol for this port.
-                                This is used as a hint for implementations to offer
-                                richer behavior for protocols that they understand.
+                              description: |-
+                                The application protocol for this port.
+                                This is used as a hint for implementations to offer richer behavior for protocols that they understand.
                                 This field follows standard Kubernetes label syntax.
-                                Valid values are either: \n * Un-prefixed protocol
-                                names - reserved for IANA standard service names (as
-                                per RFC-6335 and https://www.iana.org/assignments/service-names).
-                                \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
-                                - HTTP/2 prior knowledge over cleartext as described
-                                in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
-                                * 'kubernetes.io/ws'  - WebSocket over cleartext as
-                                described in https://www.rfc-editor.org/rfc/rfc6455
-                                * 'kubernetes.io/wss' - WebSocket over TLS as described
-                                in https://www.rfc-editor.org/rfc/rfc6455 \n * Other
-                                protocols should use implementation-defined prefixed
-                                names such as mycompany.com/my-custom-protocol."
+                                Valid values are either:
+
+
+                                * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                RFC-6335 and https://www.iana.org/assignments/service-names).
+
+
+                                * Kubernetes-defined prefixed names:
+                                  * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                  * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                  * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+
+                                * Other protocols should use implementation-defined prefixed names such as
+                                mycompany.com/my-custom-protocol.
                               type: string
                             name:
-                              description: The name of this port within the service.
-                                This must be a DNS_LABEL. All ports within a ServiceSpec
-                                must have unique names. When considering the endpoints
-                                for a Service, this must match the 'name' field in
-                                the EndpointPort. Optional if only one ServicePort
-                                is defined on this service.
+                              description: |-
+                                The name of this port within the service. This must be a DNS_LABEL.
+                                All ports within a ServiceSpec must have unique names. When considering
+                                the endpoints for a Service, this must match the 'name' field in the
+                                EndpointPort.
+                                Optional if only one ServicePort is defined on this service.
                               type: string
                             nodePort:
-                              description: 'The port on each node on which this service
-                                is exposed when type is NodePort or LoadBalancer.  Usually
-                                assigned by the system. If a value is specified, in-range,
-                                and not in use it will be used, otherwise the operation
-                                will fail.  If not specified, a port will be allocated
-                                if this Service requires one.  If this field is specified
-                                when creating a Service which does not need it, creation
-                                will fail. This field will be wiped when updating
-                                a Service to no longer need it (e.g. changing type
-                                from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              description: |-
+                                The port on each node on which this service is exposed when type is
+                                NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                specified, in-range, and not in use it will be used, otherwise the
+                                operation will fail.  If not specified, a port will be allocated if this
+                                Service requires one.  If this field is specified when creating a
+                                Service which does not need it, creation will fail. This field will be
+                                wiped when updating a Service to no longer need it (e.g. changing type
+                                from NodePort to ClusterIP).
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                               format: int32
                               type: integer
                             port:
@@ -9852,22 +8738,23 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The IP protocol for this port. Supports
-                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              description: |-
+                                The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                Default is TCP.
                               type: string
                             targetPort:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Number or name of the port to access on
-                                the pods targeted by the service. Number must be in
-                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                If this is a string, it will be looked up as a named
-                                port in the target Pod''s container ports. If this
-                                is not specified, the value of the ''port'' field
-                                is used (an identity map). This field is ignored for
-                                services with clusterIP=None, and should be omitted
-                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              description: |-
+                                Number or name of the port to access on the pods targeted by the service.
+                                Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named port in the
+                                target Pod's container ports. If this is not specified, the value
+                                of the 'port' field is used (an identity map).
+                                This field is ignored for services with clusterIP=None, and should be
+                                omitted or set equal to the 'port' field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                               x-kubernetes-int-or-string: true
                           required:
                           - port
@@ -9878,33 +8765,35 @@ spec:
                         - protocol
                         x-kubernetes-list-type: map
                       publishNotReadyAddresses:
-                        description: publishNotReadyAddresses indicates that any agent
-                          which deals with endpoints for this Service should disregard
-                          any indications of ready/not-ready. The primary use case
-                          for setting this field is for a StatefulSet's Headless Service
-                          to propagate SRV DNS records for its Pods for the purpose
-                          of peer discovery. The Kubernetes controllers that generate
-                          Endpoints and EndpointSlice resources for Services interpret
-                          this to mean that all endpoints are considered "ready" even
-                          if the Pods themselves are not. Agents which consume only
-                          Kubernetes generated endpoints through the Endpoints or
-                          EndpointSlice resources can safely assume this behavior.
+                        description: |-
+                          publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                          Service should disregard any indications of ready/not-ready.
+                          The primary use case for setting this field is for a StatefulSet's Headless Service to
+                          propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                          The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                          Services interpret this to mean that all endpoints are considered "ready" even if the
+                          Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                          through the Endpoints or EndpointSlice resources can safely assume this behavior.
                         type: boolean
                       selector:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys
-                          and values matching this selector. If empty or not present,
-                          the service is assumed to have an external process managing
-                          its endpoints, which Kubernetes will not modify. Only applies
-                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
-                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: |-
+                          Route service traffic to pods with label keys and values matching this
+                          selector. If empty or not present, the service is assumed to have an
+                          external process managing its endpoints, which Kubernetes will not
+                          modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                          Ignored if type is ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
                         type: object
                         x-kubernetes-map-type: atomic
                       sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain
-                          session affinity. Enable client IP based session affinity.
-                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: |-
+                          Supports "ClientIP" and "None". Used to maintain session affinity.
+                          Enable client IP based session affinity.
+                          Must be ClientIP or None.
+                          Defaults to None.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                         type: string
                       sessionAffinityConfig:
                         description: sessionAffinityConfig contains the configurations
@@ -9915,31 +8804,32 @@ spec:
                               IP based session affinity.
                             properties:
                               timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds
-                                  of ClientIP type session sticky time. The value
-                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                description: |-
+                                  timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                  The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                  Default value is 10800(for 3 hours).
                                 format: int32
                                 type: integer
                             type: object
                         type: object
                       type:
-                        description: 'type determines how the Service is exposed.
-                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
-                          NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal
-                          IP address for load-balancing to endpoints. Endpoints are
-                          determined by the selector or if that is not specified,
-                          by manual construction of an Endpoints object or EndpointSlice
-                          objects. If clusterIP is "None", no virtual IP is allocated
-                          and the endpoints are published as a set of endpoints rather
-                          than a virtual IP. "NodePort" builds on ClusterIP and allocates
-                          a port on every node which routes to the same endpoints
-                          as the clusterIP. "LoadBalancer" builds on NodePort and
-                          creates an external load-balancer (if supported in the current
-                          cloud) which routes to the same endpoints as the clusterIP.
+                        description: |-
+                          type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                          options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                          "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                          to endpoints. Endpoints are determined by the selector or if that is not
+                          specified, by manual construction of an Endpoints object or
+                          EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                          allocated and the endpoints are published as a set of endpoints rather
+                          than a virtual IP.
+                          "NodePort" builds on ClusterIP and allocates a port on every node which
+                          routes to the same endpoints as the clusterIP.
+                          "LoadBalancer" builds on NodePort and creates an external load-balancer
+                          (if supported in the current cloud) which routes to the same endpoints
+                          as the clusterIP.
                           "ExternalName" aliases this service to the specified externalName.
                           Several other fields do not apply to ExternalName services.
-                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                         type: string
                     type: object
                 type: object
@@ -9951,12 +8841,15 @@ spec:
                     type: boolean
                   imagePullSecrets:
                     items:
-                      description: LocalObjectReference contains enough information
-                        to let you locate the referenced object inside the same namespace.
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -9976,65 +8869,63 @@ spec:
                     type: object
                   secrets:
                     items:
-                      description: "ObjectReference contains enough information to
-                        let you inspect or modify the referred object. --- New uses
-                        of this type are discouraged because of difficulty describing
-                        its usage when embedded in APIs. 1. Ignored fields.  It includes
-                        many fields which are not generally honored.  For instance,
-                        ResourceVersion and FieldPath are both very rarely valid in
-                        actual usage. 2. Invalid usage help.  It is impossible to
-                        add specific help for individual usage.  In most embedded
-                        usages, there are particular restrictions like, \"must refer
-                        only to types A and B\" or \"UID not honored\" or \"name must
-                        be restricted\". Those cannot be well described when embedded.
-                        3. Inconsistent validation.  Because the usages are different,
-                        the validation rules are different by usage, which makes it
-                        hard for users to predict what will happen. 4. The fields
-                        are both imprecise and overly precise.  Kind is not a precise
-                        mapping to a URL. This can produce ambiguity during interpretation
-                        and require a REST mapping.  In most cases, the dependency
-                        is on the group,resource tuple and the version of the actual
-                        struct is irrelevant. 5. We cannot easily change it.  Because
-                        this type is embedded in many locations, updates to this type
-                        will affect numerous schemas.  Don't make new APIs embed an
-                        underspecified API type they do not control. \n Instead of
-                        using this type, create a locally provided and used type that
-                        is well-focused on your reference. For example, ServiceReferences
-                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                        ."
+                      description: |-
+                        ObjectReference contains enough information to let you inspect or modify the referred object.
+                        ---
+                        New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                         1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                         2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                            restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                            Those cannot be well described when embedded.
+                         3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                         4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                            during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                            and the version of the actual struct is irrelevant.
+                         5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                            will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                        Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                        For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
                       properties:
                         apiVersion:
                           description: API version of the referent.
                           type: string
                         fieldPath:
-                          description: 'If referring to a piece of an object instead
-                            of an entire object, this string should contain a valid
-                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                            For example, if the object reference is to a container
-                            within a pod, this would take on a value like: "spec.containers{name}"
-                            (where "name" refers to the name of the container that
-                            triggered the event) or if no container name is specified
-                            "spec.containers[2]" (container with index 2 in this pod).
-                            This syntax is chosen only to have some well-defined way
-                            of referencing a part of an object. TODO: this design
-                            is not final and this field is subject to change in the
-                            future.'
+                          description: |-
+                            If referring to a piece of an object instead of an entire object, this string
+                            should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within a pod, this would take on a value like:
+                            "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]" (container with
+                            index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                            referencing a part of an object.
+                            TODO: this design is not final and this field is subject to change in the future.
                           type: string
                         kind:
-                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          description: |-
+                            Kind of the referent.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
                         namespace:
-                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          description: |-
+                            Namespace of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                           type: string
                         resourceVersion:
-                          description: 'Specific resourceVersion to which this reference
-                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          description: |-
+                            Specific resourceVersion to which this reference is made, if any.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                           type: string
                         uid:
-                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          description: |-
+                            UID of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - grafana.integreatly.org_grafanadatasources.yaml
   - grafana.integreatly.org_grafanafolders.yaml
   - grafana.integreatly.org_grafanaalertrulegroups.yaml
+  - grafana.integreatly.org_grafanacontactpoints.yaml
 #+kubebuilder:scaffold:crdkustomizeresource

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -13,6 +13,8 @@ Resource Types:
 
 - [GrafanaAlertRuleGroup](#grafanaalertrulegroup)
 
+- [GrafanaContactPoint](#grafanacontactpoint)
+
 - [GrafanaDashboard](#grafanadashboard)
 
 - [GrafanaDatasource](#grafanadatasource)
@@ -137,7 +139,8 @@ GrafanaAlertRuleGroupSpec defines the desired state of GrafanaAlertRuleGroup
         <td><b>folderUID</b></td>
         <td>string</td>
         <td>
-          UID of the folder containing this rule group Overrides the FolderSelector<br/>
+          UID of the folder containing this rule group
+Overrides the FolderSelector<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -181,7 +184,9 @@ selects Grafanas for import
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -193,7 +198,8 @@ selects Grafanas for import
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -215,14 +221,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -359,7 +369,8 @@ AlertRule defines a specific rule to be evaluated. It is based on the upstream m
         <td><b>queryType</b></td>
         <td>string</td>
         <td>
-          QueryType is an optional identifier for the type of query. It can be used to distinguish different types of queries.<br/>
+          QueryType is an optional identifier for the type of query.
+It can be used to distinguish different types of queries.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -450,9 +461,23 @@ GrafanaAlertRuleGroupStatus defines the observed state of GrafanaAlertRuleGroup
 
 
 
-Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, 
- type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: "Available", "Progressing", and "Degraded" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` 
- // other fields }
+Condition contains details for one aspect of the current state of this API Resource.
+---
+This struct is intended for direct use as an array at the field path .status.conditions.  For example,
+
+
+	type FooStatus struct{
+	    // Represents the observations of a foo's current state.
+	    // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
+	    // +patchMergeKey=type
+	    // +patchStrategy=merge
+	    // +listType=map
+	    // +listMapKey=type
+	    Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+
+	    // other fields
+	}
 
 <table>
     <thead>
@@ -467,7 +492,8 @@ Condition contains details for one aspect of the current state of this API Resou
         <td><b>lastTransitionTime</b></td>
         <td>string</td>
         <td>
-          lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.<br/>
+          lastTransitionTime is the last time the condition transitioned from one status to another.
+This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.<br/>
           <br/>
             <i>Format</i>: date-time<br/>
         </td>
@@ -476,14 +502,19 @@ Condition contains details for one aspect of the current state of this API Resou
         <td><b>message</b></td>
         <td>string</td>
         <td>
-          message is a human readable message indicating details about the transition. This may be an empty string.<br/>
+          message is a human readable message indicating details about the transition.
+This may be an empty string.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>reason</b></td>
         <td>string</td>
         <td>
-          reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.<br/>
+          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+Producers of specific condition types may define expected values and meanings for this field,
+and whether the values are considered a guaranteed API.
+The value should be a CamelCase string.
+This field may not be empty.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -499,14 +530,354 @@ Condition contains details for one aspect of the current state of this API Resou
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)<br/>
+          type of condition in CamelCase or in foo.example.com/CamelCase.
+---
+Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+useful (see .node.status.conditions), the ability to deconflict is important.
+The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>observedGeneration</b></td>
         <td>integer</td>
         <td>
-          observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.<br/>
+          observedGeneration represents the .metadata.generation that the condition was set based upon.
+For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+with respect to the current state of the instance.<br/>
+          <br/>
+            <i>Format</i>: int64<br/>
+            <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+## GrafanaContactPoint
+<sup><sup>[↩ Parent](#grafanaintegreatlyorgv1beta1 )</sup></sup>
+
+
+
+
+
+
+GrafanaContactPoint is the Schema for the grafanacontactpoints API
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+      <td><b>apiVersion</b></td>
+      <td>string</td>
+      <td>grafana.integreatly.org/v1beta1</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b>kind</b></td>
+      <td>string</td>
+      <td>GrafanaContactPoint</td>
+      <td>true</td>
+      </tr>
+      <tr>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta">metadata</a></b></td>
+      <td>object</td>
+      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
+      <td>true</td>
+      </tr><tr>
+        <td><b><a href="#grafanacontactpointspec">spec</a></b></td>
+        <td>object</td>
+        <td>
+          GrafanaContactPointSpec defines the desired state of GrafanaContactPoint<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#grafanacontactpointstatus">status</a></b></td>
+        <td>object</td>
+        <td>
+          GrafanaContactPointStatus defines the observed state of GrafanaContactPoint<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### GrafanaContactPoint.spec
+<sup><sup>[↩ Parent](#grafanacontactpoint)</sup></sup>
+
+
+
+GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#grafanacontactpointspecinstanceselector">instanceSelector</a></b></td>
+        <td>object</td>
+        <td>
+          selects Grafanas for import<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>settings</b></td>
+        <td>JSON</td>
+        <td>
+          <br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>allowCrossNamespaceImport</b></td>
+        <td>boolean</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>disableResolveMessage</b></td>
+        <td>boolean</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>resyncPeriod</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Format</i>: duration<br/>
+            <i>Default</i>: 10m<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>enum</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Enum</i>: alertmanager, dingding, discord, email, googlechat, kafka, line, opsgenie, pagerduty, pushover, sensugo, slack, teams, telegram, threema, victorops, webhook, wecom<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### GrafanaContactPoint.spec.instanceSelector
+<sup><sup>[↩ Parent](#grafanacontactpointspec)</sup></sup>
+
+
+
+selects Grafanas for import
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#grafanacontactpointspecinstanceselectormatchexpressionsindex">matchExpressions</a></b></td>
+        <td>[]object</td>
+        <td>
+          matchExpressions is a list of label selector requirements. The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>matchLabels</b></td>
+        <td>map[string]string</td>
+        <td>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### GrafanaContactPoint.spec.instanceSelector.matchExpressions[index]
+<sup><sup>[↩ Parent](#grafanacontactpointspecinstanceselector)</sup></sup>
+
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          key is the label key that the selector applies to.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>operator</b></td>
+        <td>string</td>
+        <td>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>values</b></td>
+        <td>[]string</td>
+        <td>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### GrafanaContactPoint.status
+<sup><sup>[↩ Parent](#grafanacontactpoint)</sup></sup>
+
+
+
+GrafanaContactPointStatus defines the observed state of GrafanaContactPoint
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#grafanacontactpointstatusconditionsindex">conditions</a></b></td>
+        <td>[]object</td>
+        <td>
+          INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+Important: Run "make" to regenerate code after modifying this file<br/>
+        </td>
+        <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### GrafanaContactPoint.status.conditions[index]
+<sup><sup>[↩ Parent](#grafanacontactpointstatus)</sup></sup>
+
+
+
+Condition contains details for one aspect of the current state of this API Resource.
+---
+This struct is intended for direct use as an array at the field path .status.conditions.  For example,
+
+
+	type FooStatus struct{
+	    // Represents the observations of a foo's current state.
+	    // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
+	    // +patchMergeKey=type
+	    // +patchStrategy=merge
+	    // +listType=map
+	    // +listMapKey=type
+	    Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+
+	    // other fields
+	}
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>lastTransitionTime</b></td>
+        <td>string</td>
+        <td>
+          lastTransitionTime is the last time the condition transitioned from one status to another.
+This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.<br/>
+          <br/>
+            <i>Format</i>: date-time<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>message</b></td>
+        <td>string</td>
+        <td>
+          message is a human readable message indicating details about the transition.
+This may be an empty string.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>reason</b></td>
+        <td>string</td>
+        <td>
+          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+Producers of specific condition types may define expected values and meanings for this field,
+and whether the values are considered a guaranteed API.
+The value should be a CamelCase string.
+This field may not be empty.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>status</b></td>
+        <td>enum</td>
+        <td>
+          status of the condition, one of True, False, Unknown.<br/>
+          <br/>
+            <i>Enum</i>: True, False, Unknown<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>type</b></td>
+        <td>string</td>
+        <td>
+          type of condition in CamelCase or in foo.example.com/CamelCase.
+---
+Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+useful (see .node.status.conditions), the ability to deconflict is important.
+The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>observedGeneration</b></td>
+        <td>integer</td>
+        <td>
+          observedGeneration represents the .metadata.generation that the condition was set based upon.
+For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+with respect to the current state of the instance.<br/>
           <br/>
             <i>Format</i>: int64<br/>
             <i>Minimum</i>: 0<br/>
@@ -690,6 +1061,9 @@ GrafanaDashboardSpec defines the desired state of GrafanaDashboard
         <td>string</td>
         <td>
           how often the dashboard is refreshed, defaults to 5m if not set<br/>
+          <br/>
+            <i>Format</i>: duration<br/>
+            <i>Default</i>: 5m<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -730,7 +1104,9 @@ selects Grafanas for import
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -742,7 +1118,8 @@ selects Grafanas for import
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -764,14 +1141,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -805,7 +1186,9 @@ dashboard from configmap
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -914,7 +1297,9 @@ Selects a key of a ConfigMap.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -955,7 +1340,9 @@ Selects a key of a Secret.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1071,7 +1458,9 @@ Selects a key of a ConfigMap.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1112,7 +1501,9 @@ Selects a key of a Secret.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1414,6 +1805,9 @@ GrafanaDatasourceSpec defines the desired state of GrafanaDatasource
         <td>string</td>
         <td>
           how often the datasource is refreshed, defaults to 5m if not set<br/>
+          <br/>
+            <i>Format</i>: duration<br/>
+            <i>Default</i>: 5m<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1475,7 +1869,7 @@ GrafanaDatasourceSpec defines the desired state of GrafanaDatasource
         <td><b>editable</b></td>
         <td>boolean</td>
         <td>
-          Deprecated field. Please, remove it from your manifests<br/>
+          Deprecated field, it has no effect<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1503,7 +1897,7 @@ GrafanaDatasourceSpec defines the desired state of GrafanaDatasource
         <td><b>orgId</b></td>
         <td>integer</td>
         <td>
-          Deprecated field. Please, remove it from your manifests<br/>
+          Deprecated field, it has no effect<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -1574,7 +1968,9 @@ selects Grafana instances for import
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1586,7 +1982,8 @@ selects Grafana instances for import
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -1608,14 +2005,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1751,7 +2152,9 @@ Selects a key of a ConfigMap.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1792,7 +2195,9 @@ Selects a key of a Secret.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1958,6 +2363,9 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         <td>string</td>
         <td>
           how often the folder is synced, defaults to 5m if not set<br/>
+          <br/>
+            <i>Format</i>: duration<br/>
+            <i>Default</i>: 5m<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1998,7 +2406,9 @@ selects Grafanas for import
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2010,7 +2420,8 @@ selects Grafanas for import
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -2032,14 +2443,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2073,7 +2488,8 @@ GrafanaFolderStatus defines the observed state of GrafanaFolder
         <td><b>hash</b></td>
         <td>string</td>
         <td>
-          INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file<br/>
+          INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+Important: Run "make" to regenerate code after modifying this file<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2411,7 +2827,9 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
         <td><b><a href="#grafanaspecdeploymentspecselector">selector</a></b></td>
         <td>object</td>
         <td>
-          A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.<br/>
+          A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2437,7 +2855,9 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
 
 
 
-A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.
 
 <table>
     <thead>
@@ -2459,7 +2879,9 @@ A label selector is a label query over a set of resources. The result of matchLa
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2471,7 +2893,8 @@ A label selector is a label query over a set of resources. The result of matchLa
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -2493,14 +2916,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2527,7 +2954,11 @@ DeploymentStrategy describes how to replace existing pods with new ones.
         <td><b><a href="#grafanaspecdeploymentspecstrategyrollingupdate">rollingUpdate</a></b></td>
         <td>object</td>
         <td>
-          Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.<br/>
+          Rolling update config params. Present only if DeploymentStrategyType =
+RollingUpdate.
+---
+TODO: Update this to follow our convention for oneOf, whatever we decide it
+to be.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2546,7 +2977,11 @@ DeploymentStrategy describes how to replace existing pods with new ones.
 
 
 
-Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.
+Rolling update config params. Present only if DeploymentStrategyType =
+RollingUpdate.
+---
+TODO: Update this to follow our convention for oneOf, whatever we decide it
+to be.
 
 <table>
     <thead>
@@ -2561,14 +2996,33 @@ Rolling update config params. Present only if DeploymentStrategyType = RollingUp
         <td><b>maxSurge</b></td>
         <td>int or string</td>
         <td>
-          The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.<br/>
+          The maximum number of pods that can be scheduled above the desired number of
+pods.
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+This can not be 0 if MaxUnavailable is 0.
+Absolute number is calculated from percentage by rounding up.
+Defaults to 25%.
+Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+the rolling update starts, such that the total number of old and new pods do not exceed
+130% of desired pods. Once old pods have been killed,
+new ReplicaSet can be scaled up further, ensuring that total number of pods running
+at any time during the update is at most 130% of desired pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>maxUnavailable</b></td>
         <td>int or string</td>
         <td>
-          The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.<br/>
+          The maximum number of pods that can be unavailable during the update.
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding down.
+This can not be 0 if MaxSurge is 0.
+Defaults to 25%.
+Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+that the total number of pods available at all times during the update is at
+least 70% of desired pods.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2595,14 +3049,16 @@ Rolling update config params. Present only if DeploymentStrategyType = RollingUp
         <td><b><a href="#grafanaspecdeploymentspectemplatemetadata">metadata</a></b></td>
         <td>object</td>
         <td>
-          Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata<br/>
+          Standard object's metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status<br/>
+          Specification of the desired behavior of the pod.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2614,7 +3070,8 @@ Rolling update config params. Present only if DeploymentStrategyType = RollingUp
 
 
 
-Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+Standard object's metadata.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 
 <table>
     <thead>
@@ -2648,7 +3105,8 @@ Standard object's metadata. More info: https://git.k8s.io/community/contributors
 
 
 
-Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+Specification of the desired behavior of the pod.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 <table>
     <thead>
@@ -2693,7 +3151,9 @@ Specification of the desired behavior of the pod. More info: https://git.k8s.io/
         <td><b><a href="#grafanaspecdeploymentspectemplatespecdnsconfig">dnsConfig</a></b></td>
         <td>object</td>
         <td>
-          Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.<br/>
+          Specifies the DNS parameters of a pod.
+Parameters specified here will be merged to the generated DNS
+configuration based on DNSPolicy.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2707,7 +3167,9 @@ Specification of the desired behavior of the pod. More info: https://git.k8s.io/
         <td><b>enableServiceLinks</b></td>
         <td>boolean</td>
         <td>
-          EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.<br/>
+          EnableServiceLinks indicates whether information about services should be injected into pod's
+environment variables, matching the syntax of Docker links.
+Optional: Defaults to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2721,49 +3183,65 @@ Specification of the desired behavior of the pod. More info: https://git.k8s.io/
         <td><b><a href="#grafanaspecdeploymentspectemplatespechostaliasesindex">hostAliases</a></b></td>
         <td>[]object</td>
         <td>
-          HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.<br/>
+          HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+file if specified. This is only valid for non-hostNetwork pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostIPC</b></td>
         <td>boolean</td>
         <td>
-          Use the host's ipc namespace. Optional: Default to false.<br/>
+          Use the host's ipc namespace.
+Optional: Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostNetwork</b></td>
         <td>boolean</td>
         <td>
-          Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.<br/>
+          Host networking requested for this pod. Use the host's network namespace.
+If this option is set, the ports that will be used must be specified.
+Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostPID</b></td>
         <td>boolean</td>
         <td>
-          Use the host's pid namespace. Optional: Default to false.<br/>
+          Use the host's pid namespace.
+Optional: Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostUsers</b></td>
         <td>boolean</td>
         <td>
-          Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.<br/>
+          Use the host's user namespace.
+Optional: Default to true.
+If set to true or not present, the pod will be run in the host user namespace, useful
+for when the pod needs a feature only available to the host user namespace, such as
+loading a kernel module with CAP_SYS_MODULE.
+When set to false, a new userns is created for the pod. Setting false is useful for
+mitigating container breakout vulnerabilities even allowing users to run their
+containers as root without actually having root privileges on the host.
+This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>hostname</b></td>
         <td>string</td>
         <td>
-          Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.<br/>
+          Specifies the hostname of the Pod
+If not specified, the pod's hostname will be set to a system-defined value.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecimagepullsecretsindex">imagePullSecrets</a></b></td>
         <td>[]object</td>
         <td>
-          ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod<br/>
+          ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+If specified, these secrets will be passed to individual puller implementations for them to use.
+More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2777,44 +3255,87 @@ Specification of the desired behavior of the pod. More info: https://git.k8s.io/
         <td><b>nodeName</b></td>
         <td>string</td>
         <td>
-          NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.<br/>
+          NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+the scheduler simply schedules this pod onto that node, assuming that it fits resource
+requirements.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>nodeSelector</b></td>
         <td>map[string]string</td>
         <td>
-          NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/<br/>
+          NodeSelector is a selector which must be true for the pod to fit on a node.
+Selector which must match a node's labels for the pod to be scheduled on that node.
+More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecos">os</a></b></td>
         <td>object</td>
         <td>
-          Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. 
- If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions 
- If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup<br/>
+          Specifies the OS of the containers in the pod.
+Some pod and container fields are restricted if this is set.
+
+
+If the OS field is set to linux, the following fields must be unset:
+-securityContext.windowsOptions
+
+
+If the OS field is set to windows, following fields must be unset:
+- spec.hostPID
+- spec.hostIPC
+- spec.hostUsers
+- spec.securityContext.seLinuxOptions
+- spec.securityContext.seccompProfile
+- spec.securityContext.fsGroup
+- spec.securityContext.fsGroupChangePolicy
+- spec.securityContext.sysctls
+- spec.shareProcessNamespace
+- spec.securityContext.runAsUser
+- spec.securityContext.runAsGroup
+- spec.securityContext.supplementalGroups
+- spec.containers[*].securityContext.seLinuxOptions
+- spec.containers[*].securityContext.seccompProfile
+- spec.containers[*].securityContext.capabilities
+- spec.containers[*].securityContext.readOnlyRootFilesystem
+- spec.containers[*].securityContext.privileged
+- spec.containers[*].securityContext.allowPrivilegeEscalation
+- spec.containers[*].securityContext.procMount
+- spec.containers[*].securityContext.runAsUser
+- spec.containers[*].securityContext.runAsGroup<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>overhead</b></td>
         <td>map[string]int or string</td>
         <td>
-          Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md<br/>
+          Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>preemptionPolicy</b></td>
         <td>string</td>
         <td>
-          PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.<br/>
+          PreemptionPolicy is the Policy for preempting pods with lower priority.
+One of Never, PreemptLowerPriority.
+Defaults to PreemptLowerPriority if unset.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>priority</b></td>
         <td>integer</td>
         <td>
-          The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.<br/>
+          The priority value. Various system components use this field to find the
+priority of the pod. When Priority Admission Controller is enabled, it
+prevents users from setting this field. The admission controller populates
+this field from PriorityClassName.
+The higher the value, the higher the priority.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -2823,77 +3344,105 @@ Specification of the desired behavior of the pod. More info: https://git.k8s.io/
         <td><b>priorityClassName</b></td>
         <td>string</td>
         <td>
-          If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.<br/>
+          If specified, indicates the pod's priority. "system-node-critical" and
+"system-cluster-critical" are two special keywords which indicate the
+highest priorities with the former being the highest priority. Any other
+name must be defined by creating a PriorityClass object with that name.
+If not specified, the pod priority will be default or zero if there is no
+default.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecreadinessgatesindex">readinessGates</a></b></td>
         <td>[]object</td>
         <td>
-          If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates<br/>
+          If specified, all readiness gates will be evaluated for pod readiness.
+A pod is ready when all its containers are ready AND
+all conditions specified in the readiness gates have status equal to "True"
+More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>restartPolicy</b></td>
         <td>string</td>
         <td>
-          RestartPolicy describes how the container should be restarted. Only one of the following restart policies may be specified. If none of the following policies is specified, the default one is RestartPolicyAlways.<br/>
+          RestartPolicy describes how the container should be restarted.
+Only one of the following restart policies may be specified.
+If none of the following policies is specified, the default one
+is RestartPolicyAlways.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runtimeClassName</b></td>
         <td>string</td>
         <td>
-          RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class<br/>
+          RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+empty definition that uses the default runtime handler.
+More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>schedulerName</b></td>
         <td>string</td>
         <td>
-          If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.<br/>
+          If specified, the pod will be dispatched by specified scheduler.
+If not specified, the pod will be dispatched by default scheduler.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
-          SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.<br/>
+          SecurityContext holds pod-level security attributes and common container settings.
+Optional: Defaults to empty.  See type description for default values of each field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>serviceAccount</b></td>
         <td>string</td>
         <td>
-          DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.<br/>
+          DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+Deprecated: Use serviceAccountName instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>serviceAccountName</b></td>
         <td>string</td>
         <td>
-          ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/<br/>
+          ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>setHostnameAsFQDN</b></td>
         <td>boolean</td>
         <td>
-          If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.<br/>
+          If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+If a pod does not have FQDN, this has no effect.
+Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>shareProcessNamespace</b></td>
         <td>boolean</td>
         <td>
-          Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.<br/>
+          Share a single process namespace between all of the containers in a pod.
+When this is set containers will be able to view and signal processes from other containers
+in the same pod, and the first process in each container will not be assigned PID 1.
+HostPID and ShareProcessNamespace cannot both be set.
+Optional: Default to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subdomain</b></td>
         <td>string</td>
         <td>
-          If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.<br/>
+          If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+If not specified, the pod will not have a domainname at all.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2916,7 +3465,9 @@ Specification of the desired behavior of the pod. More info: https://git.k8s.io/
         <td><b><a href="#grafanaspecdeploymentspectemplatespectopologyspreadconstraintsindex">topologySpreadConstraints</a></b></td>
         <td>[]object</td>
         <td>
-          TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.<br/>
+          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+domains. Scheduler will schedule pods in a way which abides by the constraints.
+All topologySpreadConstraints are ANDed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2991,14 +3542,26 @@ Describes node affinity scheduling rules for the pod.
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitynodeaffinitypreferredduringschedulingignoredduringexecutionindex">preferredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.<br/>
+          The scheduler will prefer to schedule pods to nodes that satisfy
+the affinity expressions specified by this field, but it may choose
+a node that violates one or more of the expressions. The node that is
+most preferred is the one with the greatest sum of weights, i.e.
+for each node that meets all of the scheduling requirements (resource
+request, requiredDuringScheduling affinity expressions, etc.),
+compute a sum by iterating through the elements of this field and adding
+"weight" to the sum if the node matches the corresponding matchExpressions; the
+node(s) with the highest sum are the most preferred.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitynodeaffinityrequiredduringschedulingignoredduringexecution">requiredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>object</td>
         <td>
-          If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.<br/>
+          If the affinity requirements specified by this field are not met at
+scheduling time, the pod will not be scheduled onto the node.
+If the affinity requirements specified by this field cease to be met
+at some point during pod execution (e.g. due to an update), the system
+may or may not try to eventually evict the pod from its node.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3010,7 +3573,8 @@ Describes node affinity scheduling rules for the pod.
 
 
 
-An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+An empty preferred scheduling term matches all objects with implicit weight 0
+(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
 
 <table>
     <thead>
@@ -3080,7 +3644,8 @@ A node selector term, associated with the corresponding weight.
 
 
 
-A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A node selector requirement is a selector that contains values, a key, and an operator
+that relates the key and values.
 
 <table>
     <thead>
@@ -3102,14 +3667,19 @@ A node selector requirement is a selector that contains values, a key, and an op
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
+          Represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.<br/>
+          An array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. If the operator is Gt or Lt, the values
+array must have a single element, which will be interpreted as an integer.
+This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3121,7 +3691,8 @@ A node selector requirement is a selector that contains values, a key, and an op
 
 
 
-A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A node selector requirement is a selector that contains values, a key, and an operator
+that relates the key and values.
 
 <table>
     <thead>
@@ -3143,14 +3714,19 @@ A node selector requirement is a selector that contains values, a key, and an op
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
+          Represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.<br/>
+          An array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. If the operator is Gt or Lt, the values
+array must have a single element, which will be interpreted as an integer.
+This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3162,7 +3738,11 @@ A node selector requirement is a selector that contains values, a key, and an op
 
 
 
-If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+If the affinity requirements specified by this field are not met at
+scheduling time, the pod will not be scheduled onto the node.
+If the affinity requirements specified by this field cease to be met
+at some point during pod execution (e.g. due to an update), the system
+may or may not try to eventually evict the pod from its node.
 
 <table>
     <thead>
@@ -3189,7 +3769,9 @@ If the affinity requirements specified by this field are not met at scheduling t
 
 
 
-A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+A null or empty node selector term matches no objects. The requirements of
+them are ANDed.
+The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
 
 <table>
     <thead>
@@ -3223,7 +3805,8 @@ A null or empty node selector term matches no objects. The requirements of them 
 
 
 
-A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A node selector requirement is a selector that contains values, a key, and an operator
+that relates the key and values.
 
 <table>
     <thead>
@@ -3245,14 +3828,19 @@ A node selector requirement is a selector that contains values, a key, and an op
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
+          Represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.<br/>
+          An array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. If the operator is Gt or Lt, the values
+array must have a single element, which will be interpreted as an integer.
+This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3264,7 +3852,8 @@ A node selector requirement is a selector that contains values, a key, and an op
 
 
 
-A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A node selector requirement is a selector that contains values, a key, and an operator
+that relates the key and values.
 
 <table>
     <thead>
@@ -3286,14 +3875,19 @@ A node selector requirement is a selector that contains values, a key, and an op
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
+          Represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.<br/>
+          An array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. If the operator is Gt or Lt, the values
+array must have a single element, which will be interpreted as an integer.
+This array is replaced during a strategic merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3320,14 +3914,28 @@ Describes pod affinity scheduling rules (e.g. co-locate this pod in the same nod
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindex">preferredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.<br/>
+          The scheduler will prefer to schedule pods to nodes that satisfy
+the affinity expressions specified by this field, but it may choose
+a node that violates one or more of the expressions. The node that is
+most preferred is the one with the greatest sum of weights, i.e.
+for each node that meets all of the scheduling requirements (resource
+request, requiredDuringScheduling affinity expressions, etc.),
+compute a sum by iterating through the elements of this field and adding
+"weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+node(s) with the highest sum are the most preferred.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodaffinityrequiredduringschedulingignoredduringexecutionindex">requiredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.<br/>
+          If the affinity requirements specified by this field are not met at
+scheduling time, the pod will not be scheduled onto the node.
+If the affinity requirements specified by this field cease to be met
+at some point during pod execution (e.g. due to a pod label update), the
+system may or may not try to eventually evict the pod from its node.
+When there are multiple elements, the lists of nodes corresponding to each
+podAffinityTerm are intersected, i.e. all terms must be satisfied.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3361,7 +3969,8 @@ The weights of all of the matched WeightedPodAffinityTerm fields are added per-n
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          weight associated with matching the corresponding podAffinityTerm, in the range 1-100.<br/>
+          weight associated with matching the corresponding podAffinityTerm,
+in the range 1-100.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -3390,42 +3999,70 @@ Required. A pod affinity term, associated with the corresponding weight.
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.<br/>
+          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+the labelSelector in the specified namespaces, where co-located is defined as running on a node
+whose value of the label with key topologyKey matches that of any node on which any of the
+selected pods is running.
+Empty topologyKey is not allowed.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.<br/>
+          A label query over a set of resources, in this case pods.
+If it's null, this PodAffinityTerm matches with no Pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. Also, MatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
+          MatchLabelKeys is a set of pod label keys to select which pods will
+be taken into consideration. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+to select the group of existing pods which pods will be taken into consideration
+for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+pod labels will be ignored. The default value is empty.
+The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>mismatchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
+          MismatchLabelKeys is a set of pod label keys to select which pods will
+be taken into consideration. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+to select the group of existing pods which pods will be taken into consideration
+for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+pod labels will be ignored. The default value is empty.
+The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.<br/>
+          A label query over the set of namespaces that the term applies to.
+The term is applied to the union of the namespaces selected by this field
+and the ones listed in the namespaces field.
+null selector and null or empty namespaces list means "this pod's namespace".
+An empty selector ({}) matches all namespaces.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespaces</b></td>
         <td>[]string</td>
         <td>
-          namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
+          namespaces specifies a static list of namespace names that the term applies to.
+The term is applied to the union of the namespaces listed in this field
+and the ones selected by namespaceSelector.
+null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3437,7 +4074,8 @@ Required. A pod affinity term, associated with the corresponding weight.
 
 
 
-A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+A label query over a set of resources, in this case pods.
+If it's null, this PodAffinityTerm matches with no Pods.
 
 <table>
     <thead>
@@ -3459,7 +4097,9 @@ A label query over a set of resources, in this case pods. If it's null, this Pod
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3471,7 +4111,8 @@ A label query over a set of resources, in this case pods. If it's null, this Pod
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -3493,14 +4134,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3512,7 +4157,11 @@ A label selector requirement is a selector that contains values, a key, and an o
 
 
 
-A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+A label query over the set of namespaces that the term applies to.
+The term is applied to the union of the namespaces selected by this field
+and the ones listed in the namespaces field.
+null selector and null or empty namespaces list means "this pod's namespace".
+An empty selector ({}) matches all namespaces.
 
 <table>
     <thead>
@@ -3534,7 +4183,9 @@ A label query over the set of namespaces that the term applies to. The term is a
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3546,7 +4197,8 @@ A label query over the set of namespaces that the term applies to. The term is a
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -3568,14 +4220,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3587,7 +4243,12 @@ A label selector requirement is a selector that contains values, a key, and an o
 
 
 
-Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+Defines a set of pods (namely those matching the labelSelector
+relative to the given namespace(s)) that this pod should be
+co-located (affinity) or not co-located (anti-affinity) with,
+where co-located is defined as running on a node whose value of
+the label with key <topologyKey> matches that of any node on which
+a pod of the set of pods is running
 
 <table>
     <thead>
@@ -3602,42 +4263,70 @@ Defines a set of pods (namely those matching the labelSelector relative to the g
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.<br/>
+          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+the labelSelector in the specified namespaces, where co-located is defined as running on a node
+whose value of the label with key topologyKey matches that of any node on which any of the
+selected pods is running.
+Empty topologyKey is not allowed.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodaffinityrequiredduringschedulingignoredduringexecutionindexlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.<br/>
+          A label query over a set of resources, in this case pods.
+If it's null, this PodAffinityTerm matches with no Pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. Also, MatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
+          MatchLabelKeys is a set of pod label keys to select which pods will
+be taken into consideration. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+to select the group of existing pods which pods will be taken into consideration
+for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+pod labels will be ignored. The default value is empty.
+The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>mismatchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
+          MismatchLabelKeys is a set of pod label keys to select which pods will
+be taken into consideration. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+to select the group of existing pods which pods will be taken into consideration
+for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+pod labels will be ignored. The default value is empty.
+The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodaffinityrequiredduringschedulingignoredduringexecutionindexnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.<br/>
+          A label query over the set of namespaces that the term applies to.
+The term is applied to the union of the namespaces selected by this field
+and the ones listed in the namespaces field.
+null selector and null or empty namespaces list means "this pod's namespace".
+An empty selector ({}) matches all namespaces.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespaces</b></td>
         <td>[]string</td>
         <td>
-          namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
+          namespaces specifies a static list of namespace names that the term applies to.
+The term is applied to the union of the namespaces listed in this field
+and the ones selected by namespaceSelector.
+null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3649,7 +4338,8 @@ Defines a set of pods (namely those matching the labelSelector relative to the g
 
 
 
-A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+A label query over a set of resources, in this case pods.
+If it's null, this PodAffinityTerm matches with no Pods.
 
 <table>
     <thead>
@@ -3671,7 +4361,9 @@ A label query over a set of resources, in this case pods. If it's null, this Pod
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3683,7 +4375,8 @@ A label query over a set of resources, in this case pods. If it's null, this Pod
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -3705,14 +4398,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3724,7 +4421,11 @@ A label selector requirement is a selector that contains values, a key, and an o
 
 
 
-A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+A label query over the set of namespaces that the term applies to.
+The term is applied to the union of the namespaces selected by this field
+and the ones listed in the namespaces field.
+null selector and null or empty namespaces list means "this pod's namespace".
+An empty selector ({}) matches all namespaces.
 
 <table>
     <thead>
@@ -3746,7 +4447,9 @@ A label query over the set of namespaces that the term applies to. The term is a
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3758,7 +4461,8 @@ A label query over the set of namespaces that the term applies to. The term is a
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -3780,14 +4484,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3814,14 +4522,28 @@ Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindex">preferredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.<br/>
+          The scheduler will prefer to schedule pods to nodes that satisfy
+the anti-affinity expressions specified by this field, but it may choose
+a node that violates one or more of the expressions. The node that is
+most preferred is the one with the greatest sum of weights, i.e.
+for each node that meets all of the scheduling requirements (resource
+request, requiredDuringScheduling anti-affinity expressions, etc.),
+compute a sum by iterating through the elements of this field and adding
+"weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+node(s) with the highest sum are the most preferred.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodantiaffinityrequiredduringschedulingignoredduringexecutionindex">requiredDuringSchedulingIgnoredDuringExecution</a></b></td>
         <td>[]object</td>
         <td>
-          If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.<br/>
+          If the anti-affinity requirements specified by this field are not met at
+scheduling time, the pod will not be scheduled onto the node.
+If the anti-affinity requirements specified by this field cease to be met
+at some point during pod execution (e.g. due to a pod label update), the
+system may or may not try to eventually evict the pod from its node.
+When there are multiple elements, the lists of nodes corresponding to each
+podAffinityTerm are intersected, i.e. all terms must be satisfied.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3855,7 +4577,8 @@ The weights of all of the matched WeightedPodAffinityTerm fields are added per-n
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          weight associated with matching the corresponding podAffinityTerm, in the range 1-100.<br/>
+          weight associated with matching the corresponding podAffinityTerm,
+in the range 1-100.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -3884,42 +4607,70 @@ Required. A pod affinity term, associated with the corresponding weight.
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.<br/>
+          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+the labelSelector in the specified namespaces, where co-located is defined as running on a node
+whose value of the label with key topologyKey matches that of any node on which any of the
+selected pods is running.
+Empty topologyKey is not allowed.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.<br/>
+          A label query over a set of resources, in this case pods.
+If it's null, this PodAffinityTerm matches with no Pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. Also, MatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
+          MatchLabelKeys is a set of pod label keys to select which pods will
+be taken into consideration. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+to select the group of existing pods which pods will be taken into consideration
+for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+pod labels will be ignored. The default value is empty.
+The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>mismatchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
+          MismatchLabelKeys is a set of pod label keys to select which pods will
+be taken into consideration. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+to select the group of existing pods which pods will be taken into consideration
+for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+pod labels will be ignored. The default value is empty.
+The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodantiaffinitypreferredduringschedulingignoredduringexecutionindexpodaffinitytermnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.<br/>
+          A label query over the set of namespaces that the term applies to.
+The term is applied to the union of the namespaces selected by this field
+and the ones listed in the namespaces field.
+null selector and null or empty namespaces list means "this pod's namespace".
+An empty selector ({}) matches all namespaces.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespaces</b></td>
         <td>[]string</td>
         <td>
-          namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
+          namespaces specifies a static list of namespace names that the term applies to.
+The term is applied to the union of the namespaces listed in this field
+and the ones selected by namespaceSelector.
+null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3931,7 +4682,8 @@ Required. A pod affinity term, associated with the corresponding weight.
 
 
 
-A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+A label query over a set of resources, in this case pods.
+If it's null, this PodAffinityTerm matches with no Pods.
 
 <table>
     <thead>
@@ -3953,7 +4705,9 @@ A label query over a set of resources, in this case pods. If it's null, this Pod
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -3965,7 +4719,8 @@ A label query over a set of resources, in this case pods. If it's null, this Pod
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -3987,14 +4742,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4006,7 +4765,11 @@ A label selector requirement is a selector that contains values, a key, and an o
 
 
 
-A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+A label query over the set of namespaces that the term applies to.
+The term is applied to the union of the namespaces selected by this field
+and the ones listed in the namespaces field.
+null selector and null or empty namespaces list means "this pod's namespace".
+An empty selector ({}) matches all namespaces.
 
 <table>
     <thead>
@@ -4028,7 +4791,9 @@ A label query over the set of namespaces that the term applies to. The term is a
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4040,7 +4805,8 @@ A label query over the set of namespaces that the term applies to. The term is a
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -4062,14 +4828,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4081,7 +4851,12 @@ A label selector requirement is a selector that contains values, a key, and an o
 
 
 
-Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+Defines a set of pods (namely those matching the labelSelector
+relative to the given namespace(s)) that this pod should be
+co-located (affinity) or not co-located (anti-affinity) with,
+where co-located is defined as running on a node whose value of
+the label with key <topologyKey> matches that of any node on which
+a pod of the set of pods is running
 
 <table>
     <thead>
@@ -4096,42 +4871,70 @@ Defines a set of pods (namely those matching the labelSelector relative to the g
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.<br/>
+          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+the labelSelector in the specified namespaces, where co-located is defined as running on a node
+whose value of the label with key topologyKey matches that of any node on which any of the
+selected pods is running.
+Empty topologyKey is not allowed.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodantiaffinityrequiredduringschedulingignoredduringexecutionindexlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.<br/>
+          A label query over a set of resources, in this case pods.
+If it's null, this PodAffinityTerm matches with no Pods.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. Also, MatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
+          MatchLabelKeys is a set of pod label keys to select which pods will
+be taken into consideration. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+to select the group of existing pods which pods will be taken into consideration
+for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+pod labels will be ignored. The default value is empty.
+The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>mismatchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
+          MismatchLabelKeys is a set of pod label keys to select which pods will
+be taken into consideration. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+to select the group of existing pods which pods will be taken into consideration
+for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+pod labels will be ignored. The default value is empty.
+The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecaffinitypodantiaffinityrequiredduringschedulingignoredduringexecutionindexnamespaceselector">namespaceSelector</a></b></td>
         <td>object</td>
         <td>
-          A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.<br/>
+          A label query over the set of namespaces that the term applies to.
+The term is applied to the union of the namespaces selected by this field
+and the ones listed in the namespaces field.
+null selector and null or empty namespaces list means "this pod's namespace".
+An empty selector ({}) matches all namespaces.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespaces</b></td>
         <td>[]string</td>
         <td>
-          namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
+          namespaces specifies a static list of namespace names that the term applies to.
+The term is applied to the union of the namespaces listed in this field
+and the ones selected by namespaceSelector.
+null or empty namespaces list and null namespaceSelector means "this pod's namespace".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4143,7 +4946,8 @@ Defines a set of pods (namely those matching the labelSelector relative to the g
 
 
 
-A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+A label query over a set of resources, in this case pods.
+If it's null, this PodAffinityTerm matches with no Pods.
 
 <table>
     <thead>
@@ -4165,7 +4969,9 @@ A label query over a set of resources, in this case pods. If it's null, this Pod
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4177,7 +4983,8 @@ A label query over a set of resources, in this case pods. If it's null, this Pod
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -4199,14 +5006,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4218,7 +5029,11 @@ A label selector requirement is a selector that contains values, a key, and an o
 
 
 
-A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+A label query over the set of namespaces that the term applies to.
+The term is applied to the union of the namespaces selected by this field
+and the ones listed in the namespaces field.
+null selector and null or empty namespaces list means "this pod's namespace".
+An empty selector ({}) matches all namespaces.
 
 <table>
     <thead>
@@ -4240,7 +5055,9 @@ A label query over the set of namespaces that the term applies to. The term is a
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4252,7 +5069,8 @@ A label query over the set of namespaces that the term applies to. The term is a
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -4274,14 +5092,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4308,77 +5130,119 @@ A single application container that you want to run within a pod.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.<br/>
+          Name of the container specified as a DNS_LABEL.
+Each container in a pod must have a unique name (DNS_LABEL).
+Cannot be updated.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
+          Arguments to the entrypoint.
+The container image's CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
+          Entrypoint array. Not executed within a shell.
+The container image's ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexenvindex">env</a></b></td>
         <td>[]object</td>
         <td>
-          List of environment variables to set in the container. Cannot be updated.<br/>
+          List of environment variables to set in the container.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexenvfromindex">envFrom</a></b></td>
         <td>[]object</td>
         <td>
-          List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.<br/>
+          List of sources to populate environment variables in the container.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the container is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.<br/>
+          Container image name.
+More info: https://kubernetes.io/docs/concepts/containers/images
+This field is optional to allow higher level config management to default or override
+container images in workload controllers like Deployments and StatefulSets.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>imagePullPolicy</b></td>
         <td>string</td>
         <td>
-          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
+          Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexlifecycle">lifecycle</a></b></td>
         <td>object</td>
         <td>
-          Actions that the management system should take in response to container lifecycle events. Cannot be updated.<br/>
+          Actions that the management system should take in response to container lifecycle events.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexlivenessprobe">livenessProbe</a></b></td>
         <td>object</td>
         <td>
-          Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Periodic probe of container liveness.
+Container will be restarted if the probe fails.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexportsindex">ports</a></b></td>
         <td>[]object</td>
         <td>
-          List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.<br/>
+          List of ports to expose from the container. Not specifying a port here
+DOES NOT prevent that port from being exposed. Any port which is
+listening on the default "0.0.0.0" address inside a container will be
+accessible from the network.
+Modifying this array with strategic merge patch may corrupt the data.
+For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexreadinessprobe">readinessProbe</a></b></td>
         <td>object</td>
         <td>
-          Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Periodic probe of container service readiness.
+Container will be removed from service endpoints if the probe fails.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4392,63 +5256,108 @@ A single application container that you want to run within a pod.
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexresources">resources</a></b></td>
         <td>object</td>
         <td>
-          Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Compute Resources required by this container.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>restartPolicy</b></td>
         <td>string</td>
         <td>
-          RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is "Always". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.<br/>
+          RestartPolicy defines the restart behavior of individual containers in a pod.
+This field may only be set for init containers, and the only allowed value is "Always".
+For non-init containers or when this field is not specified,
+the restart behavior is defined by the Pod's restart policy and the container type.
+Setting the RestartPolicy as "Always" for the init container will have the following effect:
+this init container will be continually restarted on
+exit until all regular containers have terminated. Once all regular
+containers have completed, all init containers with restartPolicy "Always"
+will be shut down. This lifecycle differs from normal init containers and
+is often referred to as a "sidecar" container. Although this init
+container still starts in the init container sequence, it does not wait
+for the container to complete before proceeding to the next init
+container. Instead, the next init container starts immediately after this
+init container is started, or after any startupProbe has successfully
+completed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
-          SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br/>
+          SecurityContext defines the security options the container should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexstartupprobe">startupProbe</a></b></td>
         <td>object</td>
         <td>
-          StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          StartupProbe indicates that the Pod has successfully initialized.
+If specified, no other probes are executed until this completes successfully.
+If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+when it might take a long time to load data or warm a cache, than during steady-state operation.
+This cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdin</b></td>
         <td>boolean</td>
         <td>
-          Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.<br/>
+          Whether this container should allocate a buffer for stdin in the container runtime. If this
+is not set, reads from stdin in the container will always result in EOF.
+Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdinOnce</b></td>
         <td>boolean</td>
         <td>
-          Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false<br/>
+          Whether the container runtime should close the stdin channel after it has been opened by
+a single attach. When stdin is true the stdin stream will remain open across multiple attach
+sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+at which time stdin is closed and remains closed until the container is restarted. If this
+flag is false, a container processes that reads from stdin will never receive an EOF.
+Default is false<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePath</b></td>
         <td>string</td>
         <td>
-          Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.<br/>
+          Optional: Path at which the file to which the container's termination message
+will be written is mounted into the container's filesystem.
+Message written is intended to be brief final status, such as an assertion failure message.
+Will be truncated by the node if greater than 4096 bytes. The total message length across
+all containers will be limited to 12kb.
+Defaults to /dev/termination-log.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePolicy</b></td>
         <td>string</td>
         <td>
-          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.<br/>
+          Indicate how the termination message should be populated. File will use the contents of
+terminationMessagePath to populate the container status message on both success and failure.
+FallbackToLogsOnError will use the last chunk of container log output if the termination
+message file is empty and the container exited with an error.
+The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+Defaults to File.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tty</b></td>
         <td>boolean</td>
         <td>
-          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.<br/>
+          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4462,14 +5371,18 @@ A single application container that you want to run within a pod.
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexvolumemountsindex">volumeMounts</a></b></td>
         <td>[]object</td>
         <td>
-          Pod volumes to mount into the container's filesystem. Cannot be updated.<br/>
+          Pod volumes to mount into the container's filesystem.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>workingDir</b></td>
         <td>string</td>
         <td>
-          Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.<br/>
+          Container's working directory.
+If not specified, the container runtime's default will be used, which
+might be configured in the container image.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4503,7 +5416,15 @@ EnvVar represents an environment variable present in a Container.
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".<br/>
+          Variable references $(VAR_NAME) are expanded
+using the previously defined environment variables in the container and
+any service environment variables. If a variable cannot be resolved,
+the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+"$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+Escaped references will never be expanded, regardless of whether the variable
+exists or not.
+Defaults to "".<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4544,14 +5465,16 @@ Source for the environment variable's value. Cannot be used if value is not empt
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexenvindexvaluefromfieldref">fieldRef</a></b></td>
         <td>object</td>
         <td>
-          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
+          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexenvindexvaluefromresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
+          Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4592,7 +5515,9 @@ Selects a key of a ConfigMap.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4611,7 +5536,8 @@ Selects a key of a ConfigMap.
 
 
 
-Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
 
 <table>
     <thead>
@@ -4645,7 +5571,8 @@ Selects a field of the pod: supports metadata.name, metadata.namespace, `metadat
 
 
 
-Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
 
 <table>
     <thead>
@@ -4708,7 +5635,9 @@ Selects a key of a secret in the pod's namespace
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4783,7 +5712,9 @@ The ConfigMap to select from
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4817,7 +5748,9 @@ The Secret to select from
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4836,7 +5769,8 @@ The Secret to select from
 
 
 
-Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+Actions that the management system should take in response to container lifecycle events.
+Cannot be updated.
 
 <table>
     <thead>
@@ -4851,14 +5785,25 @@ Actions that the management system should take in response to container lifecycl
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexlifecyclepoststart">postStart</a></b></td>
         <td>object</td>
         <td>
-          PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
+          PostStart is called immediately after a container is created. If the handler fails,
+the container is terminated and restarted according to its restart policy.
+Other management of the container blocks until the hook completes.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexlifecycleprestop">preStop</a></b></td>
         <td>object</td>
         <td>
-          PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
+          PreStop is called immediately before a container is terminated due to an
+API request or management event such as liveness/startup probe failure,
+preemption, resource contention, etc. The handler is not called if the
+container crashes or exits. The Pod's termination grace period countdown begins before the
+PreStop hook is executed. Regardless of the outcome of the handler, the
+container will eventually terminate within the Pod's termination grace
+period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+or until the termination grace period is reached.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4870,7 +5815,10 @@ Actions that the management system should take in response to container lifecycl
 
 
 
-PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+PostStart is called immediately after a container is created. If the handler fails,
+the container is terminated and restarted according to its restart policy.
+Other management of the container blocks until the hook completes.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -4906,7 +5854,9 @@ PostStart is called immediately after a container is created. If the handler fai
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexlifecyclepoststarttcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4933,7 +5883,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4960,14 +5914,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4988,7 +5945,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5015,7 +5973,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5063,7 +6022,9 @@ Sleep represents the duration that the container should sleep before being termi
 
 
 
-Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -5078,7 +6039,9 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5097,7 +6060,15 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
 
 
 
-PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+PreStop is called immediately before a container is terminated due to an
+API request or management event such as liveness/startup probe failure,
+preemption, resource contention, etc. The handler is not called if the
+container crashes or exits. The Pod's termination grace period countdown begins before the
+PreStop hook is executed. Regardless of the outcome of the handler, the
+container will eventually terminate within the Pod's termination grace
+period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+or until the termination grace period is reached.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -5133,7 +6104,9 @@ PreStop is called immediately before a container is terminated due to an API req
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexlifecycleprestoptcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5160,7 +6133,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5187,14 +6164,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5215,7 +6195,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5242,7 +6223,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5290,7 +6272,9 @@ Sleep represents the duration that the container should sleep before being termi
 
 
 
-Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -5305,7 +6289,9 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5324,7 +6310,10 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
 
 
 
-Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+Periodic probe of container liveness.
+Container will be restarted if the probe fails.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -5346,7 +6335,8 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5369,7 +6359,8 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5378,7 +6369,8 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5387,7 +6379,8 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5403,7 +6396,16 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -5412,7 +6414,9 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5441,7 +6445,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5477,8 +6485,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5505,14 +6516,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5533,7 +6547,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5560,7 +6575,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5594,7 +6610,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5628,7 +6646,8 @@ ContainerPort represents a network port in a single container.
         <td><b>containerPort</b></td>
         <td>integer</td>
         <td>
-          Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.<br/>
+          Number of port to expose on the pod's IP address.
+This must be a valid port number, 0 < x < 65536.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5644,7 +6663,10 @@ ContainerPort represents a network port in a single container.
         <td><b>hostPort</b></td>
         <td>integer</td>
         <td>
-          Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.<br/>
+          Number of port to expose on the host.
+If specified, this must be a valid port number, 0 < x < 65536.
+If HostNetwork is specified, this must match ContainerPort.
+Most containers do not need this.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5653,14 +6675,17 @@ ContainerPort represents a network port in a single container.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.<br/>
+          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+named port in a pod must have a unique name. Name for the port that can be
+referred to by services.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>protocol</b></td>
         <td>string</td>
         <td>
-          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".<br/>
+          Protocol for port. Must be UDP, TCP, or SCTP.
+Defaults to "TCP".<br/>
           <br/>
             <i>Default</i>: TCP<br/>
         </td>
@@ -5674,7 +6699,10 @@ ContainerPort represents a network port in a single container.
 
 
 
-Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+Periodic probe of container service readiness.
+Container will be removed from service endpoints if the probe fails.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -5696,7 +6724,8 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5719,7 +6748,8 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5728,7 +6758,8 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5737,7 +6768,8 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5753,7 +6785,16 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -5762,7 +6803,9 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -5791,7 +6834,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5827,8 +6874,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5855,14 +6905,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5883,7 +6936,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5910,7 +6964,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5944,7 +6999,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5978,14 +7035,16 @@ ContainerResizePolicy represents resource resize policy for the container.
         <td><b>resourceName</b></td>
         <td>string</td>
         <td>
-          Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.<br/>
+          Name of the resource to which this resource resize policy applies.
+Supported values: cpu, memory.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>restartPolicy</b></td>
         <td>string</td>
         <td>
-          Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.<br/>
+          Restart policy to apply when specified resource is resized.
+If not specified, it defaults to NotRequired.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -5997,7 +7056,9 @@ ContainerResizePolicy represents resource resize policy for the container.
 
 
 
-Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+Compute Resources required by this container.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 <table>
     <thead>
@@ -6012,23 +7073,33 @@ Compute Resources required by this container. Cannot be updated. More info: http
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexresourcesclaimsindex">claims</a></b></td>
         <td>[]object</td>
         <td>
-          Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.<br/>
+          Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+
+This field is immutable. It can only be set for containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6055,7 +7126,9 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.<br/>
+          Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -6067,7 +7140,9 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
 
 
 
-SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+SecurityContext defines the security options the container should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 
 <table>
     <thead>
@@ -6082,42 +7157,63 @@ SecurityContext defines the security options the container should be run with. I
         <td><b>allowPrivilegeEscalation</b></td>
         <td>boolean</td>
         <td>
-          AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.<br/>
+          AllowPrivilegeEscalation controls whether a process can gain more
+privileges than its parent process. This bool directly controls if
+the no_new_privs flag will be set on the container process.
+AllowPrivilegeEscalation is true always when the container is:
+1) run as Privileged
+2) has CAP_SYS_ADMIN
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontextcapabilities">capabilities</a></b></td>
         <td>object</td>
         <td>
-          The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The capabilities to add/drop when running containers.
+Defaults to the default set of capabilities granted by the container runtime.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.<br/>
+          Run container in privileged mode.
+Processes in privileged containers are essentially equivalent to root on the host.
+Defaults to false.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>procMount</b></td>
         <td>string</td>
         <td>
-          procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.<br/>
+          procMount denotes the type of proc mount to use for the containers.
+The default is DefaultProcMount which uses the container runtime defaults for
+readonly paths and masked paths.
+This requires the ProcMountType feature flag to be enabled.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnlyRootFilesystem</b></td>
         <td>boolean</td>
         <td>
-          Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.<br/>
+          Whether this container has a read-only root filesystem.
+Default is false.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsGroup</b></td>
         <td>integer</td>
         <td>
-          The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The GID to run the entrypoint of the container process.
+Uses runtime default if unset.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -6126,14 +7222,23 @@ SecurityContext defines the security options the container should be run with. I
         <td><b>runAsNonRoot</b></td>
         <td>boolean</td>
         <td>
-          Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+          Indicates that the container must run as a non-root user.
+If true, the Kubelet will validate the image at runtime to ensure that it
+does not run as UID 0 (root) and fail to start the container if it does.
+If unset or false, no such validation will be performed.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUser</b></td>
         <td>integer</td>
         <td>
-          The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The UID to run the entrypoint of the container process.
+Defaults to user specified in image metadata if unspecified.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -6142,21 +7247,31 @@ SecurityContext defines the security options the container should be run with. I
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
         <td>object</td>
         <td>
-          The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The SELinux context to be applied to the container.
+If unspecified, the container runtime will allocate a random SELinux context for each
+container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontextseccompprofile">seccompProfile</a></b></td>
         <td>object</td>
         <td>
-          The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The seccomp options to use by this container. If seccomp options are
+provided at both the pod & container level, the container options
+override the pod options.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespeccontainersindexsecuritycontextwindowsoptions">windowsOptions</a></b></td>
         <td>object</td>
         <td>
-          The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.<br/>
+          The Windows specific settings applied to all containers.
+If unspecified, the options from the PodSecurityContext will be used.
+If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is linux.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6168,7 +7283,9 @@ SecurityContext defines the security options the container should be run with. I
 
 
 
-The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+The capabilities to add/drop when running containers.
+Defaults to the default set of capabilities granted by the container runtime.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -6202,7 +7319,11 @@ The capabilities to add/drop when running containers. Defaults to the default se
 
 
 
-The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+The SELinux context to be applied to the container.
+If unspecified, the container runtime will allocate a random SELinux context for each
+container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -6250,7 +7371,10 @@ The SELinux context to be applied to the container. If unspecified, the containe
 
 
 
-The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+The seccomp options to use by this container. If seccomp options are
+provided at both the pod & container level, the container options
+override the pod options.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -6265,15 +7389,23 @@ The seccomp options to use by this container. If seccomp options are provided at
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          type indicates which kind of seccomp profile will be applied. Valid options are: 
- Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.<br/>
+          type indicates which kind of seccomp profile will be applied.
+Valid options are:
+
+
+Localhost - a profile defined in a file on the node should be used.
+RuntimeDefault - the container runtime default profile should be used.
+Unconfined - no profile should be applied.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>localhostProfile</b></td>
         <td>string</td>
         <td>
-          localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is "Localhost". Must NOT be set for any other type.<br/>
+          localhostProfile indicates a profile defined in a file on the node should be used.
+The profile must be preconfigured on the node to work.
+Must be a descending path, relative to the kubelet's configured seccomp profile location.
+Must be set if type is "Localhost". Must NOT be set for any other type.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6285,7 +7417,10 @@ The seccomp options to use by this container. If seccomp options are provided at
 
 
 
-The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+The Windows specific settings applied to all containers.
+If unspecified, the options from the PodSecurityContext will be used.
+If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is linux.
 
 <table>
     <thead>
@@ -6300,7 +7435,9 @@ The Windows specific settings applied to all containers. If unspecified, the opt
         <td><b>gmsaCredentialSpec</b></td>
         <td>string</td>
         <td>
-          GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.<br/>
+          GMSACredentialSpec is where the GMSA admission webhook
+(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+GMSA credential spec named by the GMSACredentialSpecName field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6314,14 +7451,20 @@ The Windows specific settings applied to all containers. If unspecified, the opt
         <td><b>hostProcess</b></td>
         <td>boolean</td>
         <td>
-          HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
+          HostProcess determines if a container should be run as a 'Host Process' container.
+All of a Pod's containers must have the same effective HostProcess value
+(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUserName</b></td>
         <td>string</td>
         <td>
-          The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+          The UserName in Windows to run the entrypoint of the container process.
+Defaults to the user specified in image metadata if unspecified.
+May also be set in PodSecurityContext. If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6333,7 +7476,13 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+StartupProbe indicates that the Pod has successfully initialized.
+If specified, no other probes are executed until this completes successfully.
+If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+when it might take a long time to load data or warm a cache, than during steady-state operation.
+This cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -6355,7 +7504,8 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6378,7 +7528,8 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6387,7 +7538,8 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6396,7 +7548,8 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6412,7 +7565,16 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -6421,7 +7583,9 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -6450,7 +7614,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6486,8 +7654,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6514,14 +7685,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6542,7 +7716,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6569,7 +7744,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -6603,7 +7779,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -6671,7 +7849,8 @@ VolumeMount describes a mounting of a Volume within a container.
         <td><b>mountPath</b></td>
         <td>string</td>
         <td>
-          Path within the container at which the volume should be mounted.  Must not contain ':'.<br/>
+          Path within the container at which the volume should be mounted.  Must
+not contain ':'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -6685,28 +7864,36 @@ VolumeMount describes a mounting of a Volume within a container.
         <td><b>mountPropagation</b></td>
         <td>string</td>
         <td>
-          mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.<br/>
+          mountPropagation determines how mounts are propagated from the host
+to container and the other way around.
+When not set, MountPropagationNone is used.
+This field is beta in 1.10.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.<br/>
+          Mounted read-only if true, read-write otherwise (false or unspecified).
+Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPath</b></td>
         <td>string</td>
         <td>
-          Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).<br/>
+          Path within the volume from which the container's volume should be mounted.
+Defaults to "" (volume's root).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPathExpr</b></td>
         <td>string</td>
         <td>
-          Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.<br/>
+          Expanded path within the volume from which the container's volume should be mounted.
+Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+Defaults to "" (volume's root).
+SubPathExpr and SubPath are mutually exclusive.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6718,7 +7905,9 @@ VolumeMount describes a mounting of a Volume within a container.
 
 
 
-Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+Specifies the DNS parameters of a pod.
+Parameters specified here will be merged to the generated DNS
+configuration based on DNSPolicy.
 
 <table>
     <thead>
@@ -6733,21 +7922,28 @@ Specifies the DNS parameters of a pod. Parameters specified here will be merged 
         <td><b>nameservers</b></td>
         <td>[]string</td>
         <td>
-          A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.<br/>
+          A list of DNS name server IP addresses.
+This will be appended to the base nameservers generated from DNSPolicy.
+Duplicated nameservers will be removed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecdnsconfigoptionsindex">options</a></b></td>
         <td>[]object</td>
         <td>
-          A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.<br/>
+          A list of DNS resolver options.
+This will be merged with the base options generated from DNSPolicy.
+Duplicated entries will be removed. Resolution options given in Options
+will override those that appear in the base DNSPolicy.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>searches</b></td>
         <td>[]string</td>
         <td>
-          A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.<br/>
+          A list of DNS search domains for host-name lookup.
+This will be appended to the base search paths generated from DNSPolicy.
+Duplicated search paths will be removed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -6793,8 +7989,15 @@ PodDNSConfigOption defines DNS resolver options of a pod.
 
 
 
-An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. 
- To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+An EphemeralContainer is a temporary container that you may add to an existing Pod for
+user-initiated activities such as debugging. Ephemeral containers have no resource or
+scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+Pod to exceed its resource allocation.
+
+
+To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+Pod. Ephemeral containers may not be removed or restarted.
 
 <table>
     <thead>
@@ -6809,49 +8012,75 @@ An EphemeralContainer is a temporary container that you may add to an existing P
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.<br/>
+          Name of the ephemeral container specified as a DNS_LABEL.
+This name must be unique among all containers, init containers and ephemeral containers.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
+          Arguments to the entrypoint.
+The image's CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
+          Entrypoint array. Not executed within a shell.
+The image's ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindex">env</a></b></td>
         <td>[]object</td>
         <td>
-          List of environment variables to set in the container. Cannot be updated.<br/>
+          List of environment variables to set in the container.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvfromindex">envFrom</a></b></td>
         <td>[]object</td>
         <td>
-          List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.<br/>
+          List of sources to populate environment variables in the container.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the container is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          Container image name. More info: https://kubernetes.io/docs/concepts/containers/images<br/>
+          Container image name.
+More info: https://kubernetes.io/docs/concepts/containers/images<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>imagePullPolicy</b></td>
         <td>string</td>
         <td>
-          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
+          Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6893,21 +8122,26 @@ An EphemeralContainer is a temporary container that you may add to an existing P
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexresources">resources</a></b></td>
         <td>object</td>
         <td>
-          Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.<br/>
+          Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+already allocated to the pod.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>restartPolicy</b></td>
         <td>string</td>
         <td>
-          Restart policy for the container to manage the restart behavior of each container within a pod. This may only be set for init containers. You cannot set this field on ephemeral containers.<br/>
+          Restart policy for the container to manage the restart behavior of each
+container within a pod.
+This may only be set for init containers. You cannot set this field on
+ephemeral containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
-          Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br/>
+          Optional: SecurityContext defines the security options the ephemeral container should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6921,43 +8155,69 @@ An EphemeralContainer is a temporary container that you may add to an existing P
         <td><b>stdin</b></td>
         <td>boolean</td>
         <td>
-          Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.<br/>
+          Whether this container should allocate a buffer for stdin in the container runtime. If this
+is not set, reads from stdin in the container will always result in EOF.
+Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdinOnce</b></td>
         <td>boolean</td>
         <td>
-          Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false<br/>
+          Whether the container runtime should close the stdin channel after it has been opened by
+a single attach. When stdin is true the stdin stream will remain open across multiple attach
+sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+at which time stdin is closed and remains closed until the container is restarted. If this
+flag is false, a container processes that reads from stdin will never receive an EOF.
+Default is false<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>targetContainerName</b></td>
         <td>string</td>
         <td>
-          If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec. 
- The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.<br/>
+          If set, the name of the container from PodSpec that this ephemeral container targets.
+The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+The container runtime must implement support for this feature. If the runtime does not
+support namespace targeting then the result of setting this field is undefined.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePath</b></td>
         <td>string</td>
         <td>
-          Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.<br/>
+          Optional: Path at which the file to which the container's termination message
+will be written is mounted into the container's filesystem.
+Message written is intended to be brief final status, such as an assertion failure message.
+Will be truncated by the node if greater than 4096 bytes. The total message length across
+all containers will be limited to 12kb.
+Defaults to /dev/termination-log.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePolicy</b></td>
         <td>string</td>
         <td>
-          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.<br/>
+          Indicate how the termination message should be populated. File will use the contents of
+terminationMessagePath to populate the container status message on both success and failure.
+FallbackToLogsOnError will use the last chunk of container log output if the termination
+message file is empty and the container exited with an error.
+The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+Defaults to File.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tty</b></td>
         <td>boolean</td>
         <td>
-          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.<br/>
+          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6971,14 +8231,18 @@ An EphemeralContainer is a temporary container that you may add to an existing P
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexvolumemountsindex">volumeMounts</a></b></td>
         <td>[]object</td>
         <td>
-          Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.<br/>
+          Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>workingDir</b></td>
         <td>string</td>
         <td>
-          Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.<br/>
+          Container's working directory.
+If not specified, the container runtime's default will be used, which
+might be configured in the container image.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7012,7 +8276,15 @@ EnvVar represents an environment variable present in a Container.
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".<br/>
+          Variable references $(VAR_NAME) are expanded
+using the previously defined environment variables in the container and
+any service environment variables. If a variable cannot be resolved,
+the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+"$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+Escaped references will never be expanded, regardless of whether the variable
+exists or not.
+Defaults to "".<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7053,14 +8325,16 @@ Source for the environment variable's value. Cannot be used if value is not empt
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindexvaluefromfieldref">fieldRef</a></b></td>
         <td>object</td>
         <td>
-          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
+          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexenvindexvaluefromresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
+          Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7101,7 +8375,9 @@ Selects a key of a ConfigMap.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7120,7 +8396,8 @@ Selects a key of a ConfigMap.
 
 
 
-Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
 
 <table>
     <thead>
@@ -7154,7 +8431,8 @@ Selects a field of the pod: supports metadata.name, metadata.namespace, `metadat
 
 
 
-Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
 
 <table>
     <thead>
@@ -7217,7 +8495,9 @@ Selects a key of a secret in the pod's namespace
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7292,7 +8572,9 @@ The ConfigMap to select from
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7326,7 +8608,9 @@ The Secret to select from
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7360,14 +8644,25 @@ Lifecycle is not allowed for ephemeral containers.
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecyclepoststart">postStart</a></b></td>
         <td>object</td>
         <td>
-          PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
+          PostStart is called immediately after a container is created. If the handler fails,
+the container is terminated and restarted according to its restart policy.
+Other management of the container blocks until the hook completes.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecycleprestop">preStop</a></b></td>
         <td>object</td>
         <td>
-          PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
+          PreStop is called immediately before a container is terminated due to an
+API request or management event such as liveness/startup probe failure,
+preemption, resource contention, etc. The handler is not called if the
+container crashes or exits. The Pod's termination grace period countdown begins before the
+PreStop hook is executed. Regardless of the outcome of the handler, the
+container will eventually terminate within the Pod's termination grace
+period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+or until the termination grace period is reached.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7379,7 +8674,10 @@ Lifecycle is not allowed for ephemeral containers.
 
 
 
-PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+PostStart is called immediately after a container is created. If the handler fails,
+the container is terminated and restarted according to its restart policy.
+Other management of the container blocks until the hook completes.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -7415,7 +8713,9 @@ PostStart is called immediately after a container is created. If the handler fai
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecyclepoststarttcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7442,7 +8742,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7469,14 +8773,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7497,7 +8804,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7524,7 +8832,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -7572,7 +8881,9 @@ Sleep represents the duration that the container should sleep before being termi
 
 
 
-Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -7587,7 +8898,9 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -7606,7 +8919,15 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
 
 
 
-PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+PreStop is called immediately before a container is terminated due to an
+API request or management event such as liveness/startup probe failure,
+preemption, resource contention, etc. The handler is not called if the
+container crashes or exits. The Pod's termination grace period countdown begins before the
+PreStop hook is executed. Regardless of the outcome of the handler, the
+container will eventually terminate within the Pod's termination grace
+period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+or until the termination grace period is reached.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -7642,7 +8963,9 @@ PreStop is called immediately before a container is terminated due to an API req
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexlifecycleprestoptcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7669,7 +8992,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7696,14 +9023,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7724,7 +9054,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7751,7 +9082,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -7799,7 +9131,9 @@ Sleep represents the duration that the container should sleep before being termi
 
 
 
-Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -7814,7 +9148,9 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -7855,7 +9191,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7878,7 +9215,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7887,7 +9225,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7896,7 +9235,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7912,7 +9252,16 @@ Probes are not allowed for ephemeral containers.
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -7921,7 +9270,9 @@ Probes are not allowed for ephemeral containers.
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -7950,7 +9301,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7986,8 +9341,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8014,14 +9372,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8042,7 +9403,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8069,7 +9431,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -8103,7 +9466,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -8137,7 +9502,8 @@ ContainerPort represents a network port in a single container.
         <td><b>containerPort</b></td>
         <td>integer</td>
         <td>
-          Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.<br/>
+          Number of port to expose on the pod's IP address.
+This must be a valid port number, 0 < x < 65536.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8153,7 +9519,10 @@ ContainerPort represents a network port in a single container.
         <td><b>hostPort</b></td>
         <td>integer</td>
         <td>
-          Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.<br/>
+          Number of port to expose on the host.
+If specified, this must be a valid port number, 0 < x < 65536.
+If HostNetwork is specified, this must match ContainerPort.
+Most containers do not need this.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8162,14 +9531,17 @@ ContainerPort represents a network port in a single container.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.<br/>
+          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+named port in a pod must have a unique name. Name for the port that can be
+referred to by services.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>protocol</b></td>
         <td>string</td>
         <td>
-          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".<br/>
+          Protocol for port. Must be UDP, TCP, or SCTP.
+Defaults to "TCP".<br/>
           <br/>
             <i>Default</i>: TCP<br/>
         </td>
@@ -8205,7 +9577,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8228,7 +9601,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8237,7 +9611,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8246,7 +9621,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8262,7 +9638,16 @@ Probes are not allowed for ephemeral containers.
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -8271,7 +9656,9 @@ Probes are not allowed for ephemeral containers.
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8300,7 +9687,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8336,8 +9727,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8364,14 +9758,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8392,7 +9789,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8419,7 +9817,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -8453,7 +9852,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -8487,14 +9888,16 @@ ContainerResizePolicy represents resource resize policy for the container.
         <td><b>resourceName</b></td>
         <td>string</td>
         <td>
-          Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.<br/>
+          Name of the resource to which this resource resize policy applies.
+Supported values: cpu, memory.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>restartPolicy</b></td>
         <td>string</td>
         <td>
-          Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.<br/>
+          Restart policy to apply when specified resource is resized.
+If not specified, it defaults to NotRequired.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -8506,7 +9909,8 @@ ContainerResizePolicy represents resource resize policy for the container.
 
 
 
-Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+already allocated to the pod.
 
 <table>
     <thead>
@@ -8521,23 +9925,33 @@ Resources are not allowed for ephemeral containers. Ephemeral containers use spa
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexresourcesclaimsindex">claims</a></b></td>
         <td>[]object</td>
         <td>
-          Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.<br/>
+          Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+
+This field is immutable. It can only be set for containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8564,7 +9978,9 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.<br/>
+          Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -8576,7 +9992,8 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
 
 
 
-Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+Optional: SecurityContext defines the security options the ephemeral container should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 
 <table>
     <thead>
@@ -8591,42 +10008,63 @@ Optional: SecurityContext defines the security options the ephemeral container s
         <td><b>allowPrivilegeEscalation</b></td>
         <td>boolean</td>
         <td>
-          AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.<br/>
+          AllowPrivilegeEscalation controls whether a process can gain more
+privileges than its parent process. This bool directly controls if
+the no_new_privs flag will be set on the container process.
+AllowPrivilegeEscalation is true always when the container is:
+1) run as Privileged
+2) has CAP_SYS_ADMIN
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontextcapabilities">capabilities</a></b></td>
         <td>object</td>
         <td>
-          The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The capabilities to add/drop when running containers.
+Defaults to the default set of capabilities granted by the container runtime.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.<br/>
+          Run container in privileged mode.
+Processes in privileged containers are essentially equivalent to root on the host.
+Defaults to false.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>procMount</b></td>
         <td>string</td>
         <td>
-          procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.<br/>
+          procMount denotes the type of proc mount to use for the containers.
+The default is DefaultProcMount which uses the container runtime defaults for
+readonly paths and masked paths.
+This requires the ProcMountType feature flag to be enabled.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnlyRootFilesystem</b></td>
         <td>boolean</td>
         <td>
-          Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.<br/>
+          Whether this container has a read-only root filesystem.
+Default is false.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsGroup</b></td>
         <td>integer</td>
         <td>
-          The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The GID to run the entrypoint of the container process.
+Uses runtime default if unset.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -8635,14 +10073,23 @@ Optional: SecurityContext defines the security options the ephemeral container s
         <td><b>runAsNonRoot</b></td>
         <td>boolean</td>
         <td>
-          Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+          Indicates that the container must run as a non-root user.
+If true, the Kubelet will validate the image at runtime to ensure that it
+does not run as UID 0 (root) and fail to start the container if it does.
+If unset or false, no such validation will be performed.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUser</b></td>
         <td>integer</td>
         <td>
-          The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The UID to run the entrypoint of the container process.
+Defaults to user specified in image metadata if unspecified.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -8651,21 +10098,31 @@ Optional: SecurityContext defines the security options the ephemeral container s
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
         <td>object</td>
         <td>
-          The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The SELinux context to be applied to the container.
+If unspecified, the container runtime will allocate a random SELinux context for each
+container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontextseccompprofile">seccompProfile</a></b></td>
         <td>object</td>
         <td>
-          The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The seccomp options to use by this container. If seccomp options are
+provided at both the pod & container level, the container options
+override the pod options.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecephemeralcontainersindexsecuritycontextwindowsoptions">windowsOptions</a></b></td>
         <td>object</td>
         <td>
-          The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.<br/>
+          The Windows specific settings applied to all containers.
+If unspecified, the options from the PodSecurityContext will be used.
+If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is linux.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8677,7 +10134,9 @@ Optional: SecurityContext defines the security options the ephemeral container s
 
 
 
-The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+The capabilities to add/drop when running containers.
+Defaults to the default set of capabilities granted by the container runtime.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -8711,7 +10170,11 @@ The capabilities to add/drop when running containers. Defaults to the default se
 
 
 
-The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+The SELinux context to be applied to the container.
+If unspecified, the container runtime will allocate a random SELinux context for each
+container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -8759,7 +10222,10 @@ The SELinux context to be applied to the container. If unspecified, the containe
 
 
 
-The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+The seccomp options to use by this container. If seccomp options are
+provided at both the pod & container level, the container options
+override the pod options.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -8774,15 +10240,23 @@ The seccomp options to use by this container. If seccomp options are provided at
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          type indicates which kind of seccomp profile will be applied. Valid options are: 
- Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.<br/>
+          type indicates which kind of seccomp profile will be applied.
+Valid options are:
+
+
+Localhost - a profile defined in a file on the node should be used.
+RuntimeDefault - the container runtime default profile should be used.
+Unconfined - no profile should be applied.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>localhostProfile</b></td>
         <td>string</td>
         <td>
-          localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is "Localhost". Must NOT be set for any other type.<br/>
+          localhostProfile indicates a profile defined in a file on the node should be used.
+The profile must be preconfigured on the node to work.
+Must be a descending path, relative to the kubelet's configured seccomp profile location.
+Must be set if type is "Localhost". Must NOT be set for any other type.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8794,7 +10268,10 @@ The seccomp options to use by this container. If seccomp options are provided at
 
 
 
-The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+The Windows specific settings applied to all containers.
+If unspecified, the options from the PodSecurityContext will be used.
+If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is linux.
 
 <table>
     <thead>
@@ -8809,7 +10286,9 @@ The Windows specific settings applied to all containers. If unspecified, the opt
         <td><b>gmsaCredentialSpec</b></td>
         <td>string</td>
         <td>
-          GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.<br/>
+          GMSACredentialSpec is where the GMSA admission webhook
+(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+GMSA credential spec named by the GMSACredentialSpecName field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8823,14 +10302,20 @@ The Windows specific settings applied to all containers. If unspecified, the opt
         <td><b>hostProcess</b></td>
         <td>boolean</td>
         <td>
-          HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
+          HostProcess determines if a container should be run as a 'Host Process' container.
+All of a Pod's containers must have the same effective HostProcess value
+(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUserName</b></td>
         <td>string</td>
         <td>
-          The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+          The UserName in Windows to run the entrypoint of the container process.
+Defaults to the user specified in image metadata if unspecified.
+May also be set in PodSecurityContext. If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8864,7 +10349,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8887,7 +10373,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8896,7 +10383,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8905,7 +10393,8 @@ Probes are not allowed for ephemeral containers.
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8921,7 +10410,16 @@ Probes are not allowed for ephemeral containers.
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -8930,7 +10428,9 @@ Probes are not allowed for ephemeral containers.
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -8959,7 +10459,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -8995,8 +10499,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9023,14 +10530,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9051,7 +10561,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9078,7 +10589,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -9112,7 +10624,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -9180,7 +10694,8 @@ VolumeMount describes a mounting of a Volume within a container.
         <td><b>mountPath</b></td>
         <td>string</td>
         <td>
-          Path within the container at which the volume should be mounted.  Must not contain ':'.<br/>
+          Path within the container at which the volume should be mounted.  Must
+not contain ':'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -9194,28 +10709,36 @@ VolumeMount describes a mounting of a Volume within a container.
         <td><b>mountPropagation</b></td>
         <td>string</td>
         <td>
-          mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.<br/>
+          mountPropagation determines how mounts are propagated from the host
+to container and the other way around.
+When not set, MountPropagationNone is used.
+This field is beta in 1.10.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.<br/>
+          Mounted read-only if true, read-write otherwise (false or unspecified).
+Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPath</b></td>
         <td>string</td>
         <td>
-          Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).<br/>
+          Path within the volume from which the container's volume should be mounted.
+Defaults to "" (volume's root).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPathExpr</b></td>
         <td>string</td>
         <td>
-          Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.<br/>
+          Expanded path within the volume from which the container's volume should be mounted.
+Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+Defaults to "" (volume's root).
+SubPathExpr and SubPath are mutually exclusive.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9227,7 +10750,8 @@ VolumeMount describes a mounting of a Volume within a container.
 
 
 
-HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+pod's hosts file.
 
 <table>
     <thead>
@@ -9261,7 +10785,8 @@ HostAlias holds the mapping between IP and hostnames that will be injected as an
 
 
 
-LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+LocalObjectReference contains enough information to let you locate the
+referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -9276,7 +10801,9 @@ LocalObjectReference contains enough information to let you locate the reference
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9303,77 +10830,119 @@ A single application container that you want to run within a pod.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.<br/>
+          Name of the container specified as a DNS_LABEL.
+Each container in a pod must have a unique name (DNS_LABEL).
+Cannot be updated.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>args</b></td>
         <td>[]string</td>
         <td>
-          Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
+          Arguments to the entrypoint.
+The container image's CMD is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
+          Entrypoint array. Not executed within a shell.
+The container image's ENTRYPOINT is used if this is not provided.
+Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexenvindex">env</a></b></td>
         <td>[]object</td>
         <td>
-          List of environment variables to set in the container. Cannot be updated.<br/>
+          List of environment variables to set in the container.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexenvfromindex">envFrom</a></b></td>
         <td>[]object</td>
         <td>
-          List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.<br/>
+          List of sources to populate environment variables in the container.
+The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+will be reported as an event when the container is starting. When a key exists in multiple
+sources, the value associated with the last source will take precedence.
+Values defined by an Env with a duplicate key will take precedence.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.<br/>
+          Container image name.
+More info: https://kubernetes.io/docs/concepts/containers/images
+This field is optional to allow higher level config management to default or override
+container images in workload controllers like Deployments and StatefulSets.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>imagePullPolicy</b></td>
         <td>string</td>
         <td>
-          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
+          Image pull policy.
+One of Always, Never, IfNotPresent.
+Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/containers/images#updating-images<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycle">lifecycle</a></b></td>
         <td>object</td>
         <td>
-          Actions that the management system should take in response to container lifecycle events. Cannot be updated.<br/>
+          Actions that the management system should take in response to container lifecycle events.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexlivenessprobe">livenessProbe</a></b></td>
         <td>object</td>
         <td>
-          Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Periodic probe of container liveness.
+Container will be restarted if the probe fails.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexportsindex">ports</a></b></td>
         <td>[]object</td>
         <td>
-          List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.<br/>
+          List of ports to expose from the container. Not specifying a port here
+DOES NOT prevent that port from being exposed. Any port which is
+listening on the default "0.0.0.0" address inside a container will be
+accessible from the network.
+Modifying this array with strategic merge patch may corrupt the data.
+For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexreadinessprobe">readinessProbe</a></b></td>
         <td>object</td>
         <td>
-          Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Periodic probe of container service readiness.
+Container will be removed from service endpoints if the probe fails.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9387,63 +10956,108 @@ A single application container that you want to run within a pod.
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexresources">resources</a></b></td>
         <td>object</td>
         <td>
-          Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Compute Resources required by this container.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>restartPolicy</b></td>
         <td>string</td>
         <td>
-          RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is "Always". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.<br/>
+          RestartPolicy defines the restart behavior of individual containers in a pod.
+This field may only be set for init containers, and the only allowed value is "Always".
+For non-init containers or when this field is not specified,
+the restart behavior is defined by the Pod's restart policy and the container type.
+Setting the RestartPolicy as "Always" for the init container will have the following effect:
+this init container will be continually restarted on
+exit until all regular containers have terminated. Once all regular
+containers have completed, all init containers with restartPolicy "Always"
+will be shut down. This lifecycle differs from normal init containers and
+is often referred to as a "sidecar" container. Although this init
+container still starts in the init container sequence, it does not wait
+for the container to complete before proceeding to the next init
+container. Instead, the next init container starts immediately after this
+init container is started, or after any startupProbe has successfully
+completed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
-          SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br/>
+          SecurityContext defines the security options the container should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexstartupprobe">startupProbe</a></b></td>
         <td>object</td>
         <td>
-          StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          StartupProbe indicates that the Pod has successfully initialized.
+If specified, no other probes are executed until this completes successfully.
+If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+when it might take a long time to load data or warm a cache, than during steady-state operation.
+This cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdin</b></td>
         <td>boolean</td>
         <td>
-          Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.<br/>
+          Whether this container should allocate a buffer for stdin in the container runtime. If this
+is not set, reads from stdin in the container will always result in EOF.
+Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>stdinOnce</b></td>
         <td>boolean</td>
         <td>
-          Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false<br/>
+          Whether the container runtime should close the stdin channel after it has been opened by
+a single attach. When stdin is true the stdin stream will remain open across multiple attach
+sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+at which time stdin is closed and remains closed until the container is restarted. If this
+flag is false, a container processes that reads from stdin will never receive an EOF.
+Default is false<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePath</b></td>
         <td>string</td>
         <td>
-          Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.<br/>
+          Optional: Path at which the file to which the container's termination message
+will be written is mounted into the container's filesystem.
+Message written is intended to be brief final status, such as an assertion failure message.
+Will be truncated by the node if greater than 4096 bytes. The total message length across
+all containers will be limited to 12kb.
+Defaults to /dev/termination-log.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>terminationMessagePolicy</b></td>
         <td>string</td>
         <td>
-          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.<br/>
+          Indicate how the termination message should be populated. File will use the contents of
+terminationMessagePath to populate the container status message on both success and failure.
+FallbackToLogsOnError will use the last chunk of container log output if the termination
+message file is empty and the container exited with an error.
+The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+Defaults to File.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tty</b></td>
         <td>boolean</td>
         <td>
-          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.<br/>
+          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+Default is false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9457,14 +11071,18 @@ A single application container that you want to run within a pod.
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexvolumemountsindex">volumeMounts</a></b></td>
         <td>[]object</td>
         <td>
-          Pod volumes to mount into the container's filesystem. Cannot be updated.<br/>
+          Pod volumes to mount into the container's filesystem.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>workingDir</b></td>
         <td>string</td>
         <td>
-          Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.<br/>
+          Container's working directory.
+If not specified, the container runtime's default will be used, which
+might be configured in the container image.
+Cannot be updated.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9498,7 +11116,15 @@ EnvVar represents an environment variable present in a Container.
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".<br/>
+          Variable references $(VAR_NAME) are expanded
+using the previously defined environment variables in the container and
+any service environment variables. If a variable cannot be resolved,
+the reference in the input string will be unchanged. Double $$ are reduced
+to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+"$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+Escaped references will never be expanded, regardless of whether the variable
+exists or not.
+Defaults to "".<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9539,14 +11165,16 @@ Source for the environment variable's value. Cannot be used if value is not empt
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexenvindexvaluefromfieldref">fieldRef</a></b></td>
         <td>object</td>
         <td>
-          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
+          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexenvindexvaluefromresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
+          Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9587,7 +11215,9 @@ Selects a key of a ConfigMap.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9606,7 +11236,8 @@ Selects a key of a ConfigMap.
 
 
 
-Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
 
 <table>
     <thead>
@@ -9640,7 +11271,8 @@ Selects a field of the pod: supports metadata.name, metadata.namespace, `metadat
 
 
 
-Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
 
 <table>
     <thead>
@@ -9703,7 +11335,9 @@ Selects a key of a secret in the pod's namespace
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9778,7 +11412,9 @@ The ConfigMap to select from
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9812,7 +11448,9 @@ The Secret to select from
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9831,7 +11469,8 @@ The Secret to select from
 
 
 
-Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+Actions that the management system should take in response to container lifecycle events.
+Cannot be updated.
 
 <table>
     <thead>
@@ -9846,14 +11485,25 @@ Actions that the management system should take in response to container lifecycl
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexlifecyclepoststart">postStart</a></b></td>
         <td>object</td>
         <td>
-          PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
+          PostStart is called immediately after a container is created. If the handler fails,
+the container is terminated and restarted according to its restart policy.
+Other management of the container blocks until the hook completes.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycleprestop">preStop</a></b></td>
         <td>object</td>
         <td>
-          PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
+          PreStop is called immediately before a container is terminated due to an
+API request or management event such as liveness/startup probe failure,
+preemption, resource contention, etc. The handler is not called if the
+container crashes or exits. The Pod's termination grace period countdown begins before the
+PreStop hook is executed. Regardless of the outcome of the handler, the
+container will eventually terminate within the Pod's termination grace
+period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+or until the termination grace period is reached.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9865,7 +11515,10 @@ Actions that the management system should take in response to container lifecycl
 
 
 
-PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+PostStart is called immediately after a container is created. If the handler fails,
+the container is terminated and restarted according to its restart policy.
+Other management of the container blocks until the hook completes.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -9901,7 +11554,9 @@ PostStart is called immediately after a container is created. If the handler fai
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexlifecyclepoststarttcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9928,7 +11583,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9955,14 +11614,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9983,7 +11645,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10010,7 +11673,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10058,7 +11722,9 @@ Sleep represents the duration that the container should sleep before being termi
 
 
 
-Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -10073,7 +11739,9 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10092,7 +11760,15 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
 
 
 
-PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+PreStop is called immediately before a container is terminated due to an
+API request or management event such as liveness/startup probe failure,
+preemption, resource contention, etc. The handler is not called if the
+container crashes or exits. The Pod's termination grace period countdown begins before the
+PreStop hook is executed. Regardless of the outcome of the handler, the
+container will eventually terminate within the Pod's termination grace
+period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+or until the termination grace period is reached.
+More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
 
 <table>
     <thead>
@@ -10128,7 +11804,9 @@ PreStop is called immediately before a container is terminated due to an API req
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexlifecycleprestoptcpsocket">tcpSocket</a></b></td>
         <td>object</td>
         <td>
-          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
+          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10155,7 +11833,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10182,14 +11864,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10210,7 +11895,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10237,7 +11923,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10285,7 +11972,9 @@ Sleep represents the duration that the container should sleep before being termi
 
 
 
-Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
+Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+for the backward compatibility. There are no validation of this field and
+lifecycle hooks will fail in runtime when tcp handler is specified.
 
 <table>
     <thead>
@@ -10300,7 +11989,9 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10319,7 +12010,10 @@ Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the ba
 
 
 
-Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+Periodic probe of container liveness.
+Container will be restarted if the probe fails.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -10341,7 +12035,8 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10364,7 +12059,8 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10373,7 +12069,8 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10382,7 +12079,8 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10398,7 +12096,16 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -10407,7 +12114,9 @@ Periodic probe of container liveness. Container will be restarted if the probe f
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10436,7 +12145,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10472,8 +12185,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10500,14 +12216,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10528,7 +12247,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10555,7 +12275,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10589,7 +12310,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10623,7 +12346,8 @@ ContainerPort represents a network port in a single container.
         <td><b>containerPort</b></td>
         <td>integer</td>
         <td>
-          Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.<br/>
+          Number of port to expose on the pod's IP address.
+This must be a valid port number, 0 < x < 65536.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10639,7 +12363,10 @@ ContainerPort represents a network port in a single container.
         <td><b>hostPort</b></td>
         <td>integer</td>
         <td>
-          Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.<br/>
+          Number of port to expose on the host.
+If specified, this must be a valid port number, 0 < x < 65536.
+If HostNetwork is specified, this must match ContainerPort.
+Most containers do not need this.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10648,14 +12375,17 @@ ContainerPort represents a network port in a single container.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.<br/>
+          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+named port in a pod must have a unique name. Name for the port that can be
+referred to by services.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>protocol</b></td>
         <td>string</td>
         <td>
-          Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".<br/>
+          Protocol for port. Must be UDP, TCP, or SCTP.
+Defaults to "TCP".<br/>
           <br/>
             <i>Default</i>: TCP<br/>
         </td>
@@ -10669,7 +12399,10 @@ ContainerPort represents a network port in a single container.
 
 
 
-Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+Periodic probe of container service readiness.
+Container will be removed from service endpoints if the probe fails.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -10691,7 +12424,8 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10714,7 +12448,8 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10723,7 +12458,8 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10732,7 +12468,8 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10748,7 +12485,16 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -10757,7 +12503,9 @@ Periodic probe of container service readiness. Container will be removed from se
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -10786,7 +12534,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10822,8 +12574,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10850,14 +12605,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -10878,7 +12636,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10905,7 +12664,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10939,7 +12699,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10973,14 +12735,16 @@ ContainerResizePolicy represents resource resize policy for the container.
         <td><b>resourceName</b></td>
         <td>string</td>
         <td>
-          Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.<br/>
+          Name of the resource to which this resource resize policy applies.
+Supported values: cpu, memory.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>restartPolicy</b></td>
         <td>string</td>
         <td>
-          Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.<br/>
+          Restart policy to apply when specified resource is resized.
+If not specified, it defaults to NotRequired.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -10992,7 +12756,9 @@ ContainerResizePolicy represents resource resize policy for the container.
 
 
 
-Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+Compute Resources required by this container.
+Cannot be updated.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 <table>
     <thead>
@@ -11007,23 +12773,33 @@ Compute Resources required by this container. Cannot be updated. More info: http
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexresourcesclaimsindex">claims</a></b></td>
         <td>[]object</td>
         <td>
-          Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.<br/>
+          Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+
+This field is immutable. It can only be set for containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11050,7 +12826,9 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.<br/>
+          Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -11062,7 +12840,9 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
 
 
 
-SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+SecurityContext defines the security options the container should be run with.
+If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 
 <table>
     <thead>
@@ -11077,42 +12857,63 @@ SecurityContext defines the security options the container should be run with. I
         <td><b>allowPrivilegeEscalation</b></td>
         <td>boolean</td>
         <td>
-          AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.<br/>
+          AllowPrivilegeEscalation controls whether a process can gain more
+privileges than its parent process. This bool directly controls if
+the no_new_privs flag will be set on the container process.
+AllowPrivilegeEscalation is true always when the container is:
+1) run as Privileged
+2) has CAP_SYS_ADMIN
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontextcapabilities">capabilities</a></b></td>
         <td>object</td>
         <td>
-          The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The capabilities to add/drop when running containers.
+Defaults to the default set of capabilities granted by the container runtime.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.<br/>
+          Run container in privileged mode.
+Processes in privileged containers are essentially equivalent to root on the host.
+Defaults to false.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>procMount</b></td>
         <td>string</td>
         <td>
-          procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.<br/>
+          procMount denotes the type of proc mount to use for the containers.
+The default is DefaultProcMount which uses the container runtime defaults for
+readonly paths and masked paths.
+This requires the ProcMountType feature flag to be enabled.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnlyRootFilesystem</b></td>
         <td>boolean</td>
         <td>
-          Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.<br/>
+          Whether this container has a read-only root filesystem.
+Default is false.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsGroup</b></td>
         <td>integer</td>
         <td>
-          The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The GID to run the entrypoint of the container process.
+Uses runtime default if unset.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -11121,14 +12922,23 @@ SecurityContext defines the security options the container should be run with. I
         <td><b>runAsNonRoot</b></td>
         <td>boolean</td>
         <td>
-          Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+          Indicates that the container must run as a non-root user.
+If true, the Kubelet will validate the image at runtime to ensure that it
+does not run as UID 0 (root) and fail to start the container if it does.
+If unset or false, no such validation will be performed.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUser</b></td>
         <td>integer</td>
         <td>
-          The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The UID to run the entrypoint of the container process.
+Defaults to user specified in image metadata if unspecified.
+May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -11137,21 +12947,31 @@ SecurityContext defines the security options the container should be run with. I
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
         <td>object</td>
         <td>
-          The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The SELinux context to be applied to the container.
+If unspecified, the container runtime will allocate a random SELinux context for each
+container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontextseccompprofile">seccompProfile</a></b></td>
         <td>object</td>
         <td>
-          The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The seccomp options to use by this container. If seccomp options are
+provided at both the pod & container level, the container options
+override the pod options.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecinitcontainersindexsecuritycontextwindowsoptions">windowsOptions</a></b></td>
         <td>object</td>
         <td>
-          The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.<br/>
+          The Windows specific settings applied to all containers.
+If unspecified, the options from the PodSecurityContext will be used.
+If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is linux.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11163,7 +12983,9 @@ SecurityContext defines the security options the container should be run with. I
 
 
 
-The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+The capabilities to add/drop when running containers.
+Defaults to the default set of capabilities granted by the container runtime.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -11197,7 +13019,11 @@ The capabilities to add/drop when running containers. Defaults to the default se
 
 
 
-The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+The SELinux context to be applied to the container.
+If unspecified, the container runtime will allocate a random SELinux context for each
+container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -11245,7 +13071,10 @@ The SELinux context to be applied to the container. If unspecified, the containe
 
 
 
-The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+The seccomp options to use by this container. If seccomp options are
+provided at both the pod & container level, the container options
+override the pod options.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -11260,15 +13089,23 @@ The seccomp options to use by this container. If seccomp options are provided at
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          type indicates which kind of seccomp profile will be applied. Valid options are: 
- Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.<br/>
+          type indicates which kind of seccomp profile will be applied.
+Valid options are:
+
+
+Localhost - a profile defined in a file on the node should be used.
+RuntimeDefault - the container runtime default profile should be used.
+Unconfined - no profile should be applied.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>localhostProfile</b></td>
         <td>string</td>
         <td>
-          localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is "Localhost". Must NOT be set for any other type.<br/>
+          localhostProfile indicates a profile defined in a file on the node should be used.
+The profile must be preconfigured on the node to work.
+Must be a descending path, relative to the kubelet's configured seccomp profile location.
+Must be set if type is "Localhost". Must NOT be set for any other type.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11280,7 +13117,10 @@ The seccomp options to use by this container. If seccomp options are provided at
 
 
 
-The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+The Windows specific settings applied to all containers.
+If unspecified, the options from the PodSecurityContext will be used.
+If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is linux.
 
 <table>
     <thead>
@@ -11295,7 +13135,9 @@ The Windows specific settings applied to all containers. If unspecified, the opt
         <td><b>gmsaCredentialSpec</b></td>
         <td>string</td>
         <td>
-          GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.<br/>
+          GMSACredentialSpec is where the GMSA admission webhook
+(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+GMSA credential spec named by the GMSACredentialSpecName field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -11309,14 +13151,20 @@ The Windows specific settings applied to all containers. If unspecified, the opt
         <td><b>hostProcess</b></td>
         <td>boolean</td>
         <td>
-          HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
+          HostProcess determines if a container should be run as a 'Host Process' container.
+All of a Pod's containers must have the same effective HostProcess value
+(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUserName</b></td>
         <td>string</td>
         <td>
-          The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+          The UserName in Windows to run the entrypoint of the container process.
+Defaults to the user specified in image metadata if unspecified.
+May also be set in PodSecurityContext. If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11328,7 +13176,13 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+StartupProbe indicates that the Pod has successfully initialized.
+If specified, no other probes are executed until this completes successfully.
+If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+when it might take a long time to load data or warm a cache, than during steady-state operation.
+This cannot be updated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 
 <table>
     <thead>
@@ -11350,7 +13204,8 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>failureThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.<br/>
+          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+Defaults to 3. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11373,7 +13228,8 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>initialDelaySeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after the container has started before liveness probes are initiated.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11382,7 +13238,8 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>periodSeconds</b></td>
         <td>integer</td>
         <td>
-          How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.<br/>
+          How often (in seconds) to perform the probe.
+Default to 10 seconds. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11391,7 +13248,8 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>successThreshold</b></td>
         <td>integer</td>
         <td>
-          Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
+          Minimum consecutive successes for the probe to be considered successful after having failed.
+Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11407,7 +13265,16 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>terminationGracePeriodSeconds</b></td>
         <td>integer</td>
         <td>
-          Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
+          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+value overrides the value provided by the pod spec.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -11416,7 +13283,9 @@ StartupProbe indicates that the Pod has successfully initialized. If specified, 
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
+          Number of seconds after which the probe times out.
+Defaults to 1 second. Minimum value is 1.
+More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -11445,7 +13314,11 @@ Exec specifies the action to take.
         <td><b>command</b></td>
         <td>[]string</td>
         <td>
-          Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
+          Command is the command line to execute inside the container, the working directory for the
+command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+a shell, you need to explicitly call out to that shell.
+Exit status of 0 is treated as live/healthy and non-zero is unhealthy.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11481,8 +13354,11 @@ GRPC specifies an action involving a GRPC port.
         <td><b>service</b></td>
         <td>string</td>
         <td>
-          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
- If this is not specified, the default behavior is defined by gRPC.<br/>
+          Service is the name of the service to place in the gRPC HealthCheckRequest
+(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+If this is not specified, the default behavior is defined by gRPC.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11509,14 +13385,17 @@ HTTPGet specifies the http request to perform.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Name or number of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.<br/>
+          Host name to connect to, defaults to the pod IP. You probably want to set
+"Host" in httpHeaders instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -11537,7 +13416,8 @@ HTTPGet specifies the http request to perform.
         <td><b>scheme</b></td>
         <td>string</td>
         <td>
-          Scheme to use for connecting to the host. Defaults to HTTP.<br/>
+          Scheme to use for connecting to the host.
+Defaults to HTTP.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11564,7 +13444,8 @@ HTTPHeader describes a custom header to be used in HTTP probes
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
+          The header field name.
+This will be canonicalized upon output, so case-variant names will be understood as the same header.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -11598,7 +13479,9 @@ TCPSocket specifies an action involving a TCP port.
         <td><b>port</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.<br/>
+          Number or name of the port to access on the container.
+Number must be in the range 1 to 65535.
+Name must be an IANA_SVC_NAME.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -11666,7 +13549,8 @@ VolumeMount describes a mounting of a Volume within a container.
         <td><b>mountPath</b></td>
         <td>string</td>
         <td>
-          Path within the container at which the volume should be mounted.  Must not contain ':'.<br/>
+          Path within the container at which the volume should be mounted.  Must
+not contain ':'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -11680,28 +13564,36 @@ VolumeMount describes a mounting of a Volume within a container.
         <td><b>mountPropagation</b></td>
         <td>string</td>
         <td>
-          mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.<br/>
+          mountPropagation determines how mounts are propagated from the host
+to container and the other way around.
+When not set, MountPropagationNone is used.
+This field is beta in 1.10.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.<br/>
+          Mounted read-only if true, read-write otherwise (false or unspecified).
+Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPath</b></td>
         <td>string</td>
         <td>
-          Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).<br/>
+          Path within the volume from which the container's volume should be mounted.
+Defaults to "" (volume's root).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>subPathExpr</b></td>
         <td>string</td>
         <td>
-          Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.<br/>
+          Expanded path within the volume from which the container's volume should be mounted.
+Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+Defaults to "" (volume's root).
+SubPathExpr and SubPath are mutually exclusive.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11713,9 +13605,36 @@ VolumeMount describes a mounting of a Volume within a container.
 
 
 
-Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. 
- If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions 
- If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+Specifies the OS of the containers in the pod.
+Some pod and container fields are restricted if this is set.
+
+
+If the OS field is set to linux, the following fields must be unset:
+-securityContext.windowsOptions
+
+
+If the OS field is set to windows, following fields must be unset:
+- spec.hostPID
+- spec.hostIPC
+- spec.hostUsers
+- spec.securityContext.seLinuxOptions
+- spec.securityContext.seccompProfile
+- spec.securityContext.fsGroup
+- spec.securityContext.fsGroupChangePolicy
+- spec.securityContext.sysctls
+- spec.shareProcessNamespace
+- spec.securityContext.runAsUser
+- spec.securityContext.runAsGroup
+- spec.securityContext.supplementalGroups
+- spec.containers[*].securityContext.seLinuxOptions
+- spec.containers[*].securityContext.seccompProfile
+- spec.containers[*].securityContext.capabilities
+- spec.containers[*].securityContext.readOnlyRootFilesystem
+- spec.containers[*].securityContext.privileged
+- spec.containers[*].securityContext.allowPrivilegeEscalation
+- spec.containers[*].securityContext.procMount
+- spec.containers[*].securityContext.runAsUser
+- spec.containers[*].securityContext.runAsGroup
 
 <table>
     <thead>
@@ -11730,7 +13649,10 @@ Specifies the OS of the containers in the pod. Some pod and container fields are
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null<br/>
+          Name is the name of the operating system. The currently supported values are linux and windows.
+Additional value may be defined in future and can be one of:
+https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+Clients should expect to handle additional values and treat unrecognized values in this field as os: null<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -11769,7 +13691,8 @@ PodReadinessGate contains the reference to a pod condition
 
 
 
-SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.
+SecurityContext holds pod-level security attributes and common container settings.
+Optional: Defaults to empty.  See type description for default values of each field.
 
 <table>
     <thead>
@@ -11784,9 +13707,18 @@ SecurityContext holds pod-level security attributes and common container setting
         <td><b>fsGroup</b></td>
         <td>integer</td>
         <td>
-          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: 
- 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- 
- If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.<br/>
+          A special supplemental group that applies to all containers in a pod.
+Some volume types allow the Kubelet to change the ownership of that volume
+to be owned by the pod:
+
+
+1. The owning GID will be the FSGroup
+2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+3. The permission bits are OR'd with rw-rw----
+
+
+If unset, the Kubelet will not modify the ownership and permissions of any volume.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -11795,14 +13727,25 @@ SecurityContext holds pod-level security attributes and common container setting
         <td><b>fsGroupChangePolicy</b></td>
         <td>string</td>
         <td>
-          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used. Note that this field cannot be set when spec.os.name is windows.<br/>
+          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+before being exposed inside Pod. This field will only apply to
+volume types which support fsGroup based ownership(and permissions).
+It will have no effect on ephemeral volume types such as: secret, configmaps
+and emptydir.
+Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsGroup</b></td>
         <td>integer</td>
         <td>
-          The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The GID to run the entrypoint of the container process.
+Uses runtime default if unset.
+May also be set in SecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence
+for that container.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -11811,14 +13754,24 @@ SecurityContext holds pod-level security attributes and common container setting
         <td><b>runAsNonRoot</b></td>
         <td>boolean</td>
         <td>
-          Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+          Indicates that the container must run as a non-root user.
+If true, the Kubelet will validate the image at runtime to ensure that it
+does not run as UID 0 (root) and fail to start the container if it does.
+If unset or false, no such validation will be performed.
+May also be set in SecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUser</b></td>
         <td>integer</td>
         <td>
-          The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The UID to run the entrypoint of the container process.
+Defaults to user specified in image metadata if unspecified.
+May also be set in SecurityContext.  If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence
+for that container.
+Note that this field cannot be set when spec.os.name is windows.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -11827,35 +13780,52 @@ SecurityContext holds pod-level security attributes and common container setting
         <td><b><a href="#grafanaspecdeploymentspectemplatespecsecuritycontextselinuxoptions">seLinuxOptions</a></b></td>
         <td>object</td>
         <td>
-          The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The SELinux context to be applied to all containers.
+If unspecified, the container runtime will allocate a random SELinux context for each
+container.  May also be set in SecurityContext.  If set in
+both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+takes precedence for that container.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecsecuritycontextseccompprofile">seccompProfile</a></b></td>
         <td>object</td>
         <td>
-          The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.<br/>
+          The seccomp options to use by the containers in this pod.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>supplementalGroups</b></td>
         <td>[]integer</td>
         <td>
-          A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container. Note that group memberships defined in the container image for the uid of the container process are still effective, even if they are not included in this list. Note that this field cannot be set when spec.os.name is windows.<br/>
+          A list of groups applied to the first process run in each container, in addition
+to the container's primary GID, the fsGroup (if specified), and group memberships
+defined in the container image for the uid of the container process. If unspecified,
+no additional groups are added to any container. Note that group memberships
+defined in the container image for the uid of the container process are still effective,
+even if they are not included in this list.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecsecuritycontextsysctlsindex">sysctls</a></b></td>
         <td>[]object</td>
         <td>
-          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.<br/>
+          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+sysctls (by the container runtime) might fail to launch.
+Note that this field cannot be set when spec.os.name is windows.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecsecuritycontextwindowsoptions">windowsOptions</a></b></td>
         <td>object</td>
         <td>
-          The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.<br/>
+          The Windows specific settings applied to all containers.
+If unspecified, the options within a container's SecurityContext will be used.
+If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is linux.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11867,7 +13837,12 @@ SecurityContext holds pod-level security attributes and common container setting
 
 
 
-The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+The SELinux context to be applied to all containers.
+If unspecified, the container runtime will allocate a random SELinux context for each
+container.  May also be set in SecurityContext.  If set in
+both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+takes precedence for that container.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -11915,7 +13890,8 @@ The SELinux context to be applied to all containers. If unspecified, the contain
 
 
 
-The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.
+The seccomp options to use by the containers in this pod.
+Note that this field cannot be set when spec.os.name is windows.
 
 <table>
     <thead>
@@ -11930,15 +13906,23 @@ The seccomp options to use by the containers in this pod. Note that this field c
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          type indicates which kind of seccomp profile will be applied. Valid options are: 
- Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.<br/>
+          type indicates which kind of seccomp profile will be applied.
+Valid options are:
+
+
+Localhost - a profile defined in a file on the node should be used.
+RuntimeDefault - the container runtime default profile should be used.
+Unconfined - no profile should be applied.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>localhostProfile</b></td>
         <td>string</td>
         <td>
-          localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is "Localhost". Must NOT be set for any other type.<br/>
+          localhostProfile indicates a profile defined in a file on the node should be used.
+The profile must be preconfigured on the node to work.
+Must be a descending path, relative to the kubelet's configured seccomp profile location.
+Must be set if type is "Localhost". Must NOT be set for any other type.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11984,7 +13968,10 @@ Sysctl defines a kernel parameter to be set
 
 
 
-The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+The Windows specific settings applied to all containers.
+If unspecified, the options within a container's SecurityContext will be used.
+If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+Note that this field cannot be set when spec.os.name is linux.
 
 <table>
     <thead>
@@ -11999,7 +13986,9 @@ The Windows specific settings applied to all containers. If unspecified, the opt
         <td><b>gmsaCredentialSpec</b></td>
         <td>string</td>
         <td>
-          GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.<br/>
+          GMSACredentialSpec is where the GMSA admission webhook
+(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+GMSA credential spec named by the GMSACredentialSpecName field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12013,14 +14002,20 @@ The Windows specific settings applied to all containers. If unspecified, the opt
         <td><b>hostProcess</b></td>
         <td>boolean</td>
         <td>
-          HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
+          HostProcess determines if a container should be run as a 'Host Process' container.
+All of a Pod's containers must have the same effective HostProcess value
+(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+In addition, if HostProcess is true then HostNetwork must also be set to true.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>runAsUserName</b></td>
         <td>string</td>
         <td>
-          The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+          The UserName in Windows to run the entrypoint of the container process.
+Defaults to the user specified in image metadata if unspecified.
+May also be set in PodSecurityContext. If set in both SecurityContext and
+PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12032,7 +14027,8 @@ The Windows specific settings applied to all containers. If unspecified, the opt
 
 
 
-The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+The pod this Toleration is attached to tolerates any taint that matches
+the triple <key,value,effect> using the matching operator <operator>.
 
 <table>
     <thead>
@@ -12047,28 +14043,36 @@ The pod this Toleration is attached to tolerates any taint that matches the trip
         <td><b>effect</b></td>
         <td>string</td>
         <td>
-          Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.<br/>
+          Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>key</b></td>
         <td>string</td>
         <td>
-          Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.<br/>
+          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.<br/>
+          Operator represents a key's relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tolerationSeconds</b></td>
         <td>integer</td>
         <td>
-          TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.<br/>
+          TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -12077,7 +14081,8 @@ The pod this Toleration is attached to tolerates any taint that matches the trip
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.<br/>
+          Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12104,7 +14109,23 @@ TopologySpreadConstraint specifies how to spread matching pods among the given t
         <td><b>maxSkew</b></td>
         <td>integer</td>
         <td>
-          MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.<br/>
+          MaxSkew describes the degree to which pods may be unevenly distributed.
+When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+between the number of matching pods in the target topology and the global minimum.
+The global minimum is the minimum number of matching pods in an eligible domain
+or zero if the number of eligible domains is less than MinDomains.
+For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+labelSelector spread as 2/2/1:
+In this case, the global minimum is 1.
+| zone1 | zone2 | zone3 |
+|  P P  |  P P  |   P   |
+- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+violate MaxSkew(1).
+- if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+to topologies that satisfy it.
+It's a required field. Default value is 1 and 0 is not allowed.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12113,38 +14134,95 @@ TopologySpreadConstraint specifies how to spread matching pods among the given t
         <td><b>topologyKey</b></td>
         <td>string</td>
         <td>
-          TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.<br/>
+          TopologyKey is the key of node labels. Nodes that have a label with this key
+and identical values are considered to be in the same topology.
+We consider each <key, value> as a "bucket", and try to put balanced number
+of pods into each bucket.
+We define a domain as a particular instance of a topology.
+Also, we define an eligible domain as a domain whose nodes meet the requirements of
+nodeAffinityPolicy and nodeTaintsPolicy.
+e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+It's a required field.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>whenUnsatisfiable</b></td>
         <td>string</td>
         <td>
-          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.<br/>
+          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+the spread constraint.
+- DoNotSchedule (default) tells the scheduler not to schedule it.
+- ScheduleAnyway tells the scheduler to schedule the pod in any location,
+  but giving higher precedence to topologies that would help reduce the
+  skew.
+A constraint is considered "Unsatisfiable" for an incoming pod
+if and only if every possible node assignment for that pod would violate
+"MaxSkew" on some topology.
+For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+labelSelector spread as 3/1/1:
+| zone1 | zone2 | zone3 |
+| P P P |   P   |   P   |
+If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+won't make it *more* imbalanced.
+It's a required field.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespectopologyspreadconstraintsindexlabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.<br/>
+          LabelSelector is used to find matching pods.
+Pods that match this label selector are counted to determine the number of pods
+in their corresponding topology domain.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>matchLabelKeys</b></td>
         <td>[]string</td>
         <td>
-          MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. 
- This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).<br/>
+          MatchLabelKeys is a set of pod label keys to select the pods over which
+spreading will be calculated. The keys are used to lookup values from the
+incoming pod labels, those key-value labels are ANDed with labelSelector
+to select the group of existing pods over which spreading will be calculated
+for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+MatchLabelKeys cannot be set when LabelSelector isn't set.
+Keys that don't exist in the incoming pod labels will
+be ignored. A null or empty list means only match against labelSelector.
+
+
+This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>minDomains</b></td>
         <td>integer</td>
         <td>
-          MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. 
- For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. 
- This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).<br/>
+          MinDomains indicates a minimum number of eligible domains.
+When the number of eligible domains with matching topology keys is less than minDomains,
+Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+this value has no effect on scheduling.
+As a result, when the number of eligible domains is less than minDomains,
+scheduler won't schedule more than maxSkew Pods to those domains.
+If value is nil, the constraint behaves as if MinDomains is equal to 1.
+Valid values are integers greater than 0.
+When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+labelSelector spread as 2/2/2:
+| zone1 | zone2 | zone3 |
+|  P P  |  P P  |  P P  |
+The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+In this situation, new pod with the same labelSelector cannot be scheduled,
+because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+it will violate MaxSkew.
+
+
+This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12153,16 +14231,29 @@ TopologySpreadConstraint specifies how to spread matching pods among the given t
         <td><b>nodeAffinityPolicy</b></td>
         <td>string</td>
         <td>
-          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. 
- If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.<br/>
+          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+when calculating pod topology spread skew. Options are:
+- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+If this value is nil, the behavior is equivalent to the Honor policy.
+This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>nodeTaintsPolicy</b></td>
         <td>string</td>
         <td>
-          NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. 
- If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.<br/>
+          NodeTaintsPolicy indicates how we will treat node taints when calculating
+pod topology spread skew. Options are:
+- Honor: nodes without taints, along with tainted nodes for which the incoming pod
+has a toleration, are included.
+- Ignore: node taints are ignored. All nodes are included.
+
+
+If this value is nil, the behavior is equivalent to the Ignore policy.
+This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12174,7 +14265,9 @@ TopologySpreadConstraint specifies how to spread matching pods among the given t
 
 
 
-LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+LabelSelector is used to find matching pods.
+Pods that match this label selector are counted to determine the number of pods
+in their corresponding topology domain.
 
 <table>
     <thead>
@@ -12196,7 +14289,9 @@ LabelSelector is used to find matching pods. Pods that match this label selector
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12208,7 +14303,8 @@ LabelSelector is used to find matching pods. Pods that match this label selector
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -12230,14 +14326,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12264,14 +14364,18 @@ Volume represents a named volume in a pod that may be accessed by any container 
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names<br/>
+          name of the volume.
+Must be a DNS_LABEL and unique within the pod.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexawselasticblockstore">awsElasticBlockStore</a></b></td>
         <td>object</td>
         <td>
-          awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
+          awsElasticBlockStore represents an AWS Disk resource that is attached to a
+kubelet's host machine and then exposed to the pod.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12299,7 +14403,8 @@ Volume represents a named volume in a pod that may be accessed by any container 
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexcinder">cinder</a></b></td>
         <td>object</td>
         <td>
-          cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
+          cinder represents a cinder volume attached and mounted on kubelets host machine.
+More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12327,18 +14432,42 @@ Volume represents a named volume in a pod that may be accessed by any container 
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexemptydir">emptyDir</a></b></td>
         <td>object</td>
         <td>
-          emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br/>
+          emptyDir represents a temporary directory that shares a pod's lifetime.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexephemeral">ephemeral</a></b></td>
         <td>object</td>
         <td>
-          ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. 
- Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). 
- Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. 
- Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. 
- A pod can use both types of ephemeral volumes and persistent volumes at the same time.<br/>
+          ephemeral represents a volume that is handled by a cluster storage driver.
+The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+and deleted when the pod is removed.
+
+
+Use this if:
+a) the volume is only needed while the pod runs,
+b) features of normal volumes like restoring from snapshot or capacity
+   tracking are needed,
+c) the storage driver is specified through a storage class, and
+d) the storage driver supports dynamic volume provisioning through
+   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+   information on the connection between this volume type
+   and PersistentVolumeClaim).
+
+
+Use PersistentVolumeClaim or one of the vendor-specific
+APIs for volumes that persist for longer than the lifecycle
+of an individual pod.
+
+
+Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+be used that way - see the documentation of the driver for
+more information.
+
+
+A pod can use both types of ephemeral volumes and
+persistent volumes at the same time.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12352,7 +14481,8 @@ Volume represents a named volume in a pod that may be accessed by any container 
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexflexvolume">flexVolume</a></b></td>
         <td>object</td>
         <td>
-          flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.<br/>
+          flexVolume represents a generic volume resource that is
+provisioned/attached using an exec based plugin.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12366,49 +14496,67 @@ Volume represents a named volume in a pod that may be accessed by any container 
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexgcepersistentdisk">gcePersistentDisk</a></b></td>
         <td>object</td>
         <td>
-          gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
+          gcePersistentDisk represents a GCE Disk resource that is attached to a
+kubelet's host machine and then exposed to the pod.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexgitrepo">gitRepo</a></b></td>
         <td>object</td>
         <td>
-          gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.<br/>
+          gitRepo represents a git repository at a particular revision.
+DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+into the Pod's container.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexglusterfs">glusterfs</a></b></td>
         <td>object</td>
         <td>
-          glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md<br/>
+          glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+More info: https://examples.k8s.io/volumes/glusterfs/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexhostpath">hostPath</a></b></td>
         <td>object</td>
         <td>
-          hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.<br/>
+          hostPath represents a pre-existing file or directory on the host
+machine that is directly exposed to the container. This is generally
+used for system agents or other privileged things that are allowed
+to see the host machine. Most containers will NOT need this.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+---
+TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+mount host directories as read/write.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexiscsi">iscsi</a></b></td>
         <td>object</td>
         <td>
-          iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md<br/>
+          iscsi represents an ISCSI Disk resource that is attached to a
+kubelet's host machine and then exposed to the pod.
+More info: https://examples.k8s.io/volumes/iscsi/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexnfs">nfs</a></b></td>
         <td>object</td>
         <td>
-          nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
+          nfs represents an NFS mount on the host that shares a pod's lifetime
+More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexpersistentvolumeclaim">persistentVolumeClaim</a></b></td>
         <td>object</td>
         <td>
-          persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims<br/>
+          persistentVolumeClaimVolumeSource represents a reference to a
+PersistentVolumeClaim in the same namespace.
+More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12443,7 +14591,8 @@ Volume represents a named volume in a pod that may be accessed by any container 
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexrbd">rbd</a></b></td>
         <td>object</td>
         <td>
-          rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md<br/>
+          rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+More info: https://examples.k8s.io/volumes/rbd/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12457,7 +14606,8 @@ Volume represents a named volume in a pod that may be accessed by any container 
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexsecret">secret</a></b></td>
         <td>object</td>
         <td>
-          secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret<br/>
+          secret represents a secret that should populate this volume.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#secret<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12483,7 +14633,9 @@ Volume represents a named volume in a pod that may be accessed by any container 
 
 
 
-awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+awsElasticBlockStore represents an AWS Disk resource that is attached to a
+kubelet's host machine and then exposed to the pod.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 
 <table>
     <thead>
@@ -12498,21 +14650,29 @@ awsElasticBlockStore represents an AWS Disk resource that is attached to a kubel
         <td><b>volumeID</b></td>
         <td>string</td>
         <td>
-          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
+          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
+          fsType is the filesystem type of the volume that you want to mount.
+Tip: Ensure that the filesystem type is supported by the host operating system.
+Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>partition</b></td>
         <td>integer</td>
         <td>
-          partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).<br/>
+          partition is the partition in the volume that you want to mount.
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12521,7 +14681,8 @@ awsElasticBlockStore represents an AWS Disk resource that is attached to a kubel
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
+          readOnly value true will force the readOnly setting in VolumeMounts.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12569,7 +14730,9 @@ azureDisk represents an Azure Data Disk mount on the host and bind mount to the 
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
+          fsType is Filesystem type to mount.
+Must be a filesystem type supported by the host operating system.
+Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12583,7 +14746,8 @@ azureDisk represents an Azure Data Disk mount on the host and bind mount to the 
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
+          readOnly Defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12624,7 +14788,8 @@ azureFile represents an Azure File Service mount on the host and bind mount to t
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
+          readOnly defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12651,7 +14816,8 @@ cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
         <td><b>monitors</b></td>
         <td>[]string</td>
         <td>
-          monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
+          monitors is Required: Monitors is a collection of Ceph monitors
+More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -12665,28 +14831,33 @@ cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
+          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.
+More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>secretFile</b></td>
         <td>string</td>
         <td>
-          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
+          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexcephfssecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
+          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
+          user is optional: User is the rados user name, default is admin
+More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12698,7 +14869,8 @@ cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
 
 
 
-secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
 
 <table>
     <thead>
@@ -12713,7 +14885,9 @@ secretRef is Optional: SecretRef is reference to the authentication secret for U
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12725,7 +14899,8 @@ secretRef is Optional: SecretRef is reference to the authentication secret for U
 
 
 
-cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+cinder represents a cinder volume attached and mounted on kubelets host machine.
+More info: https://examples.k8s.io/mysql-cinder-pd/README.md
 
 <table>
     <thead>
@@ -12740,28 +14915,35 @@ cinder represents a cinder volume attached and mounted on kubelets host machine.
         <td><b>volumeID</b></td>
         <td>string</td>
         <td>
-          volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
+          volumeID used to identify the volume in cinder.
+More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
+          fsType is the filesystem type to mount.
+Must be a filesystem type supported by the host operating system.
+Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
+          readOnly defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.
+More info: https://examples.k8s.io/mysql-cinder-pd/README.md<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexcindersecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.<br/>
+          secretRef is optional: points to a secret object containing parameters used to connect
+to OpenStack.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12773,7 +14955,8 @@ cinder represents a cinder volume attached and mounted on kubelets host machine.
 
 
 
-secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.
+secretRef is optional: points to a secret object containing parameters used to connect
+to OpenStack.
 
 <table>
     <thead>
@@ -12788,7 +14971,9 @@ secretRef is optional: points to a secret object containing parameters used to c
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12815,7 +15000,13 @@ configMap represents a configMap that should populate this volume
         <td><b>defaultMode</b></td>
         <td>integer</td>
         <td>
-          defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          defaultMode is optional: mode bits used to set permissions on created files by default.
+Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+Defaults to 0644.
+Directories within the path are not affected by this setting.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12824,14 +15015,22 @@ configMap represents a configMap that should populate this volume
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexconfigmapitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.<br/>
+          items if unspecified, each key-value pair in the Data field of the referenced
+ConfigMap will be projected into the volume as a file whose name is the
+key and content is the value. If specified, the listed keys will be
+projected into the specified paths, and unlisted keys will not be
+present. If a key is specified which is not present in the ConfigMap,
+the volume setup will error unless it is marked optional. Paths must be
+relative and may not contain the '..' path or start with '..'.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12872,14 +15071,22 @@ Maps a string key to a path within a volume.
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.<br/>
+          path is the relative path of the file to map the key to.
+May not be an absolute path.
+May not contain the path element '..'.
+May not start with the string '..'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          mode is Optional: mode bits used to set permissions on this file.
+Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+If not specified, the volume defaultMode will be used.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -12908,35 +15115,44 @@ csi (Container Storage Interface) represents ephemeral storage that is handled b
         <td><b>driver</b></td>
         <td>string</td>
         <td>
-          driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.<br/>
+          driver is the name of the CSI driver that handles this volume.
+Consult with your admin for the correct name as registered in the cluster.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.<br/>
+          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+If not provided, the empty value is passed to the associated CSI driver
+which will determine the default filesystem to apply.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexcsinodepublishsecretref">nodePublishSecretRef</a></b></td>
         <td>object</td>
         <td>
-          nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.<br/>
+          nodePublishSecretRef is a reference to the secret object containing
+sensitive information to pass to the CSI driver to complete the CSI
+NodePublishVolume and NodeUnpublishVolume calls.
+This field is optional, and  may be empty if no secret is required. If the
+secret object contains more than one secret, all secret references are passed.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).<br/>
+          readOnly specifies a read-only configuration for the volume.
+Defaults to false (read/write).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeAttributes</b></td>
         <td>map[string]string</td>
         <td>
-          volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.<br/>
+          volumeAttributes stores driver-specific properties that are passed to the CSI
+driver. Consult your driver's documentation for supported values.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12948,7 +15164,11 @@ csi (Container Storage Interface) represents ephemeral storage that is handled b
 
 
 
-nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+nodePublishSecretRef is a reference to the secret object containing
+sensitive information to pass to the CSI driver to complete the CSI
+NodePublishVolume and NodeUnpublishVolume calls.
+This field is optional, and  may be empty if no secret is required. If the
+secret object contains more than one secret, all secret references are passed.
 
 <table>
     <thead>
@@ -12963,7 +15183,9 @@ nodePublishSecretRef is a reference to the secret object containing sensitive in
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12990,7 +15212,14 @@ downwardAPI represents downward API about the pod that should populate this volu
         <td><b>defaultMode</b></td>
         <td>integer</td>
         <td>
-          Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          Optional: mode bits to use on created files by default. Must be a
+Optional: mode bits used to set permissions on created files by default.
+Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+Defaults to 0644.
+Directories within the path are not affected by this setting.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -13040,7 +15269,12 @@ DownwardAPIVolumeFile represents information to create the file containing the p
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          Optional: mode bits used to set permissions on this file, must be an octal value
+between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+If not specified, the volume defaultMode will be used.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -13049,7 +15283,8 @@ DownwardAPIVolumeFile represents information to create the file containing the p
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexdownwardapiitemsindexresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.<br/>
+          Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13095,7 +15330,8 @@ Required: Selects a field of the pod: only annotations, labels, name and namespa
 
 
 
-Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
 
 <table>
     <thead>
@@ -13136,7 +15372,8 @@ Selects a resource of the container: only resources limits and requests (limits.
 
 
 
-emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+emptyDir represents a temporary directory that shares a pod's lifetime.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
 
 <table>
     <thead>
@@ -13151,14 +15388,22 @@ emptyDir represents a temporary directory that shares a pod's lifetime. More inf
         <td><b>medium</b></td>
         <td>string</td>
         <td>
-          medium represents what type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br/>
+          medium represents what type of storage medium should back this directory.
+The default is "" which means to use the node's default medium.
+Must be an empty string (default) or Memory.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>sizeLimit</b></td>
         <td>int or string</td>
         <td>
-          sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br/>
+          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+The size limit is also applicable for memory medium.
+The maximum usage on memory medium EmptyDir would be the minimum value between
+the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+The default is nil which means that the limit is undefined.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13170,11 +15415,34 @@ emptyDir represents a temporary directory that shares a pod's lifetime. More inf
 
 
 
-ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. 
- Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). 
- Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. 
- Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. 
- A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+ephemeral represents a volume that is handled by a cluster storage driver.
+The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+and deleted when the pod is removed.
+
+
+Use this if:
+a) the volume is only needed while the pod runs,
+b) features of normal volumes like restoring from snapshot or capacity
+   tracking are needed,
+c) the storage driver is specified through a storage class, and
+d) the storage driver supports dynamic volume provisioning through
+   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+   information on the connection between this volume type
+   and PersistentVolumeClaim).
+
+
+Use PersistentVolumeClaim or one of the vendor-specific
+APIs for volumes that persist for longer than the lifecycle
+of an individual pod.
+
+
+Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+be used that way - see the documentation of the driver for
+more information.
+
+
+A pod can use both types of ephemeral volumes and
+persistent volumes at the same time.
 
 <table>
     <thead>
@@ -13189,10 +15457,30 @@ ephemeral represents a volume that is handled by a cluster storage driver. The v
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplate">volumeClaimTemplate</a></b></td>
         <td>object</td>
         <td>
-          Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). 
- An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. 
- This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. 
- Required, must not be nil.<br/>
+          Will be used to create a stand-alone PVC to provision the volume.
+The pod in which this EphemeralVolumeSource is embedded will be the
+owner of the PVC, i.e. the PVC will be deleted together with the
+pod.  The name of the PVC will be `<pod name>-<volume name>` where
+`<volume name>` is the name from the `PodSpec.Volumes` array
+entry. Pod validation will reject the pod if the concatenated name
+is not valid for a PVC (for example, too long).
+
+
+An existing PVC with that name that is not owned by the pod
+will *not* be used for the pod to avoid using an unrelated
+volume by mistake. Starting the pod is then blocked until
+the unrelated PVC is removed. If such a pre-created PVC is
+meant to be used by the pod, the PVC has to updated with an
+owner reference to the pod once the pod exists. Normally
+this should not be necessary, but it may be useful when
+manually reconstructing a broken cluster.
+
+
+This field is read-only and no changes will be made by Kubernetes
+to the PVC after it has been created.
+
+
+Required, must not be nil.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13204,10 +15492,30 @@ ephemeral represents a volume that is handled by a cluster storage driver. The v
 
 
 
-Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). 
- An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. 
- This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. 
- Required, must not be nil.
+Will be used to create a stand-alone PVC to provision the volume.
+The pod in which this EphemeralVolumeSource is embedded will be the
+owner of the PVC, i.e. the PVC will be deleted together with the
+pod.  The name of the PVC will be `<pod name>-<volume name>` where
+`<volume name>` is the name from the `PodSpec.Volumes` array
+entry. Pod validation will reject the pod if the concatenated name
+is not valid for a PVC (for example, too long).
+
+
+An existing PVC with that name that is not owned by the pod
+will *not* be used for the pod to avoid using an unrelated
+volume by mistake. Starting the pod is then blocked until
+the unrelated PVC is removed. If such a pre-created PVC is
+meant to be used by the pod, the PVC has to updated with an
+owner reference to the pod once the pod exists. Normally
+this should not be necessary, but it may be useful when
+manually reconstructing a broken cluster.
+
+
+This field is read-only and no changes will be made by Kubernetes
+to the PVC after it has been created.
+
+
+Required, must not be nil.
 
 <table>
     <thead>
@@ -13222,14 +15530,19 @@ Will be used to create a stand-alone PVC to provision the volume. The pod in whi
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespec">spec</a></b></td>
         <td>object</td>
         <td>
-          The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.<br/>
+          The specification for the PersistentVolumeClaim. The entire content is
+copied unchanged into the PVC that gets created from this
+template. The same fields as in a PersistentVolumeClaim
+are also valid here.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>metadata</b></td>
         <td>object</td>
         <td>
-          May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.<br/>
+          May contain labels and annotations that will be copied into the PVC
+when creating it. No other fields are allowed and will be rejected during
+validation.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13241,7 +15554,10 @@ Will be used to create a stand-alone PVC to provision the volume. The pod in whi
 
 
 
-The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+The specification for the PersistentVolumeClaim. The entire content is
+copied unchanged into the PVC that gets created from this
+template. The same fields as in a PersistentVolumeClaim
+are also valid here.
 
 <table>
     <thead>
@@ -13256,28 +15572,62 @@ The specification for the PersistentVolumeClaim. The entire content is copied un
         <td><b>accessModes</b></td>
         <td>[]string</td>
         <td>
-          accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1<br/>
+          accessModes contains the desired access modes the volume should have.
+More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespecdatasource">dataSource</a></b></td>
         <td>object</td>
         <td>
-          dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.<br/>
+          dataSource field can be used to specify either:
+* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+* An existing PVC (PersistentVolumeClaim)
+If the provisioner or an external controller can support the specified data source,
+it will create a new volume based on the contents of the specified data source.
+When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+If the namespace is specified, then dataSourceRef will not be copied to dataSource.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
         <td>
-          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.<br/>
+          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+volume is desired. This may be any object from a non-empty API group (non
+core object) or a PersistentVolumeClaim object.
+When this field is specified, volume binding will only succeed if the type of
+the specified object matches some installed volume populator or dynamic
+provisioner.
+This field will replace the functionality of the dataSource field and as such
+if both fields are non-empty, they must have the same value. For backwards
+compatibility, when namespace isn't specified in dataSourceRef,
+both fields (dataSource and dataSourceRef) will be set to the same
+value automatically if one of them is empty and the other is non-empty.
+When namespace is specified in dataSourceRef,
+dataSource isn't set to the same value and must be empty.
+There are three important differences between dataSource and dataSourceRef:
+* While dataSource only allows two specific types of objects, dataSourceRef
+  allows any non-core object, as well as PersistentVolumeClaim objects.
+* While dataSource ignores disallowed values (dropping them), dataSourceRef
+  preserves all values, and generates an error if a disallowed value is
+  specified.
+* While dataSource only allows local objects, dataSourceRef allows objects
+  in any namespaces.
+(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexephemeralvolumeclaimtemplatespecresources">resources</a></b></td>
         <td>object</td>
         <td>
-          resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources<br/>
+          resources represents the minimum resources the volume should have.
+If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+that are lower than previous value but must still be higher than capacity recorded in the
+status field of the claim.
+More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13291,21 +15641,34 @@ The specification for the PersistentVolumeClaim. The entire content is copied un
         <td><b>storageClassName</b></td>
         <td>string</td>
         <td>
-          storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1<br/>
+          storageClassName is the name of the StorageClass required by the claim.
+More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeAttributesClassName</b></td>
         <td>string</td>
         <td>
-          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.<br/>
+          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+If specified, the CSI driver will create or update the volume with the attributes defined
+in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+will be set by the persistentvolume controller if it exists.
+If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+exists.
+More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeMode</b></td>
         <td>string</td>
         <td>
-          volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.<br/>
+          volumeMode defines what type of volume is required by the claim.
+Value of Filesystem is implied when not included in claim spec.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13324,7 +15687,14 @@ The specification for the PersistentVolumeClaim. The entire content is copied un
 
 
 
-dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+dataSource field can be used to specify either:
+* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+* An existing PVC (PersistentVolumeClaim)
+If the provisioner or an external controller can support the specified data source,
+it will create a new volume based on the contents of the specified data source.
+When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+If the namespace is specified, then dataSourceRef will not be copied to dataSource.
 
 <table>
     <thead>
@@ -13353,7 +15723,9 @@ dataSource field can be used to specify either: * An existing VolumeSnapshot obj
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
+          APIGroup is the group for the resource being referenced.
+If APIGroup is not specified, the specified Kind must be in the core API group.
+For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13365,7 +15737,29 @@ dataSource field can be used to specify either: * An existing VolumeSnapshot obj
 
 
 
-dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+volume is desired. This may be any object from a non-empty API group (non
+core object) or a PersistentVolumeClaim object.
+When this field is specified, volume binding will only succeed if the type of
+the specified object matches some installed volume populator or dynamic
+provisioner.
+This field will replace the functionality of the dataSource field and as such
+if both fields are non-empty, they must have the same value. For backwards
+compatibility, when namespace isn't specified in dataSourceRef,
+both fields (dataSource and dataSourceRef) will be set to the same
+value automatically if one of them is empty and the other is non-empty.
+When namespace is specified in dataSourceRef,
+dataSource isn't set to the same value and must be empty.
+There are three important differences between dataSource and dataSourceRef:
+* While dataSource only allows two specific types of objects, dataSourceRef
+  allows any non-core object, as well as PersistentVolumeClaim objects.
+* While dataSource ignores disallowed values (dropping them), dataSourceRef
+  preserves all values, and generates an error if a disallowed value is
+  specified.
+* While dataSource only allows local objects, dataSourceRef allows objects
+  in any namespaces.
+(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
 
 <table>
     <thead>
@@ -13394,14 +15788,18 @@ dataSourceRef specifies the object from which to populate the volume with data, 
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
+          APIGroup is the group for the resource being referenced.
+If APIGroup is not specified, the specified Kind must be in the core API group.
+For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespace</b></td>
         <td>string</td>
         <td>
-          Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.<br/>
+          Namespace is the namespace of resource being referenced
+Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13413,7 +15811,11 @@ dataSourceRef specifies the object from which to populate the volume with data, 
 
 
 
-resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+resources represents the minimum resources the volume should have.
+If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+that are lower than previous value but must still be higher than capacity recorded in the
+status field of the claim.
+More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
 
 <table>
     <thead>
@@ -13428,14 +15830,18 @@ resources represents the minimum resources the volume should have. If RecoverVol
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13469,7 +15875,9 @@ selector is a label query over volumes to consider for binding.
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13481,7 +15889,8 @@ selector is a label query over volumes to consider for binding.
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -13503,14 +15912,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13537,7 +15950,10 @@ fc represents a Fibre Channel resource that is attached to a kubelet's host mach
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
+          fsType is the filesystem type to mount.
+Must be a filesystem type supported by the host operating system.
+Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13553,7 +15969,8 @@ fc represents a Fibre Channel resource that is attached to a kubelet's host mach
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
+          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13567,7 +15984,8 @@ fc represents a Fibre Channel resource that is attached to a kubelet's host mach
         <td><b>wwids</b></td>
         <td>[]string</td>
         <td>
-          wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.<br/>
+          wwids Optional: FC volume world wide identifiers (wwids)
+Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13579,7 +15997,8 @@ fc represents a Fibre Channel resource that is attached to a kubelet's host mach
 
 
 
-flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+flexVolume represents a generic volume resource that is
+provisioned/attached using an exec based plugin.
 
 <table>
     <thead>
@@ -13601,7 +16020,9 @@ flexVolume represents a generic volume resource that is provisioned/attached usi
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.<br/>
+          fsType is the filesystem type to mount.
+Must be a filesystem type supported by the host operating system.
+Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13615,14 +16036,19 @@ flexVolume represents a generic volume resource that is provisioned/attached usi
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
+          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexflexvolumesecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.<br/>
+          secretRef is Optional: secretRef is reference to the secret object containing
+sensitive information to pass to the plugin scripts. This may be
+empty if no secret object is specified. If the secret object
+contains more than one secret, all secrets are passed to the plugin
+scripts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13634,7 +16060,11 @@ flexVolume represents a generic volume resource that is provisioned/attached usi
 
 
 
-secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+secretRef is Optional: secretRef is reference to the secret object containing
+sensitive information to pass to the plugin scripts. This may be
+empty if no secret object is specified. If the secret object
+contains more than one secret, all secrets are passed to the plugin
+scripts.
 
 <table>
     <thead>
@@ -13649,7 +16079,9 @@ secretRef is Optional: secretRef is reference to the secret object containing se
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13676,7 +16108,8 @@ flocker represents a Flocker volume attached to a kubelet's host machine. This d
         <td><b>datasetName</b></td>
         <td>string</td>
         <td>
-          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated<br/>
+          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+should be considered as deprecated<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13695,7 +16128,9 @@ flocker represents a Flocker volume attached to a kubelet's host machine. This d
 
 
 
-gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+gcePersistentDisk represents a GCE Disk resource that is attached to a
+kubelet's host machine and then exposed to the pod.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
 
 <table>
     <thead>
@@ -13710,21 +16145,30 @@ gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's
         <td><b>pdName</b></td>
         <td>string</td>
         <td>
-          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
+          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
+          fsType is filesystem type of the volume that you want to mount.
+Tip: Ensure that the filesystem type is supported by the host operating system.
+Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>partition</b></td>
         <td>integer</td>
         <td>
-          partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
+          partition is the partition in the volume that you want to mount.
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -13733,7 +16177,9 @@ gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
+          readOnly here will force the ReadOnly setting in VolumeMounts.
+Defaults to false.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13745,7 +16191,10 @@ gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's
 
 
 
-gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+gitRepo represents a git repository at a particular revision.
+DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+into the Pod's container.
 
 <table>
     <thead>
@@ -13767,7 +16216,10 @@ gitRepo represents a git repository at a particular revision. DEPRECATED: GitRep
         <td><b>directory</b></td>
         <td>string</td>
         <td>
-          directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.<br/>
+          directory is the target directory name.
+Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+git repository.  Otherwise, if specified, the volume will contain the git repository in
+the subdirectory with the given name.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13786,7 +16238,8 @@ gitRepo represents a git repository at a particular revision. DEPRECATED: GitRep
 
 
 
-glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+More info: https://examples.k8s.io/volumes/glusterfs/README.md
 
 <table>
     <thead>
@@ -13801,21 +16254,25 @@ glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
         <td><b>endpoints</b></td>
         <td>string</td>
         <td>
-          endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
+          endpoints is the endpoint name that details Glusterfs topology.
+More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
+          path is the Glusterfs volume path.
+More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
+          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+Defaults to false.
+More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13827,7 +16284,14 @@ glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
 
 
 
-hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.
+hostPath represents a pre-existing file or directory on the host
+machine that is directly exposed to the container. This is generally
+used for system agents or other privileged things that are allowed
+to see the host machine. Most containers will NOT need this.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+---
+TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+mount host directories as read/write.
 
 <table>
     <thead>
@@ -13842,14 +16306,18 @@ hostPath represents a pre-existing file or directory on the host machine that is
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath<br/>
+          path of the directory on the host.
+If the path is a symlink, it will follow the link to the real path.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath<br/>
+          type for HostPath Volume
+Defaults to ""
+More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13861,7 +16329,9 @@ hostPath represents a pre-existing file or directory on the host machine that is
 
 
 
-iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md
+iscsi represents an ISCSI Disk resource that is attached to a
+kubelet's host machine and then exposed to the pod.
+More info: https://examples.k8s.io/volumes/iscsi/README.md
 
 <table>
     <thead>
@@ -13892,7 +16362,8 @@ iscsi represents an ISCSI Disk resource that is attached to a kubelet's host mac
         <td><b>targetPortal</b></td>
         <td>string</td>
         <td>
-          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).<br/>
+          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+is other than default (typically TCP ports 860 and 3260).<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -13913,35 +16384,44 @@ iscsi represents an ISCSI Disk resource that is attached to a kubelet's host mac
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
+          fsType is the filesystem type of the volume that you want to mount.
+Tip: Ensure that the filesystem type is supported by the host operating system.
+Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>initiatorName</b></td>
         <td>string</td>
         <td>
-          initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.<br/>
+          initiatorName is the custom iSCSI Initiator Name.
+If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+<target portal>:<volume name> will be created for the connection.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>iscsiInterface</b></td>
         <td>string</td>
         <td>
-          iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).<br/>
+          iscsiInterface is the interface Name that uses an iSCSI transport.
+Defaults to 'default' (tcp).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>portals</b></td>
         <td>[]string</td>
         <td>
-          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).<br/>
+          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+is other than default (typically TCP ports 860 and 3260).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.<br/>
+          readOnly here will force the ReadOnly setting in VolumeMounts.
+Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13975,7 +16455,9 @@ secretRef is the CHAP Secret for iSCSI target and initiator authentication
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13987,7 +16469,8 @@ secretRef is the CHAP Secret for iSCSI target and initiator authentication
 
 
 
-nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+nfs represents an NFS mount on the host that shares a pod's lifetime
+More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
 
 <table>
     <thead>
@@ -14002,21 +16485,25 @@ nfs represents an NFS mount on the host that shares a pod's lifetime More info: 
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
+          path that is exported by the NFS server.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>server</b></td>
         <td>string</td>
         <td>
-          server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
+          server is the hostname or IP address of the NFS server.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
+          readOnly here will force the NFS export to be mounted with read-only permissions.
+Defaults to false.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14028,7 +16515,9 @@ nfs represents an NFS mount on the host that shares a pod's lifetime More info: 
 
 
 
-persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+persistentVolumeClaimVolumeSource represents a reference to a
+PersistentVolumeClaim in the same namespace.
+More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
 
 <table>
     <thead>
@@ -14043,14 +16532,16 @@ persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeCl
         <td><b>claimName</b></td>
         <td>string</td>
         <td>
-          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims<br/>
+          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly Will force the ReadOnly setting in VolumeMounts. Default false.<br/>
+          readOnly Will force the ReadOnly setting in VolumeMounts.
+Default false.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14084,7 +16575,9 @@ photonPersistentDisk represents a PhotonController persistent disk attached and 
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
+          fsType is the filesystem type to mount.
+Must be a filesystem type supported by the host operating system.
+Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14118,14 +16611,17 @@ portworxVolume represents a portworx volume attached and mounted on kubelets hos
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.<br/>
+          fSType represents the filesystem type to mount
+Must be a filesystem type supported by the host operating system.
+Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
+          readOnly defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14152,7 +16648,12 @@ projected items for all in one resources secrets, configmaps, and downward API
         <td><b>defaultMode</b></td>
         <td>integer</td>
         <td>
-          defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          defaultMode are the mode bits used to set permissions on created files by default.
+Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+Directories within the path are not affected by this setting.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -14188,10 +16689,22 @@ Projection that may be projected along with other supported volume types
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexclustertrustbundle">clusterTrustBundle</a></b></td>
         <td>object</td>
         <td>
-          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file. 
- Alpha, gated by the ClusterTrustBundleProjection feature gate. 
- ClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector. 
- Kubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time.<br/>
+          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+of ClusterTrustBundle objects in an auto-updating file.
+
+
+Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+
+ClusterTrustBundle objects can either be selected by name, or by the
+combination of signer name and a label selector.
+
+
+Kubelet performs aggressive normalization of the PEM contents written
+into the pod filesystem.  Esoteric PEM features such as inter-block
+comments and block headers are stripped.  Certificates are deduplicated.
+The ordering of certificates within the file is arbitrary, and Kubelet
+may change the order over time.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14231,10 +16744,22 @@ Projection that may be projected along with other supported volume types
 
 
 
-ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file. 
- Alpha, gated by the ClusterTrustBundleProjection feature gate. 
- ClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector. 
- Kubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time.
+ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+of ClusterTrustBundle objects in an auto-updating file.
+
+
+Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+
+ClusterTrustBundle objects can either be selected by name, or by the
+combination of signer name and a label selector.
+
+
+Kubelet performs aggressive normalization of the PEM contents written
+into the pod filesystem.  Esoteric PEM features such as inter-block
+comments and block headers are stripped.  Certificates are deduplicated.
+The ordering of certificates within the file is arbitrary, and Kubelet
+may change the order over time.
 
 <table>
     <thead>
@@ -14256,28 +16781,38 @@ ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of Clust
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexclustertrustbundlelabelselector">labelSelector</a></b></td>
         <td>object</td>
         <td>
-          Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as "match nothing".  If set but empty, interpreted as "match everything".<br/>
+          Select all ClusterTrustBundles that match this label selector.  Only has
+effect if signerName is set.  Mutually-exclusive with name.  If unset,
+interpreted as "match nothing".  If set but empty, interpreted as "match
+everything".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.<br/>
+          Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+with signerName and labelSelector.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>optional</b></td>
         <td>boolean</td>
         <td>
-          If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.<br/>
+          If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+aren't available.  If using name, then the named ClusterTrustBundle is
+allowed not to exist.  If using signerName, then the combination of
+signerName and labelSelector is allowed to match zero
+ClusterTrustBundles.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>signerName</b></td>
         <td>string</td>
         <td>
-          Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.<br/>
+          Select all ClusterTrustBundles that match this signer name.
+Mutually-exclusive with name.  The contents of all selected
+ClusterTrustBundles will be unified and deduplicated.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14289,7 +16824,10 @@ ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of Clust
 
 
 
-Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as "match nothing".  If set but empty, interpreted as "match everything".
+Select all ClusterTrustBundles that match this label selector.  Only has
+effect if signerName is set.  Mutually-exclusive with name.  If unset,
+interpreted as "match nothing".  If set but empty, interpreted as "match
+everything".
 
 <table>
     <thead>
@@ -14311,7 +16849,9 @@ Select all ClusterTrustBundles that match this label selector.  Only has effect 
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14323,7 +16863,8 @@ Select all ClusterTrustBundles that match this label selector.  Only has effect 
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -14345,14 +16886,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14379,14 +16924,22 @@ configMap information about the configMap data to project
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexconfigmapitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.<br/>
+          items if unspecified, each key-value pair in the Data field of the referenced
+ConfigMap will be projected into the volume as a file whose name is the
+key and content is the value. If specified, the listed keys will be
+projected into the specified paths, and unlisted keys will not be
+present. If a key is specified which is not present in the ConfigMap,
+the volume setup will error unless it is marked optional. Paths must be
+relative and may not contain the '..' path or start with '..'.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14427,14 +16980,22 @@ Maps a string key to a path within a volume.
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.<br/>
+          path is the relative path of the file to map the key to.
+May not be an absolute path.
+May not contain the path element '..'.
+May not start with the string '..'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          mode is Optional: mode bits used to set permissions on this file.
+Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+If not specified, the volume defaultMode will be used.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -14504,7 +17065,12 @@ DownwardAPIVolumeFile represents information to create the file containing the p
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          Optional: mode bits used to set permissions on this file, must be an octal value
+between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+If not specified, the volume defaultMode will be used.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -14513,7 +17079,8 @@ DownwardAPIVolumeFile represents information to create the file containing the p
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexdownwardapiitemsindexresourcefieldref">resourceFieldRef</a></b></td>
         <td>object</td>
         <td>
-          Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.<br/>
+          Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14559,7 +17126,8 @@ Required: Selects a field of the pod: only annotations, labels, name and namespa
 
 
 
-Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+Selects a resource of the container: only resources limits and requests
+(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
 
 <table>
     <thead>
@@ -14615,14 +17183,22 @@ secret information about the secret data to project
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexprojectedsourcesindexsecretitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.<br/>
+          items if unspecified, each key-value pair in the Data field of the referenced
+Secret will be projected into the volume as a file whose name is the
+key and content is the value. If specified, the listed keys will be
+projected into the specified paths, and unlisted keys will not be
+present. If a key is specified which is not present in the Secret,
+the volume setup will error unless it is marked optional. Paths must be
+relative and may not contain the '..' path or start with '..'.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14663,14 +17239,22 @@ Maps a string key to a path within a volume.
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.<br/>
+          path is the relative path of the file to map the key to.
+May not be an absolute path.
+May not contain the path element '..'.
+May not start with the string '..'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          mode is Optional: mode bits used to set permissions on this file.
+Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+If not specified, the volume defaultMode will be used.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -14699,21 +17283,30 @@ serviceAccountToken is information about the serviceAccountToken data to project
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path is the path relative to the mount point of the file to project the token into.<br/>
+          path is the path relative to the mount point of the file to project the
+token into.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>audience</b></td>
         <td>string</td>
         <td>
-          audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.<br/>
+          audience is the intended audience of the token. A recipient of a token
+must identify itself with an identifier specified in the audience of the
+token, and otherwise should reject the token. The audience defaults to the
+identifier of the apiserver.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>expirationSeconds</b></td>
         <td>integer</td>
         <td>
-          expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.<br/>
+          expirationSeconds is the requested duration of validity of the service
+account token. As the token approaches expiration, the kubelet volume
+plugin will proactively rotate the service account token. The kubelet will
+start trying to rotate the token if the token is older than 80 percent of
+its time to live or if the token is older than 24 hours.Defaults to 1 hour
+and must be at least 10 minutes.<br/>
           <br/>
             <i>Format</i>: int64<br/>
         </td>
@@ -14742,7 +17335,9 @@ quobyte represents a Quobyte mount on the host that shares a pod's lifetime
         <td><b>registry</b></td>
         <td>string</td>
         <td>
-          registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes<br/>
+          registry represents a single or multiple Quobyte Registry services
+specified as a string as host:port pair (multiple entries are separated with commas)
+which acts as the central registry for volumes<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -14756,28 +17351,32 @@ quobyte represents a Quobyte mount on the host that shares a pod's lifetime
         <td><b>group</b></td>
         <td>string</td>
         <td>
-          group to map volume access to Default is no group<br/>
+          group to map volume access to
+Default is no group<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.<br/>
+          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+Defaults to false.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>tenant</b></td>
         <td>string</td>
         <td>
-          tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin<br/>
+          tenant owning the given Quobyte volume in the Backend
+Used with dynamically provisioned Quobyte volumes, value is set by the plugin<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          user to map volume access to Defaults to serivceaccount user<br/>
+          user to map volume access to
+Defaults to serivceaccount user<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14789,7 +17388,8 @@ quobyte represents a Quobyte mount on the host that shares a pod's lifetime
 
 
 
-rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+More info: https://examples.k8s.io/volumes/rbd/README.md
 
 <table>
     <thead>
@@ -14804,56 +17404,73 @@ rbd represents a Rados Block Device mount on the host that shares a pod's lifeti
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
+          image is the rados image name.
+More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>monitors</b></td>
         <td>[]string</td>
         <td>
-          monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
+          monitors is a collection of Ceph monitors.
+More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
+          fsType is the filesystem type of the volume that you want to mount.
+Tip: Ensure that the filesystem type is supported by the host operating system.
+Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+TODO: how do we prevent errors in the filesystem from compromising the machine<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>keyring</b></td>
         <td>string</td>
         <td>
-          keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
+          keyring is the path to key ring for RBDUser.
+Default is /etc/ceph/keyring.
+More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>pool</b></td>
         <td>string</td>
         <td>
-          pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
+          pool is the rados pool name.
+Default is rbd.
+More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
+          readOnly here will force the ReadOnly setting in VolumeMounts.
+Defaults to false.
+More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexrbdsecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
+          secretRef is name of the authentication secret for RBDUser. If provided
+overrides keyring.
+Default is nil.
+More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>user</b></td>
         <td>string</td>
         <td>
-          user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
+          user is the rados user name.
+Default is admin.
+More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14865,7 +17482,10 @@ rbd represents a Rados Block Device mount on the host that shares a pod's lifeti
 
 
 
-secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+secretRef is name of the authentication secret for RBDUser. If provided
+overrides keyring.
+Default is nil.
+More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
 
 <table>
     <thead>
@@ -14880,7 +17500,9 @@ secretRef is name of the authentication secret for RBDUser. If provided override
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14914,7 +17536,8 @@ scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernete
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexscaleiosecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.<br/>
+          secretRef references to the secret for ScaleIO user and other
+sensitive information. If this is not provided, Login operation will fail.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -14928,7 +17551,10 @@ scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernete
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".<br/>
+          fsType is the filesystem type to mount.
+Must be a filesystem type supported by the host operating system.
+Ex. "ext4", "xfs", "ntfs".
+Default is "xfs".<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14942,7 +17568,8 @@ scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernete
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
+          readOnly Defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14956,7 +17583,8 @@ scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernete
         <td><b>storageMode</b></td>
         <td>string</td>
         <td>
-          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.<br/>
+          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+Default is ThinProvisioned.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -14970,7 +17598,8 @@ scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernete
         <td><b>volumeName</b></td>
         <td>string</td>
         <td>
-          volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.<br/>
+          volumeName is the name of a volume already created in the ScaleIO system
+that is associated with this volume source.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -14982,7 +17611,8 @@ scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernete
 
 
 
-secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+secretRef references to the secret for ScaleIO user and other
+sensitive information. If this is not provided, Login operation will fail.
 
 <table>
     <thead>
@@ -14997,7 +17627,9 @@ secretRef references to the secret for ScaleIO user and other sensitive informat
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15009,7 +17641,8 @@ secretRef references to the secret for ScaleIO user and other sensitive informat
 
 
 
-secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+secret represents a secret that should populate this volume.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
 
 <table>
     <thead>
@@ -15024,7 +17657,13 @@ secret represents a secret that should populate this volume. More info: https://
         <td><b>defaultMode</b></td>
         <td>integer</td>
         <td>
-          defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          defaultMode is Optional: mode bits used to set permissions on created files by default.
+Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values
+for mode bits. Defaults to 0644.
+Directories within the path are not affected by this setting.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -15033,7 +17672,13 @@ secret represents a secret that should populate this volume. More info: https://
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexsecretitemsindex">items</a></b></td>
         <td>[]object</td>
         <td>
-          items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.<br/>
+          items If unspecified, each key-value pair in the Data field of the referenced
+Secret will be projected into the volume as a file whose name is the
+key and content is the value. If specified, the listed keys will be
+projected into the specified paths, and unlisted keys will not be
+present. If a key is specified which is not present in the Secret,
+the volume setup will error unless it is marked optional. Paths must be
+relative and may not contain the '..' path or start with '..'.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15047,7 +17692,8 @@ secret represents a secret that should populate this volume. More info: https://
         <td><b>secretName</b></td>
         <td>string</td>
         <td>
-          secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret<br/>
+          secretName is the name of the secret in the pod's namespace to use.
+More info: https://kubernetes.io/docs/concepts/storage/volumes#secret<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15081,14 +17727,22 @@ Maps a string key to a path within a volume.
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.<br/>
+          path is the relative path of the file to map the key to.
+May not be an absolute path.
+May not contain the path element '..'.
+May not start with the string '..'.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>mode</b></td>
         <td>integer</td>
         <td>
-          mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.<br/>
+          mode is Optional: mode bits used to set permissions on this file.
+Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+If not specified, the volume defaultMode will be used.
+This might be in conflict with other options that affect the file
+mode, like fsGroup, and the result can be other mode bits set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -15117,35 +17771,45 @@ storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
+          fsType is the filesystem type to mount.
+Must be a filesystem type supported by the host operating system.
+Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>readOnly</b></td>
         <td>boolean</td>
         <td>
-          readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.<br/>
+          readOnly defaults to false (read/write). ReadOnly here will force
+the ReadOnly setting in VolumeMounts.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecdeploymentspectemplatespecvolumesindexstorageossecretref">secretRef</a></b></td>
         <td>object</td>
         <td>
-          secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.<br/>
+          secretRef specifies the secret to use for obtaining the StorageOS API
+credentials.  If not specified, default values will be attempted.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeName</b></td>
         <td>string</td>
         <td>
-          volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.<br/>
+          volumeName is the human-readable name of the StorageOS volume.  Volume
+names are only unique within a namespace.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>volumeNamespace</b></td>
         <td>string</td>
         <td>
-          volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.<br/>
+          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+namespace is specified then the Pod's namespace will be used.  This allows the
+Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+Set VolumeName to any name to override the default behaviour.
+Set to "default" if you are not using namespaces within StorageOS.
+Namespaces that do not pre-exist within StorageOS will be created.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15157,7 +17821,8 @@ storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes
 
 
 
-secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+secretRef specifies the secret to use for obtaining the StorageOS API
+credentials.  If not specified, default values will be attempted.
 
 <table>
     <thead>
@@ -15172,7 +17837,9 @@ secretRef specifies the secret to use for obtaining the StorageOS API credential
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15206,7 +17873,9 @@ vsphereVolume represents a vSphere volume attached and mounted on kubelets host 
         <td><b>fsType</b></td>
         <td>string</td>
         <td>
-          fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
+          fsType is filesystem type to mount.
+Must be a filesystem type supported by the host operating system.
+Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15302,7 +17971,9 @@ AdminPassword key to talk to the external grafana instance.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15343,7 +18014,9 @@ AdminUser key to talk to the external grafana instance.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15384,7 +18057,9 @@ The API key to talk to the external grafana instance, you need to define ether a
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -15486,28 +18161,45 @@ IngressSpec describes the Ingress the user wishes to exist.
         <td><b><a href="#grafanaspecingressspecdefaultbackend">defaultBackend</a></b></td>
         <td>object</td>
         <td>
-          defaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller.<br/>
+          defaultBackend is the backend that should handle requests that don't
+match any rule. If Rules are not specified, DefaultBackend must be specified.
+If DefaultBackend is not set, the handling of requests that do not match any
+of the rules will be up to the Ingress controller.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>ingressClassName</b></td>
         <td>string</td>
         <td>
-          ingressClassName is the name of an IngressClass cluster resource. Ingress controller implementations use this field to know whether they should be serving this Ingress resource, by a transitive connection (controller -> IngressClass -> Ingress resource). Although the `kubernetes.io/ingress.class` annotation (simple constant name) was never formally defined, it was widely supported by Ingress controllers to create a direct binding between Ingress controller and Ingress resources. Newly created Ingress resources should prefer using the field. However, even though the annotation is officially deprecated, for backwards compatibility reasons, ingress controllers should still honor that annotation if present.<br/>
+          ingressClassName is the name of an IngressClass cluster resource. Ingress
+controller implementations use this field to know whether they should be
+serving this Ingress resource, by a transitive connection
+(controller -> IngressClass -> Ingress resource). Although the
+`kubernetes.io/ingress.class` annotation (simple constant name) was never
+formally defined, it was widely supported by Ingress controllers to create
+a direct binding between Ingress controller and Ingress resources. Newly
+created Ingress resources should prefer using the field. However, even
+though the annotation is officially deprecated, for backwards compatibility
+reasons, ingress controllers should still honor that annotation if present.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecingressspecrulesindex">rules</a></b></td>
         <td>[]object</td>
         <td>
-          rules is a list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.<br/>
+          rules is a list of host rules used to configure the Ingress. If unspecified,
+or no rule matches, all traffic is sent to the default backend.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecingressspectlsindex">tls</a></b></td>
         <td>[]object</td>
         <td>
-          tls represents the TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.<br/>
+          tls represents the TLS configuration. Currently the Ingress only supports a
+single TLS port, 443. If multiple members of this list specify different hosts,
+they will be multiplexed on the same port according to the hostname specified
+through the SNI TLS extension, if the ingress controller fulfilling the
+ingress supports SNI.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15519,7 +18211,10 @@ IngressSpec describes the Ingress the user wishes to exist.
 
 
 
-defaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller.
+defaultBackend is the backend that should handle requests that don't
+match any rule. If Rules are not specified, DefaultBackend must be specified.
+If DefaultBackend is not set, the handling of requests that do not match any
+of the rules will be up to the Ingress controller.
 
 <table>
     <thead>
@@ -15534,14 +18229,18 @@ defaultBackend is the backend that should handle requests that don't match any r
         <td><b><a href="#grafanaspecingressspecdefaultbackendresource">resource</a></b></td>
         <td>object</td>
         <td>
-          resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".<br/>
+          resource is an ObjectRef to another Kubernetes resource in the namespace
+of the Ingress object. If resource is specified, a service.Name and
+service.Port must not be specified.
+This is a mutually exclusive setting with "Service".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecingressspecdefaultbackendservice">service</a></b></td>
         <td>object</td>
         <td>
-          service references a service as a backend. This is a mutually exclusive setting with "Resource".<br/>
+          service references a service as a backend.
+This is a mutually exclusive setting with "Resource".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15553,7 +18252,10 @@ defaultBackend is the backend that should handle requests that don't match any r
 
 
 
-resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
+resource is an ObjectRef to another Kubernetes resource in the namespace
+of the Ingress object. If resource is specified, a service.Name and
+service.Port must not be specified.
+This is a mutually exclusive setting with "Service".
 
 <table>
     <thead>
@@ -15582,7 +18284,9 @@ resource is an ObjectRef to another Kubernetes resource in the namespace of the 
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
+          APIGroup is the group for the resource being referenced.
+If APIGroup is not specified, the specified Kind must be in the core API group.
+For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15594,7 +18298,8 @@ resource is an ObjectRef to another Kubernetes resource in the namespace of the 
 
 
 
-service references a service as a backend. This is a mutually exclusive setting with "Resource".
+service references a service as a backend.
+This is a mutually exclusive setting with "Resource".
 
 <table>
     <thead>
@@ -15609,14 +18314,16 @@ service references a service as a backend. This is a mutually exclusive setting 
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          name is the referenced service. The service must exist in the same namespace as the Ingress object.<br/>
+          name is the referenced service. The service must exist in
+the same namespace as the Ingress object.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#grafanaspecingressspecdefaultbackendserviceport">port</a></b></td>
         <td>object</td>
         <td>
-          port of the referenced service. A port name or port number is required for a IngressServiceBackend.<br/>
+          port of the referenced service. A port name or port number
+is required for a IngressServiceBackend.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15628,7 +18335,8 @@ service references a service as a backend. This is a mutually exclusive setting 
 
 
 
-port of the referenced service. A port name or port number is required for a IngressServiceBackend.
+port of the referenced service. A port name or port number
+is required for a IngressServiceBackend.
 
 <table>
     <thead>
@@ -15643,14 +18351,16 @@ port of the referenced service. A port name or port number is required for a Ing
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          name is the name of the port on the Service. This is a mutually exclusive setting with "Number".<br/>
+          name is the name of the port on the Service.
+This is a mutually exclusive setting with "Number".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>number</b></td>
         <td>integer</td>
         <td>
-          number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".<br/>
+          number is the numerical port number (e.g. 80) on the Service.
+This is a mutually exclusive setting with "Name".<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -15664,7 +18374,9 @@ port of the referenced service. A port name or port number is required for a Ing
 
 
 
-IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+IngressRule represents the rules mapping the paths under a specified host to
+the related backend services. Incoming requests are first evaluated for a host
+match, then routed to the backend associated with the matching IngressRuleValue.
 
 <table>
     <thead>
@@ -15679,15 +18391,40 @@ IngressRule represents the rules mapping the paths under a specified host to the
         <td><b>host</b></td>
         <td>string</td>
         <td>
-          host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in RFC 3986: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the IP in the Spec of the parent Ingress. 2. The `:` delimiter is not respected because ports are not allowed. Currently the port of an Ingress is implicitly :80 for http and :443 for https. Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue. 
- host can be "precise" which is a domain name without the terminating dot of a network host (e.g. "foo.bar.com") or "wildcard", which is a domain name prefixed with a single wildcard label (e.g. "*.foo.com"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == "*"). Requests will be matched against the Host field in the following way: 1. If host is precise, the request matches this rule if the http host header is equal to Host. 2. If host is a wildcard, then the request matches this rule if the http host header is to equal to the suffix (removing the first label) of the wildcard rule.<br/>
+          host is the fully qualified domain name of a network host, as defined by RFC 3986.
+Note the following deviations from the "host" part of the
+URI as defined in RFC 3986:
+1. IPs are not allowed. Currently an IngressRuleValue can only apply to
+   the IP in the Spec of the parent Ingress.
+2. The `:` delimiter is not respected because ports are not allowed.
+	  Currently the port of an Ingress is implicitly :80 for http and
+	  :443 for https.
+Both these may change in the future.
+Incoming requests are matched against the host before the
+IngressRuleValue. If the host is unspecified, the Ingress routes all
+traffic based on the specified IngressRuleValue.
+
+
+host can be "precise" which is a domain name without the terminating dot of
+a network host (e.g. "foo.bar.com") or "wildcard", which is a domain name
+prefixed with a single wildcard label (e.g. "*.foo.com").
+The wildcard character '*' must appear by itself as the first DNS label and
+matches only a single label. You cannot have a wildcard label by itself (e.g. Host == "*").
+Requests will be matched against the Host field in the following way:
+1. If host is precise, the request matches this rule if the http host header is equal to Host.
+2. If host is a wildcard, then the request matches this rule if the http host header
+is to equal to the suffix (removing the first label) of the wildcard rule.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecingressspecrulesindexhttp">http</a></b></td>
         <td>object</td>
         <td>
-          HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.<br/>
+          HTTPIngressRuleValue is a list of http selectors pointing to backends.
+In the example: http://<host>/<path>?<searchpart> -> backend where
+where parts of the url correspond to RFC 3986, this resource will be used
+to match against everything after the last '/' and before the first '?'
+or '#'.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15699,7 +18436,11 @@ IngressRule represents the rules mapping the paths under a specified host to the
 
 
 
-HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.
+HTTPIngressRuleValue is a list of http selectors pointing to backends.
+In the example: http://<host>/<path>?<searchpart> -> backend where
+where parts of the url correspond to RFC 3986, this resource will be used
+to match against everything after the last '/' and before the first '?'
+or '#'.
 
 <table>
     <thead>
@@ -15726,7 +18467,8 @@ HTTPIngressRuleValue is a list of http selectors pointing to backends. In the ex
 
 
 
-HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
+HTTPIngressPath associates a path with a backend. Incoming urls matching the
+path are forwarded to the backend.
 
 <table>
     <thead>
@@ -15741,21 +18483,38 @@ HTTPIngressPath associates a path with a backend. Incoming urls matching the pat
         <td><b><a href="#grafanaspecingressspecrulesindexhttppathsindexbackend">backend</a></b></td>
         <td>object</td>
         <td>
-          backend defines the referenced service endpoint to which the traffic will be forwarded to.<br/>
+          backend defines the referenced service endpoint to which the traffic
+will be forwarded to.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>pathType</b></td>
         <td>string</td>
         <td>
-          pathType determines the interpretation of the path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is done on a path element by element basis. A path element refers is the list of labels in the path split by the '/' separator. A request is a match for path p if every p is an element-wise prefix of p of the request path. Note that if the last element of the path is a substring of the last element in request path, it is not a match (e.g. /foo/bar matches /foo/bar/baz, but does not match /foo/barbaz). * ImplementationSpecific: Interpretation of the Path matching is up to the IngressClass. Implementations can treat this as a separate PathType or treat it identically to Prefix or Exact path types. Implementations are required to support all path types.<br/>
+          pathType determines the interpretation of the path matching. PathType can
+be one of the following values:
+* Exact: Matches the URL path exactly.
+* Prefix: Matches based on a URL path prefix split by '/'. Matching is
+  done on a path element by element basis. A path element refers is the
+  list of labels in the path split by the '/' separator. A request is a
+  match for path p if every p is an element-wise prefix of p of the
+  request path. Note that if the last element of the path is a substring
+  of the last element in request path, it is not a match (e.g. /foo/bar
+  matches /foo/bar/baz, but does not match /foo/barbaz).
+* ImplementationSpecific: Interpretation of the Path matching is up to
+  the IngressClass. Implementations can treat this as a separate PathType
+  or treat it identically to Prefix or Exact path types.
+Implementations are required to support all path types.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>path</b></td>
         <td>string</td>
         <td>
-          path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/' and must be present when using PathType with value "Exact" or "Prefix".<br/>
+          path is matched against the path of an incoming request. Currently it can
+contain characters disallowed from the conventional "path" part of a URL
+as defined by RFC 3986. Paths must begin with a '/' and must be present
+when using PathType with value "Exact" or "Prefix".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15767,7 +18526,8 @@ HTTPIngressPath associates a path with a backend. Incoming urls matching the pat
 
 
 
-backend defines the referenced service endpoint to which the traffic will be forwarded to.
+backend defines the referenced service endpoint to which the traffic
+will be forwarded to.
 
 <table>
     <thead>
@@ -15782,14 +18542,18 @@ backend defines the referenced service endpoint to which the traffic will be for
         <td><b><a href="#grafanaspecingressspecrulesindexhttppathsindexbackendresource">resource</a></b></td>
         <td>object</td>
         <td>
-          resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".<br/>
+          resource is an ObjectRef to another Kubernetes resource in the namespace
+of the Ingress object. If resource is specified, a service.Name and
+service.Port must not be specified.
+This is a mutually exclusive setting with "Service".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecingressspecrulesindexhttppathsindexbackendservice">service</a></b></td>
         <td>object</td>
         <td>
-          service references a service as a backend. This is a mutually exclusive setting with "Resource".<br/>
+          service references a service as a backend.
+This is a mutually exclusive setting with "Resource".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15801,7 +18565,10 @@ backend defines the referenced service endpoint to which the traffic will be for
 
 
 
-resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
+resource is an ObjectRef to another Kubernetes resource in the namespace
+of the Ingress object. If resource is specified, a service.Name and
+service.Port must not be specified.
+This is a mutually exclusive setting with "Service".
 
 <table>
     <thead>
@@ -15830,7 +18597,9 @@ resource is an ObjectRef to another Kubernetes resource in the namespace of the 
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
+          APIGroup is the group for the resource being referenced.
+If APIGroup is not specified, the specified Kind must be in the core API group.
+For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15842,7 +18611,8 @@ resource is an ObjectRef to another Kubernetes resource in the namespace of the 
 
 
 
-service references a service as a backend. This is a mutually exclusive setting with "Resource".
+service references a service as a backend.
+This is a mutually exclusive setting with "Resource".
 
 <table>
     <thead>
@@ -15857,14 +18627,16 @@ service references a service as a backend. This is a mutually exclusive setting 
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          name is the referenced service. The service must exist in the same namespace as the Ingress object.<br/>
+          name is the referenced service. The service must exist in
+the same namespace as the Ingress object.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b><a href="#grafanaspecingressspecrulesindexhttppathsindexbackendserviceport">port</a></b></td>
         <td>object</td>
         <td>
-          port of the referenced service. A port name or port number is required for a IngressServiceBackend.<br/>
+          port of the referenced service. A port name or port number
+is required for a IngressServiceBackend.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15876,7 +18648,8 @@ service references a service as a backend. This is a mutually exclusive setting 
 
 
 
-port of the referenced service. A port name or port number is required for a IngressServiceBackend.
+port of the referenced service. A port name or port number
+is required for a IngressServiceBackend.
 
 <table>
     <thead>
@@ -15891,14 +18664,16 @@ port of the referenced service. A port name or port number is required for a Ing
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          name is the name of the port on the Service. This is a mutually exclusive setting with "Number".<br/>
+          name is the name of the port on the Service.
+This is a mutually exclusive setting with "Number".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>number</b></td>
         <td>integer</td>
         <td>
-          number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".<br/>
+          number is the numerical port number (e.g. 80) on the Service.
+This is a mutually exclusive setting with "Name".<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -15927,14 +18702,21 @@ IngressTLS describes the transport layer security associated with an ingress.
         <td><b>hosts</b></td>
         <td>[]string</td>
         <td>
-          hosts is a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.<br/>
+          hosts is a list of hosts included in the TLS certificate. The values in
+this list must match the name/s used in the tlsSecret. Defaults to the
+wildcard host setting for the loadbalancer controller fulfilling this
+Ingress, if left unspecified.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>secretName</b></td>
         <td>string</td>
         <td>
-          secretName is the name of the secret used to terminate TLS traffic on port 443. Field is left optional to allow TLS routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the "Host" header is used for routing.<br/>
+          secretName is the name of the secret used to terminate TLS traffic on
+port 443. Field is left optional to allow TLS routing based on SNI
+hostname alone. If the SNI host in a listener conflicts with the "Host"
+header field used by an IngressRule, the SNI host is used for termination
+and value of the "Host" header is used for routing.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15961,7 +18743,9 @@ IngressTLS describes the transport layer security associated with an ingress.
         <td><b><a href="#grafanaspecjsonnetlibrarylabelselector">libraryLabelSelector</a></b></td>
         <td>object</td>
         <td>
-          A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.<br/>
+          A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -15973,7 +18757,9 @@ IngressTLS describes the transport layer security associated with an ingress.
 
 
 
-A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.
 
 <table>
     <thead>
@@ -15995,7 +18781,9 @@ A label selector is a label query over a set of resources. The result of matchLa
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -16007,7 +18795,8 @@ A label selector is a label query over a set of resources. The result of matchLa
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -16029,14 +18818,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -16138,14 +18931,16 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
         <td><b><a href="#grafanaspecpersistentvolumeclaimspecdatasource">dataSource</a></b></td>
         <td>object</td>
         <td>
-          TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.<br/>
+          TypedLocalObjectReference contains enough information to let you locate the
+typed referenced object inside the same namespace.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecpersistentvolumeclaimspecdatasourceref">dataSourceRef</a></b></td>
         <td>object</td>
         <td>
-          TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.<br/>
+          TypedLocalObjectReference contains enough information to let you locate the
+typed referenced object inside the same namespace.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16159,7 +18954,9 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
         <td><b><a href="#grafanaspecpersistentvolumeclaimspecselector">selector</a></b></td>
         <td>object</td>
         <td>
-          A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.<br/>
+          A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16192,7 +18989,8 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
 
 
 
-TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
+TypedLocalObjectReference contains enough information to let you locate the
+typed referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -16221,7 +19019,9 @@ TypedLocalObjectReference contains enough information to let you locate the type
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
+          APIGroup is the group for the resource being referenced.
+If APIGroup is not specified, the specified Kind must be in the core API group.
+For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -16233,7 +19033,8 @@ TypedLocalObjectReference contains enough information to let you locate the type
 
 
 
-TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
+TypedLocalObjectReference contains enough information to let you locate the
+typed referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -16262,7 +19063,9 @@ TypedLocalObjectReference contains enough information to let you locate the type
         <td><b>apiGroup</b></td>
         <td>string</td>
         <td>
-          APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.<br/>
+          APIGroup is the group for the resource being referenced.
+If APIGroup is not specified, the specified Kind must be in the core API group.
+For any other third-party types, APIGroup is required.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -16289,23 +19092,33 @@ ResourceRequirements describes the compute resource requirements.
         <td><b><a href="#grafanaspecpersistentvolumeclaimspecresourcesclaimsindex">claims</a></b></td>
         <td>[]object</td>
         <td>
-          Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.<br/>
+          Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+
+This field is immutable. It can only be set for containers.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>limits</b></td>
         <td>map[string]int or string</td>
         <td>
-          Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>requests</b></td>
         <td>map[string]int or string</td>
         <td>
-          Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -16332,7 +19145,9 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.<br/>
+          Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -16344,7 +19159,9 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
 
 
 
-A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.
 
 <table>
     <thead>
@@ -16366,7 +19183,9 @@ A label selector is a label query over a set of resources. The result of matchLa
         <td><b>matchLabels</b></td>
         <td>map[string]string</td>
         <td>
-          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
+          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+map is equivalent to an element of matchExpressions, whose key field is "key", the
+operator is "In", and the values array contains only "value". The requirements are ANDed.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -16378,7 +19197,8 @@ A label selector is a label query over a set of resources. The result of matchLa
 
 
 
-A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+A label selector requirement is a selector that contains values, a key, and an operator that
+relates the key and values.
 
 <table>
     <thead>
@@ -16400,14 +19220,18 @@ A label selector requirement is a selector that contains values, a key, and an o
         <td><b>operator</b></td>
         <td>string</td>
         <td>
-          operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
+          operator represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists and DoesNotExist.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>values</b></td>
         <td>[]string</td>
         <td>
-          values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.<br/>
+          values is an array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. This array is replaced during a strategic
+merge patch.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -16564,7 +19388,8 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
         <td><b><a href="#grafanaspecroutespecto">to</a></b></td>
         <td>object</td>
         <td>
-          RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.<br/>
+          RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service'
+kind is allowed. Use 'weight' field to emphasize one over others.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16583,7 +19408,8 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
 
 
 
-RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.
+RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service'
+kind is allowed. Use 'weight' field to emphasize one over others.
 
 <table>
     <thead>
@@ -16612,7 +19438,8 @@ RouteTargetReference specifies the target that resolve into endpoints. Only the 
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.<br/>
+          weight as an integer between 0 and 256, default 100, that specifies the target's relative weight
+against other target reference objects. 0 suppresses requests to this backend.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -16641,7 +19468,9 @@ RoutePort defines a port mapping from a router to an endpoint in the service end
         <td><b>targetPort</b></td>
         <td>int or string</td>
         <td>
-          The target port on pods selected by the service this route points to. If this is a string, it will be looked up as a named port in the target endpoints port list. Required<br/>
+          The target port on pods selected by the service this route points to.
+If this is a string, it will be looked up as a named port in the target
+endpoints port list. Required<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -16689,15 +19518,24 @@ TLSConfig defines config used to secure a route and provide termination
         <td><b>destinationCACertificate</b></td>
         <td>string</td>
         <td>
-          destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.<br/>
+          destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt
+termination this file should be provided in order to have routers use it for health checks on the secure connection.
+If this field is not specified, the router may provide its own destination CA and perform hostname validation using
+the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically
+verify.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>insecureEdgeTerminationPolicy</b></td>
         <td>string</td>
         <td>
-          insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. 
- * Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.<br/>
+          insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
+each router may make its own decisions on which ports to expose, this is normally port 80.
+
+
+* Allow - traffic is sent to the server on the insecure port (default)
+* Disable - no traffic is allowed on the insecure port.
+* Redirect - clients are redirected to the secure port.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16716,7 +19554,8 @@ TLSConfig defines config used to secure a route and provide termination
 
 
 
-RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.
+RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service'
+kind is allowed. Use 'weight' field to emphasize one over others.
 
 <table>
     <thead>
@@ -16745,7 +19584,8 @@ RouteTargetReference specifies the target that resolve into endpoints. Only the 
         <td><b>weight</b></td>
         <td>integer</td>
         <td>
-          weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.<br/>
+          weight as an integer between 0 and 256, default 100, that specifies the target's relative weight
+against other target reference objects. 0 suppresses requests to this backend.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -16842,50 +19682,120 @@ ServiceSpec describes the attributes that a user creates on a service.
         <td><b>allocateLoadBalancerNodePorts</b></td>
         <td>boolean</td>
         <td>
-          allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.<br/>
+          allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+allocated for services with type LoadBalancer.  Default is "true". It
+may be set to "false" if the cluster load-balancer does not rely on
+NodePorts.  If the caller requests specific NodePorts (by specifying a
+value), those requests will be respected, regardless of this field.
+This field may only be set for services with type LoadBalancer and will
+be cleared if the type is changed to any other type.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>clusterIP</b></td>
         <td>string</td>
         <td>
-          clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
+          clusterIP is the IP address of the service and is usually assigned
+randomly. If an address is specified manually, is in-range (as per
+system configuration), and is not in use, it will be allocated to the
+service; otherwise creation of the service will fail. This field may not
+be changed through updates unless the type field is also being changed
+to ExternalName (which requires this field to be blank) or the type
+field is being changed from ExternalName (in which case this field may
+optionally be specified, as describe above).  Valid values are "None",
+empty string (""), or a valid IP address. Setting this to "None" makes a
+"headless service" (no virtual IP), which is useful when direct endpoint
+connections are preferred and proxying is not required.  Only applies to
+types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+when creating a Service of type ExternalName, creation will fail. This
+field will be wiped when updating a Service to type ExternalName.
+More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>clusterIPs</b></td>
         <td>[]string</td>
         <td>
-          ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. 
- This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
+          ClusterIPs is a list of IP addresses assigned to this service, and are
+usually assigned randomly.  If an address is specified manually, is
+in-range (as per system configuration), and is not in use, it will be
+allocated to the service; otherwise creation of the service will fail.
+This field may not be changed through updates unless the type field is
+also being changed to ExternalName (which requires this field to be
+empty) or the type field is being changed from ExternalName (in which
+case this field may optionally be specified, as describe above).  Valid
+values are "None", empty string (""), or a valid IP address.  Setting
+this to "None" makes a "headless service" (no virtual IP), which is
+useful when direct endpoint connections are preferred and proxying is
+not required.  Only applies to types ClusterIP, NodePort, and
+LoadBalancer. If this field is specified when creating a Service of type
+ExternalName, creation will fail. This field will be wiped when updating
+a Service to type ExternalName.  If this field is not specified, it will
+be initialized from the clusterIP field.  If this field is specified,
+clients must ensure that clusterIPs[0] and clusterIP have the same
+value.
+
+
+This field may hold a maximum of two entries (dual-stack IPs, in either order).
+These IPs must correspond to the values of the ipFamilies field. Both
+clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>externalIPs</b></td>
         <td>[]string</td>
         <td>
-          externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.<br/>
+          externalIPs is a list of IP addresses for which nodes in the cluster
+will also accept traffic for this service.  These IPs are not managed by
+Kubernetes.  The user is responsible for ensuring that traffic arrives
+at a node with this IP.  A common example is external load-balancers
+that are not part of the Kubernetes system.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>externalName</b></td>
         <td>string</td>
         <td>
-          externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".<br/>
+          externalName is the external reference that discovery mechanisms will
+return as an alias for this service (e.g. a DNS CNAME record). No
+proxying will be involved.  Must be a lowercase RFC-1123 hostname
+(https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>externalTrafficPolicy</b></td>
         <td>string</td>
         <td>
-          externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.<br/>
+          externalTrafficPolicy describes how nodes distribute service traffic they
+receive on one of the Service's "externally-facing" addresses (NodePorts,
+ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+the service in a way that assumes that external load balancers will take care
+of balancing the service traffic between nodes, and so each node will deliver
+traffic only to the node-local endpoints of the service, without masquerading
+the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+be dropped.) The default value, "Cluster", uses the standard behavior of
+routing to all endpoints evenly (possibly modified by topology and other
+features). Note that traffic sent to an External IP or LoadBalancer IP from
+within the cluster will always get "Cluster" semantics, but clients sending to
+a NodePort from within the cluster may need to take traffic policy into account
+when picking a node.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>healthCheckNodePort</b></td>
         <td>integer</td>
         <td>
-          healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.<br/>
+          healthCheckNodePort specifies the healthcheck nodePort for the service.
+This only applies when type is set to LoadBalancer and
+externalTrafficPolicy is set to Local. If a value is specified, is
+in-range, and is not in use, it will be used.  If not specified, a value
+will be automatically allocated.  External systems (e.g. load-balancers)
+can use this port to determine if a given node holds endpoints for this
+service or not.  If this field is specified when creating a Service
+which does not need it, creation will fail. This field will be wiped
+when updating a Service to no longer need it (e.g. changing type).
+This field cannot be updated once set.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -16894,71 +19804,133 @@ ServiceSpec describes the attributes that a user creates on a service.
         <td><b>internalTrafficPolicy</b></td>
         <td>string</td>
         <td>
-          InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).<br/>
+          InternalTrafficPolicy describes how nodes distribute service traffic they
+receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+only want to talk to endpoints of the service on the same node as the pod,
+dropping the traffic if there are no local endpoints. The default value,
+"Cluster", uses the standard behavior of routing to all endpoints evenly
+(possibly modified by topology and other features).<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>ipFamilies</b></td>
         <td>[]string</td>
         <td>
-          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName. 
- This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.<br/>
+          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+service. This field is usually assigned automatically based on cluster
+configuration and the ipFamilyPolicy field. If this field is specified
+manually, the requested family is available in the cluster,
+and ipFamilyPolicy allows it, it will be used; otherwise creation of
+the service will fail. This field is conditionally mutable: it allows
+for adding or removing a secondary IP family, but it does not allow
+changing the primary IP family of the Service. Valid values are "IPv4"
+and "IPv6".  This field only applies to Services of types ClusterIP,
+NodePort, and LoadBalancer, and does apply to "headless" services.
+This field will be wiped when updating a Service to type ExternalName.
+
+
+This field may hold a maximum of two entries (dual-stack families, in
+either order).  These families must correspond to the values of the
+clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+governed by the ipFamilyPolicy field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>ipFamilyPolicy</b></td>
         <td>string</td>
         <td>
-          IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.<br/>
+          IPFamilyPolicy represents the dual-stack-ness requested or required by
+this Service. If there is no value provided, then this field will be set
+to SingleStack. Services can be "SingleStack" (a single IP family),
+"PreferDualStack" (two IP families on dual-stack configured clusters or
+a single IP family on single-stack clusters), or "RequireDualStack"
+(two IP families on dual-stack configured clusters, otherwise fail). The
+ipFamilies and clusterIPs fields depend on the value of this field. This
+field will be wiped when updating a service to type ExternalName.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>loadBalancerClass</b></td>
         <td>string</td>
         <td>
-          loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.<br/>
+          loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+If specified, the value of this field must be a label-style identifier, with an optional prefix,
+e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+balancer implementation is used, today this is typically done through the cloud provider integration,
+but should apply for any default implementation. If set, it is assumed that a load balancer
+implementation is watching for Services with a matching class. Any default load balancer
+implementation (e.g. cloud providers) should ignore Services that set this field.
+This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>loadBalancerIP</b></td>
         <td>string</td>
         <td>
-          Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations. Using it is non-portable and it may not support dual-stack. Users are encouraged to use implementation-specific annotations when available.<br/>
+          Only applies to Service Type: LoadBalancer.
+This feature depends on whether the underlying cloud-provider supports specifying
+the loadBalancerIP when a load balancer is created.
+This field will be ignored if the cloud-provider does not support the feature.
+Deprecated: This field was under-specified and its meaning varies across implementations.
+Using it is non-portable and it may not support dual-stack.
+Users are encouraged to use implementation-specific annotations when available.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>loadBalancerSourceRanges</b></td>
         <td>[]string</td>
         <td>
-          If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/<br/>
+          If specified and supported by the platform, this will restrict traffic through the cloud-provider
+load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+cloud-provider does not support the feature."
+More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#grafanaspecservicespecportsindex">ports</a></b></td>
         <td>[]object</td>
         <td>
-          The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
+          The list of ports that are exposed by this service.
+More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>publishNotReadyAddresses</b></td>
         <td>boolean</td>
         <td>
-          publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.<br/>
+          publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+Service should disregard any indications of ready/not-ready.
+The primary use case for setting this field is for a StatefulSet's Headless Service to
+propagate SRV DNS records for its Pods for the purpose of peer discovery.
+The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+Services interpret this to mean that all endpoints are considered "ready" even if the
+Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+through the Endpoints or EndpointSlice resources can safely assume this behavior.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>selector</b></td>
         <td>map[string]string</td>
         <td>
-          Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/<br/>
+          Route service traffic to pods with label keys and values matching this
+selector. If empty or not present, the service is assumed to have an
+external process managing its endpoints, which Kubernetes will not
+modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+Ignored if type is ExternalName.
+More info: https://kubernetes.io/docs/concepts/services-networking/service/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>sessionAffinity</b></td>
         <td>string</td>
         <td>
-          Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
+          Supports "ClientIP" and "None". Used to maintain session affinity.
+Enable client IP based session affinity.
+Must be ClientIP or None.
+Defaults to None.
+More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -16972,7 +19944,22 @@ ServiceSpec describes the attributes that a user creates on a service.
         <td><b>type</b></td>
         <td>string</td>
         <td>
-          type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types<br/>
+          type determines how the Service is exposed. Defaults to ClusterIP. Valid
+options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+"ClusterIP" allocates a cluster-internal IP address for load-balancing
+to endpoints. Endpoints are determined by the selector or if that is not
+specified, by manual construction of an Endpoints object or
+EndpointSlice objects. If clusterIP is "None", no virtual IP is
+allocated and the endpoints are published as a set of endpoints rather
+than a virtual IP.
+"NodePort" builds on ClusterIP and allocates a port on every node which
+routes to the same endpoints as the clusterIP.
+"LoadBalancer" builds on NodePort and creates an external load-balancer
+(if supported in the current cloud) which routes to the same endpoints
+as the clusterIP.
+"ExternalName" aliases this service to the specified externalName.
+Several other fields do not apply to ExternalName services.
+More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -17008,24 +19995,50 @@ ServicePort contains information on service's port.
         <td><b>appProtocol</b></td>
         <td>string</td>
         <td>
-          The application protocol for this port. This is used as a hint for implementations to offer richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax. Valid values are either: 
- * Un-prefixed protocol names - reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). 
- * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior- * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455 * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455 
- * Other protocols should use implementation-defined prefixed names such as mycompany.com/my-custom-protocol.<br/>
+          The application protocol for this port.
+This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+This field follows standard Kubernetes label syntax.
+Valid values are either:
+
+
+* Un-prefixed protocol names - reserved for IANA standard service names (as per
+RFC-6335 and https://www.iana.org/assignments/service-names).
+
+
+* Kubernetes-defined prefixed names:
+  * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+  * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+  * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+
+* Other protocols should use implementation-defined prefixed names such as
+mycompany.com/my-custom-protocol.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.<br/>
+          The name of this port within the service. This must be a DNS_LABEL.
+All ports within a ServiceSpec must have unique names. When considering
+the endpoints for a Service, this must match the 'name' field in the
+EndpointPort.
+Optional if only one ServicePort is defined on this service.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>nodePort</b></td>
         <td>integer</td>
         <td>
-          The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport<br/>
+          The port on each node on which this service is exposed when type is
+NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+specified, in-range, and not in use it will be used, otherwise the
+operation will fail.  If not specified, a port will be allocated if this
+Service requires one.  If this field is specified when creating a
+Service which does not need it, creation will fail. This field will be
+wiped when updating a Service to no longer need it (e.g. changing type
+from NodePort to ClusterIP).
+More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -17034,7 +20047,8 @@ ServicePort contains information on service's port.
         <td><b>protocol</b></td>
         <td>string</td>
         <td>
-          The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.<br/>
+          The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+Default is TCP.<br/>
           <br/>
             <i>Default</i>: TCP<br/>
         </td>
@@ -17043,7 +20057,14 @@ ServicePort contains information on service's port.
         <td><b>targetPort</b></td>
         <td>int or string</td>
         <td>
-          Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service<br/>
+          Number or name of the port to access on the pods targeted by the service.
+Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+If this is a string, it will be looked up as a named port in the
+target Pod's container ports. If this is not specified, the value
+of the 'port' field is used (an identity map).
+This field is ignored for services with clusterIP=None, and should be
+omitted or set equal to the 'port' field.
+More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -17097,7 +20118,9 @@ clientIP contains the configurations of Client IP based session affinity.
         <td><b>timeoutSeconds</b></td>
         <td>integer</td>
         <td>
-          timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).<br/>
+          timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+Default value is 10800(for 3 hours).<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -17159,7 +20182,8 @@ ServiceAccount sets how the ServiceAccount object should look like with your gra
 
 
 
-LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+LocalObjectReference contains enough information to let you locate the
+referenced object inside the same namespace.
 
 <table>
     <thead>
@@ -17174,7 +20198,9 @@ LocalObjectReference contains enough information to let you locate the reference
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+TODO: Add other useful fields. apiVersion, kind, uid?<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -17220,8 +20246,23 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
 
 
 
-ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. 
- Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+ObjectReference contains enough information to let you inspect or modify the referred object.
+---
+New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+ 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+ 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+    restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+    Those cannot be well described when embedded.
+ 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+ 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+    during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+    and the version of the actual struct is irrelevant.
+ 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+    will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
 
 <table>
     <thead>
@@ -17243,42 +20284,54 @@ ObjectReference contains enough information to let you inspect or modify the ref
         <td><b>fieldPath</b></td>
         <td>string</td>
         <td>
-          If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.<br/>
+          If referring to a piece of an object instead of an entire object, this string
+should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+For example, if the object reference is to a container within a pod, this would take on a value like:
+"spec.containers{name}" (where "name" refers to the name of the container that triggered
+the event) or if no container name is specified "spec.containers[2]" (container with
+index 2 in this pod). This syntax is chosen only to have some well-defined way of
+referencing a part of an object.
+TODO: this design is not final and this field is subject to change in the future.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>kind</b></td>
         <td>string</td>
         <td>
-          Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds<br/>
+          Kind of the referent.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names<br/>
+          Name of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>namespace</b></td>
         <td>string</td>
         <td>
-          Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/<br/>
+          Namespace of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>resourceVersion</b></td>
         <td>string</td>
         <td>
-          Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency<br/>
+          Specific resourceVersion to which this reference is made, if any.
+More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>uid</b></td>
         <td>string</td>
         <td>
-          UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids<br/>
+          UID of the referent.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
This PR supplements #1483.

It resolves two issues around documentation:

- In Makefile, we didn't have a step to regenerate CRDs that are stored in `config/`. Thus, documentation (`api-docs`) did not reflect the latest changes;
- kustomization.yaml in `config/` did not contain a reference to `grafana.integreatly.org_grafanacontactpoints.yaml`, thus it was not included in documentation.

**NOTE:** PR is split into 3 commits to distinguish "human-made" changes from autogenerated files. 