### PR TITLE
Update release.yaml to add linux/ppc64le

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,7 @@ jobs:
           for i in ${{ env.REPOS }}
           do
             export KO_DOCKER_REPO=${i}
-            ko build --sbom=spdx --image-refs ./image-digest-${i%.*} --bare --platform linux/arm64,linux/arm/v7,linux/amd64 -t ${{ github.ref_name }} \
+            ko build --sbom=spdx --image-refs ./image-digest-${i%.*} --bare --platform linux/arm64,linux/arm/v7,linux/amd64,linux/ppc64le -t ${{ github.ref_name }} \
             --image-label org.opencontainers.image.title=grafana-operator \
             --image-label org.opencontainers.image.description="An operator for Grafana that installs and manages Grafana instances & Dashboards & Datasources through Kubernetes/OpenShift CRs" \
             --image-label org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }} \


### PR DESCRIPTION
We need to fix this issue, so we need ppc64le v5.9.2 

Failed to pull image "ghcr.io/grafana/grafana-operator@sha256:e7923d1a71b90a8ad66d114aec4b2b4e4929f15ba91872f64c5e271629612284": rpc error: code = Unknown desc = choosing image instance: no image found in image index for architecture ppc64le, variant "", OS linux