### PR TITLE
fix(GrafanaFolder): proper status updates for removed CRs, don't fail on missing folder in onFolderDeleted events 

### DIFF
--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -269,7 +269,7 @@ func (r *GrafanaFolderReconciler) onFolderDeleted(ctx context.Context, namespace
 			_, err = grafanaClient.Folders.DeleteFolder(params) //nolint
 			if err != nil {
 				var notFound *folders.DeleteFolderNotFound
-				if errors.As(err, &notFound) {
+				if !errors.As(err, &notFound) {
 					return err
 				}
 			}
@@ -281,6 +281,7 @@ func (r *GrafanaFolderReconciler) onFolderDeleted(ctx context.Context, namespace
 			}
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Two fixes for `grafanafolder` controller:

- Previously, `onFolderDeleted` would treat a missing folder (e.g. deleted through Grafana UI) as an error, which should have never been the case. - We just overlooked a missing `!` in error handling logic;
- When cleaning up status for CRs that had been deleted, `syncFolders` was supposed to check if a folder still exists in Grafana, but instead of using method for folders, it used one for dashboards.

Two manual test cases to verify the fix:

- `onFolderDeleted`:
  - Steps:
    - deploy `GrafanaFolder` CR (e.g. from `examples/folder`);
    - `Grafana` CR should contain a reference to the folder in `status.folders`;
    - remove the folder from UI;
    - remove the folder CR;
  - Expected results:
    - No errors;
    - No event requeues;
    - `Grafana` CR should no longer contain a reference to the folder in `status.folders`;
- `syncFolders`:
  - Steps:
    - deploy `GrafanaFolder` CR (e.g. from `examples/folder`);
    - `Grafana` CR should contain a reference to the folder in `status.folders`;
    - scale down the operator (`kubectl scale deployment grafana-operator-controller-manager-v5 --replicas 0`);
    - remove the `GrafanaFolder` CR;
    - scale up the operator (`kubectl scale deployment grafana-operator-controller-manager-v5 --replicas 1`);
  - Expected results:
    - No errors;
    - Log message "folder no longer exists";
    - `Grafana` CR should no longer contain a reference to the folder in `status.folders`.

Fixes: #1512