### PR TITLE
fix(GrafanaDashboard): properly finish reconciliation in onDashboardDeleted when dashboard is missing

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,7 +58,7 @@ linters-settings:
     default-signifies-exhaustive: false
 
   nestif:
-    min-complexity: 20
+    min-complexity: 30
 
   goconst:
     min-len: 3


### PR DESCRIPTION
In #1504, we introduced a minor regression:
If a dashboard is deleted outside of the operator (e.g. through Grafana UI), then the operator skips Plugin and Status reconciliations. This PR should fix that.

Manual test case:

- Steps:
  - deploy `GrafanaDashboard` CR (e.g. from `examples/basic`);
  - `Grafana` CR should contain a reference to the dashboard in `status.dashboards`;
  - remove the dashboard from UI;
  - remove the dashboard CR;
- Expected results:
  - No errors / panics;
  - `Grafana` CR should no longer contain a reference to the dashboard in `status.dashboards`.