### PR TITLE
Adding Grafana v10 ContactPoint types

### DIFF
--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -45,7 +45,7 @@ type GrafanaContactPointSpec struct {
 
 	Settings *apiextensions.JSON `json:"settings"`
 
-	// +kubebuilder:validation:Enum=alertmanager;dingding;discord;email;googlechat;kafka;line;opsgenie;pagerduty;pushover;sensugo;slack;teams;telegram;threema;victorops;webhook;wecom
+	// +kubebuilder:validation:Enum=alertmanager;prometheus-alertmanager;dingding;discord;email;googlechat;kafka;line;opsgenie;pagerduty;pushover;sensugo;sensu;slack;teams;telegram;threema;victorops;webhook;wecom;hipchat;oncall
 	Type string `json:"type,omitempty"`
 
 	// +optional

--- a/bundle/manifests/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -69,6 +69,7 @@ spec:
               type:
                 enum:
                 - alertmanager
+                - prometheus-alertmanager
                 - dingding
                 - discord
                 - email
@@ -79,6 +80,7 @@ spec:
                 - pagerduty
                 - pushover
                 - sensugo
+                - sensu
                 - slack
                 - teams
                 - telegram
@@ -86,6 +88,8 @@ spec:
                 - victorops
                 - webhook
                 - wecom
+                - hipchat
+                - oncall
                 type: string
             required:
             - instanceSelector

--- a/config/crd-for-docs-generation/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd-for-docs-generation/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -105,6 +105,7 @@ spec:
               type:
                 enum:
                 - alertmanager
+                - prometheus-alertmanager
                 - dingding
                 - discord
                 - email
@@ -115,6 +116,7 @@ spec:
                 - pagerduty
                 - pushover
                 - sensugo
+                - sensu
                 - slack
                 - teams
                 - telegram
@@ -122,6 +124,8 @@ spec:
                 - victorops
                 - webhook
                 - wecom
+                - hipchat
+                - oncall
                 type: string
             required:
             - instanceSelector

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -71,6 +71,7 @@ spec:
               type:
                 enum:
                 - alertmanager
+                - prometheus-alertmanager
                 - dingding
                 - discord
                 - email
@@ -81,6 +82,7 @@ spec:
                 - pagerduty
                 - pushover
                 - sensugo
+                - sensu
                 - slack
                 - teams
                 - telegram
@@ -88,6 +90,8 @@ spec:
                 - victorops
                 - webhook
                 - wecom
+                - hipchat
+                - oncall
                 type: string
             required:
             - instanceSelector

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -71,6 +71,7 @@ spec:
               type:
                 enum:
                 - alertmanager
+                - prometheus-alertmanager
                 - dingding
                 - discord
                 - email
@@ -81,6 +82,7 @@ spec:
                 - pagerduty
                 - pushover
                 - sensugo
+                - sensu
                 - slack
                 - teams
                 - telegram
@@ -88,6 +90,8 @@ spec:
                 - victorops
                 - webhook
                 - wecom
+                - hipchat
+                - oncall
                 type: string
             required:
             - instanceSelector

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -746,7 +746,7 @@ GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
         <td>
           <br/>
           <br/>
-            <i>Enum</i>: alertmanager, dingding, discord, email, googlechat, kafka, line, opsgenie, pagerduty, pushover, sensugo, slack, teams, telegram, threema, victorops, webhook, wecom<br/>
+            <i>Enum</i>: alertmanager, prometheus-alertmanager, dingding, discord, email, googlechat, kafka, line, opsgenie, pagerduty, pushover, sensugo, sensu, slack, teams, telegram, threema, victorops, webhook, wecom, hipchat, oncall<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
Closes https://github.com/grafana/grafana-operator/issues/1548

Just added new items in list from
https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/

Basically, we have to keep backward compitability for old grafana versions and include new types. The users have to choose types in accordance with grafana version they use.

Tested manually:
![image](https://github.com/grafana/grafana-operator/assets/96792836/9f214d02-9158-486d-92aa-c486b48827ab)

<details>
  <summary>Manifest</summary>

 ```
 sources:
    - repoURL: https://github.com/andrejshapal/grafana-operator.git
      targetRevision: master
      path: deploy/helm/grafana-operator
      helm:
        values: |

          fullnameOverride: "grafana-operator"

          namespaceScope: true
          image:
            repository: njuhaandrej/grafana-operator
            pullPolicy: Always
            tag: 8d1372eb04c3804416f724d98967bdb931ad026de458510f787866d818655757
          resources:
            limits:
              cpu: 100m
              memory: 200Mi
            requests:
              cpu: 50m
              memory: 100Mi

          serviceMonitor:
            enabled: false

    - repoURL: https://kiwigrid.github.io
      chart: any-resource
      targetRevision: "0.1.0"
      helm:
        values: |
          anyResources:
            grafana-one: |-
              apiVersion: grafana.integreatly.org/v1beta1
              kind: Grafana
              metadata:
                name: grafana-one
                labels:
                  dashboards: "grafana-one"
              spec:
                config:
                  log:
                    mode: "console"
                  auth:
                    disable_login_form: "false"
                  security:
                    admin_user: root
                    admin_password: secret
                deployment:
                  spec:
                    template:
                      spec:
                        containers:
                          - name: grafana
                            image: grafana/grafana:10.4.2

            contactpoint: |-
              apiVersion: grafana.integreatly.org/v1beta1
              kind: GrafanaContactPoint
              metadata:
                name: prometheus-alertmanager
              spec:
                instanceSelector:
                  matchLabels:
                    dashboards: "grafana-one"
                name: Prometheus Alertmanager
                type: prometheus-alertmanager
                settings:
                  url: http://kube-prometheus-stack-alertmanager.monitoring.svc:9093
            
            datasource: |-
              apiVersion: grafana.integreatly.org/v1beta1
              kind: GrafanaDatasource
              metadata:
                name: alertmanager-alerting
              spec:
                instanceSelector:
                  matchLabels:
                    dashboards: "grafana-one"
                datasource:
                  name: alertmananger-alerting
                  orgId: 1
                  access: proxy
                  type: alertmanager
                  url: http://kube-prometheus-stack-alertmanager.monitoring.svc:9093
                  jsonData:
                    implementation: prometheus
                    handleGrafanaManagedAlerts: true
                  basicAuth: false
```

</details>