### PR TITLE
chore: categorize dependency updates and other changes in auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Changes
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
Release note of grafana-operator seems to be generated by GitHub's auto-generation feature.
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

It is hard for us to read large number of changes that may contains important changes.
Special attention should be paid when important changes are mixed in with the large number of dependency change logs.

Fortunately, the PRs automatically generated by dependabot are labeled `dependencies`. This could be used to categorize the list of changes in the release notes to reduce the burden on the user.
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options

The release notes should now appear as follows:

```md
## What's Changed

### Changes

- chore: some update by @~~  in #123
- some important changes by @~~ in #456

### Dependencies

- chore(deps): bump ~~ by @dependabot in #789
```

The category titles are tentative, so if you have a good one, please let me know.