### PR TITLE
docs: Create proposal about parent folder management for GrafanaFolder CR

### DIFF
--- a/docs/docs/proposals/004-grafanafolder-parent-folder-management.md
+++ b/docs/docs/proposals/004-grafanafolder-parent-folder-management.md
@@ -97,7 +97,7 @@ Tests will require an update to Grafana 10 or 11.
 
 ## Decision Outcome
 
-<!-- TODO: to define with maintainers -->
+We will implement this proposal by combining both options, simmilar to the way we handle this topic in alert rule groups. Both `parentFolderUID` and `parentFolderRef` will be available (mutually exclusivity validated by the CR spec).
 
 ## Related discussions
 


### PR DESCRIPTION
CHANGELOG:
* Add proposal around using parentFolderUID and parentFolderRef in GrafanaFolder CR to permits the use of the Grafana subfolder feature (grafana >= 10)

No breaking change in this documentation. I'm open for a discussion around it in PR comment.