### PR TITLE
Feat(helm): Add possibility to attach volume (cm, secret...) to the operator pod

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -65,6 +65,8 @@ It's easier to just manage this configuration outside of the operator.
 | additionalLabels | object | `{}` | additional labels to add to all resources |
 | affinity | object | `{}` | pod affinity |
 | env | list | `[]` | Additional environment variables |
+| extraVolumeMounts | list | `[]` | Additional Volumes that will be mounted to the operator container. Need to match with an extraVolume name |
+| extraVolumes | list | `[]` | Volume that will be mounted in the container. Configmaps and Secrets need to be in the same namespace |
 | fullnameOverride | string | `""` | Overrides the fully qualified app name. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in grafana operator container |
 | image.repository | string | `"ghcr.io/grafana/grafana-operator"` | grafana operator image repository |

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
           volumeMounts:
             - name: dashboards-dir
               mountPath: /tmp/dashboards
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.metricsService.metricsPort }}
               name: metrics
@@ -82,6 +85,9 @@ spec:
       volumes:
         - name: dashboards-dir
           emptyDir: {}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -26,6 +26,23 @@ env: []
   # - name: MY_VAR
   #   value: "myvalue"
 
+# -- Volume that will be mounted in the container. Configmaps and Secrets need to be in the same namespace
+extraVolumes: []
+  # - name: my-config
+  #   configMap:
+  #     name: my-config
+  # - name: my-secret
+  #   secret:
+  #     secretName: my-secret
+
+# -- Additional Volumes that will be mounted to the operator container. Need to match with an extraVolume name
+extraVolumeMounts: []
+  # - name: my-config
+  #   mountPath: "/etc/config"
+  #   readOnly: true
+  # - name: my-secret
+  #   mountPath: "/etc/secret"
+
 image:
   # -- grafana operator image repository
   repository: ghcr.io/grafana/grafana-operator


### PR DESCRIPTION
## Aim of the merge request:

This MR updates the HelmChart of the grafana-operator to permits user to attach volume to the container deployed by the HelmChart. To do this, we implement `extraVolumes` and `extraVolumeMounts` field in the HelmChart.

## Implementation details

We choose to implement these field like this because it gives flexibility with the `env` field to use variable from mounted secret. If you have any comment about it, let me know. :)

## Additional comments

To be fully honest, I don't understand how you handle version update of the HelmChart, let's discuss about this here.