### PR TITLE
chore(workflows): verify golangci-lint config

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -99,6 +99,10 @@ jobs:
         with:
           version: "v1.56.2"
 
+      - name: Verify golangci-lint config
+        run: |
+          golangci-lint config verify
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v5.0.0
         with:
-          version: "v1.56.2"
+          version: "v1.57.2"
 
       - name: Verify golangci-lint config
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,17 +35,10 @@ linters-settings:
   misspell:
     locale: US
 
-  unused:
-    go: "1.19"
-
   unparam:
     check-exported: true
 
-  govet:
-    check-shadowing: false
-
   gosimple:
-    go: "1.19"
     checks: ["all"]
 
   errorlint:
@@ -88,13 +81,11 @@ linters-settings:
 
   nolintlint:
     allow-unused: false
-    allow-leading-space: true
     allow-no-explanation: []
     require-explanation: false
     require-specific: false
 
   staticcheck:
-    go: "1.19"
     checks: ["all"]
 
   thelper:


### PR DESCRIPTION
`golangci-lint` has a built-in functionality to validate its config for presence of deprecated options. This PR adds a verification step. [Example](https://github.com/grafana/grafana-operator/actions/runs/8957833010/job/24601360787?pr=1518):

<img width="1629" alt="image" src="https://github.com/grafana/grafana-operator/assets/46579601/6ced8389-c226-434c-bdec-a7fa2f576150">

**Additional changes:**
- bump version to `v1.57.2`;
- remove deprecated options (**NOTE**: we no longer need to pin certain linters to specific go versions, it's all detected automatically through `go.mod`).
