### PR TITLE
feat(helm): All recommended Kubernetes labels

### DIFF
--- a/deploy/helm/grafana-operator/Chart.yaml
+++ b/deploy/helm/grafana-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/grafana-operator/Chart.yaml
+++ b/deploy/helm/grafana-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/grafana-operator/templates/_helpers.tpl
+++ b/deploy/helm/grafana-operator/templates/_helpers.tpl
@@ -47,6 +47,10 @@ helm.sh/chart: {{ include "grafana-operator.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: grafana-operator
+{{- with .Values.additionalLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/deploy/helm/grafana-operator/templates/cm.yaml
+++ b/deploy/helm/grafana-operator/templates/cm.yaml
@@ -5,9 +5,8 @@ metadata:
   name: {{ include "grafana-operator.fullname" . }}
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
-    {{- with .Values.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "grafana-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
 data:
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1

--- a/deploy/helm/grafana-operator/templates/cm.yaml
+++ b/deploy/helm/grafana-operator/templates/cm.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/component: config
+    app.kubernetes.io/component: operator
 data:
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    {{- with .Values.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    app.kubernetes.io/component: workload
 spec:
   replicas: 1
   selector:
@@ -21,9 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "grafana-operator.selectorLabels" . | nindent 8 }}
-        {{- with .Values.additionalLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        app.kubernetes.io/component: workload
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/component: workload
+    app.kubernetes.io/component: operator
 spec:
   replicas: 1
   selector:
@@ -19,7 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "grafana-operator.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: workload
+        app.kubernetes.io/component: operator
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -21,7 +21,7 @@ metadata:
   name: {{ include "grafana-operator.fullname" $ }}
   labels:
     {{- include "grafana-operator.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: rbac
+    app.kubernetes.io/component: operator
 rules:
   {{- toYaml $rbac.rules | nindent 2 }}
   {{- if $isOpenShift }}
@@ -37,7 +37,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "grafana-operator.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: rbac
+    app.kubernetes.io/component: operator
 subjects:
   - kind: ServiceAccount
     name: {{ include "grafana-operator.serviceAccountName" $ }}

--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -21,9 +21,7 @@ metadata:
   name: {{ include "grafana-operator.fullname" $ }}
   labels:
     {{- include "grafana-operator.labels" $ | nindent 4 }}
-    {{- with $.Values.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    app.kubernetes.io/component: rbac
 rules:
   {{- toYaml $rbac.rules | nindent 2 }}
   {{- if $isOpenShift }}
@@ -39,9 +37,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "grafana-operator.labels" $ | nindent 4 }}
-    {{- with $.Values.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    app.kubernetes.io/component: rbac
 subjects:
   - kind: ServiceAccount
     name: {{ include "grafana-operator.serviceAccountName" $ }}

--- a/deploy/helm/grafana-operator/templates/service.yaml
+++ b/deploy/helm/grafana-operator/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/component: networking
+    app.kubernetes.io/component: operator
 spec:
   type: {{ .Values.metricsService.type }}
   ports:

--- a/deploy/helm/grafana-operator/templates/service.yaml
+++ b/deploy/helm/grafana-operator/templates/service.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    {{- with .Values.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    app.kubernetes.io/component: networking
 spec:
   type: {{ .Values.metricsService.type }}
   ports:

--- a/deploy/helm/grafana-operator/templates/serviceaccount.yaml
+++ b/deploy/helm/grafana-operator/templates/serviceaccount.yaml
@@ -6,9 +6,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    {{- with .Values.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    app.kubernetes.io/component: rbac
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/helm/grafana-operator/templates/serviceaccount.yaml
+++ b/deploy/helm/grafana-operator/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/component: rbac
+    app.kubernetes.io/component: operator
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/helm/grafana-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/grafana-operator/templates/servicemonitor.yaml
@@ -6,9 +6,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    {{- with .Values.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    app.kubernetes.io/component: metrics
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/helm/grafana-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/grafana-operator/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "grafana-operator.namespace" . }}
   labels:
     {{- include "grafana-operator.labels" . | nindent 4 }}
-    app.kubernetes.io/component: metrics
+    app.kubernetes.io/component: operator
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Add missing labels and refactoring additional labels.

I don't change Helm chart version, because it is `v0.1.4` but in [documentation](https://github.com/grafana/grafana-operator/tree/master/deploy/helm/grafana-operator#installation), it is `v5.9.0`:

```
helm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version v5.9.0
```