### PR TITLE
docs: Fix parameter auth.disable_login_form type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ spec:
     log:
       mode: "console"
     auth:
-      disable_login_form: false
+      disable_login_form: "false"
     security:
       admin_user: root
       admin_password: secret

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ spec:
   config:
     log:
       mode: "console"
-    auth:
-      disable_login_form: "false"
     security:
       admin_user: root
       admin_password: secret


### PR DESCRIPTION
CHANGELOG:

- Fix auth.disable_login_form in the example in README.md


When we test the example of the README, it fails : 
`$ kubectl apply -f grafana.yaml
The Grafana "grafana" is invalid: spec.config.auth.disable_login_form: Invalid value: "boolean": spec.config.auth.disable_login_form in body must be of type string: "boolean"`