### PR TITLE
chore: update default grafana version

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,7 +63,7 @@ spec:
               memory: 20Mi
           env:
             - name: RELATED_IMAGE_GRAFANA
-              value: "docker.io/grafana/grafana:9.5.17"
+              value: "docker.io/grafana/grafana:10.4.3"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -3,7 +3,7 @@ package config
 const (
 	// Grafana
 	GrafanaImage   = "docker.io/grafana/grafana"
-	GrafanaVersion = "9.5.17"
+	GrafanaVersion = "10.4.3"
 
 	// Paths
 	GrafanaDataPath               = "/var/lib/grafana"

--- a/tests/e2e/example-test/00-assert.yaml
+++ b/tests/e2e/example-test/00-assert.yaml
@@ -3,12 +3,12 @@ kind: Grafana
 metadata:
   name: grafana
 spec:
-  version: 9.5.17
+  version: 10.4.3
 status:
   (wildcard('http://grafana-service.*:3000', adminUrl || '')): true
   stage: complete
   stageStatus: success
-  version: 9.5.17
+  version: 10.4.3
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
@@ -18,12 +18,12 @@ status:
   adminUrl: (join('',['http://grafana-internal-service.',$namespace,':3000']))
   stage: complete
   stageStatus: success
-  version: 9.5.17
+  version: 10.4.3
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
-  name: grafana-ten
+  name: grafana-versioned
 status:
   stage: complete
   stageStatus: success

--- a/tests/e2e/example-test/00-create-versioned-grafana.yaml
+++ b/tests/e2e/example-test/00-create-versioned-grafana.yaml
@@ -1,7 +1,7 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
-  name: grafana-ten
+  name: grafana-versioned
   labels:
     dashboards: "grafana"
 spec:


### PR DESCRIPTION
Since we now store the version information in the spec, this will not affect existing resources