### PR TITLE
feat(controllers): make instanceSelector immutable 

### DIFF
--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -33,6 +33,7 @@ type GrafanaAlertRuleGroupSpec struct {
 	ResyncPeriod metav1.Duration `json:"resyncPeriod,omitempty"`
 
 	// selects Grafanas for import
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector"`
 
 	// UID of the folder containing this rule group

--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -34,6 +34,7 @@ type GrafanaContactPointSpec struct {
 	ResyncPeriod metav1.Duration `json:"resyncPeriod,omitempty"`
 
 	// selects Grafanas for import
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector"`
 
 	// +optional

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -78,6 +78,7 @@ type GrafanaDashboardSpec struct {
 	ConfigMapRef *v1.ConfigMapKeySelector `json:"configMapRef,omitempty"`
 
 	// selects Grafanas for import
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector"`
 
 	// folder assignment for dashboard

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -63,6 +63,7 @@ type GrafanaDatasourceSpec struct {
 	Datasource *GrafanaDatasourceInternal `json:"datasource"`
 
 	// selects Grafana instances for import
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector"`
 
 	// plugins

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -37,6 +37,7 @@ type GrafanaFolderSpec struct {
 	Permissions string `json:"permissions,omitempty"`
 
 	// selects Grafanas for import
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	InstanceSelector *metav1.LabelSelector `json:"instanceSelector"`
 
 	// allow to import this resources from an operator in a different namespace

--- a/bundle/manifests/grafana-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/grafana-operator.clusterserviceversion.yaml
@@ -210,13 +210,13 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: ghcr.io/grafana/grafana-operator@sha256:97561cef949b58f55ec67d133c02ac205e2ec3fb77388aeb868dacfcebad0752
-    createdAt: "2024-04-23T12:57:39Z"
+    createdAt: "2024-05-09T08:55:59Z"
     description: Deploys and manages Grafana instances, dashboards and data sources
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/grafana/grafana-operator
     support: Grafana Labs
-  name: grafana-operator.v5.8.1
+  name: grafana-operator.v5.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -510,7 +510,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: ghcr.io/grafana/grafana-operator@sha256:34229f59e1609764196870aa2672aa1b784e88583ec445ff04e810a8333b72a7
+                    image: ghcr.io/grafana/grafana-operator@sha256:48cbc5e4e361e80f27d054fb986762109c199678b12f8b1baf63cfbafc69fc82
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -604,7 +604,7 @@ spec:
   relatedImages:
     - image: docker.io/grafana/grafana@sha256:9a2acaa26a0b302a56d8e113068a1297cf0726fcaff5e6bb77344888e5f1c976
       name: grafana
-    - image: ghcr.io/grafana/grafana-operator@sha256:34229f59e1609764196870aa2672aa1b784e88583ec445ff04e810a8333b72a7
+    - image: ghcr.io/grafana/grafana-operator@sha256:48cbc5e4e361e80f27d054fb986762109c199678b12f8b1baf63cfbafc69fc82
       name: manager
     - image: ghcr.io/grafana/grafana-operator@sha256:97561cef949b58f55ec67d133c02ac205e2ec3fb77388aeb868dacfcebad0752
       name: grafana-operator-97561cef949b58f55ec67d133c02ac205e2ec3fb77388aeb868dacfcebad0752-annotation
@@ -615,4 +615,4 @@ spec:
     - grafana-operator.v5.6.3
     - grafana-operator.v5.7.0
     - grafana-operator.v5.8.0
-  version: 5.8.1
+  version: 5.9.0

--- a/bundle/manifests/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -56,6 +56,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               interval:
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$

--- a/bundle/manifests/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -54,6 +54,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               name:
                 type: string
               resyncPeriod:

--- a/bundle/manifests/grafana.integreatly.org_grafanadashboards.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanadashboards.yaml
@@ -170,6 +170,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               json:
                 type: string
               jsonnet:

--- a/bundle/manifests/grafana.integreatly.org_grafanadatasources.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanadatasources.yaml
@@ -97,6 +97,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               plugins:
                 items:
                   properties:

--- a/bundle/manifests/grafana.integreatly.org_grafanafolders.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanafolders.yaml
@@ -59,6 +59,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               permissions:
                 type: string
               resyncPeriod:

--- a/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -56,6 +56,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               interval:
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -54,6 +54,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               name:
                 type: string
               resyncPeriod:

--- a/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
@@ -170,6 +170,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               json:
                 type: string
               jsonnet:

--- a/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
@@ -97,6 +97,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               plugins:
                 items:
                   properties:

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -59,6 +59,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               permissions:
                 type: string
               resyncPeriod:

--- a/config/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/config/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -94,6 +94,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               interval:
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$

--- a/config/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -88,6 +88,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               name:
                 type: string
               resyncPeriod:

--- a/config/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/grafana.integreatly.org_grafanadashboards.yaml
@@ -258,6 +258,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               json:
                 description: dashboard json
                 type: string

--- a/config/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/grafana.integreatly.org_grafanadatasources.yaml
@@ -134,6 +134,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               plugins:
                 description: plugins
                 items:

--- a/config/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/grafana.integreatly.org_grafanafolders.yaml
@@ -94,6 +94,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               permissions:
                 description: raw json with folder permissions
                 type: string

--- a/deploy/helm/grafana-operator/Chart.yaml
+++ b/deploy/helm/grafana-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v5.8.1"
+appVersion: "v5.9.0"

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -7,14 +7,14 @@ linkTitle: "Helm installation"
 
 [grafana-operator](https://github.com/grafana/grafana-operator) for Kubernetes to manage Grafana instances and grafana resources.
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.8.1](https://img.shields.io/badge/AppVersion-v5.8.1-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.9.0](https://img.shields.io/badge/AppVersion-v5.9.0-informational?style=flat-square)
 
 ## Installation
 
 This is a OCI helm chart, helm started support OCI in version 3.8.0.
 
 ```shell
-helm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version v5.8.1
+helm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version v5.9.0
 ```
 
 Sadly helm OCI charts currently don't support searching for available versions of a helm [oci registry](https://github.com/helm/helm/issues/11000).
@@ -25,7 +25,7 @@ Helm does not provide functionality to update custom resource definitions. This 
 To avoid issues due to outdated or missing definitions, run the following command before updating an existing installation:
 
 ```shell
-kubectl apply --server-side --force-conflicts -f https://github.com/grafana/grafana-operator/releases/download/v5.8.1/crds.yaml
+kubectl apply --server-side --force-conflicts -f https://github.com/grafana/grafana-operator/releases/download/v5.9.0/crds.yaml
 ```
 
 The `--server-side` and `--force-conflict` flags are required to avoid running into issues with the `kubectl.kubernetes.io/last-applied-configuration` annotation.

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -56,6 +56,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               interval:
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -54,6 +54,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               name:
                 type: string
               resyncPeriod:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
@@ -170,6 +170,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               json:
                 type: string
               jsonnet:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
@@ -97,6 +97,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               plugins:
                 items:
                   properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -59,6 +59,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               permissions:
                 type: string
               resyncPeriod:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -55,6 +55,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               interval:
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
@@ -246,6 +249,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               name:
                 type: string
               resyncPeriod:
@@ -499,6 +505,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               json:
                 type: string
               jsonnet:
@@ -664,6 +673,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               plugins:
                 items:
                   properties:
@@ -802,6 +814,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               permissions:
                 type: string
               resyncPeriod:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -103,6 +103,8 @@ GrafanaAlertRuleGroupSpec defines the desired state of GrafanaAlertRuleGroup
         <td>object</td>
         <td>
           selects Grafanas for import<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>
         <td>true</td>
       </tr><tr>
@@ -627,6 +629,8 @@ GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
         <td>object</td>
         <td>
           selects Grafanas for import<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>
         <td>true</td>
       </tr><tr>
@@ -961,6 +965,8 @@ GrafanaDashboardSpec defines the desired state of GrafanaDashboard
         <td>object</td>
         <td>
           selects Grafanas for import<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>
         <td>true</td>
       </tr><tr>
@@ -1784,6 +1790,8 @@ GrafanaDatasourceSpec defines the desired state of GrafanaDatasource
         <td>object</td>
         <td>
           selects Grafana instances for import<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>
         <td>true</td>
       </tr><tr>
@@ -2342,6 +2350,8 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         <td>object</td>
         <td>
           selects Grafanas for import<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>
         <td>true</td>
       </tr><tr>


### PR DESCRIPTION
As previously discussed, `instanceSelector` field must be made immutable to make sure we don't end up having abandoned resources and to be in line with k8s eco-system. The PR contains the required changes. 

Fixes: #1519