### PR TITLE
docs: Add proposal for ssl specification in Grafana external block

### DIFF
--- a/docs/docs/proposals/006-ssl-specification-in-grafanaexternal.md
+++ b/docs/docs/proposals/006-ssl-specification-in-grafanaexternal.md
@@ -1,0 +1,75 @@
+---
+title: "Add TLS management block in Grafana CR External block"
+linkTitle: "Add TLS management block in Grafana CR External block"
+---
+
+## Summary
+
+Introduce the possibility to give a tls specification to the Grafana CR's external block.
+
+This document contains the complete design required to support configuring tls by extending the Grafana CRD.
+
+The suggested new feature is:
+- Permits to declare a tls block which will give the possibility to use a certificate to connect a Grafana instance.
+
+## Info
+
+status: Suggested
+
+## Motivation
+
+Currently, the operator does not permits to connect with a Grafana with a not thrusted certificate without rebuilding the full container.
+
+## Proposal
+
+This document proposes to extend the Grafana CRD external block to add a block with tls information. In this block, we will find:
+- `caBundle`: This block will contain the name of the secret where the CA bundle is currently stored. To do this, we could use the `*v1.SecretKeySelector` mechanism already used in the Grafana CRD. (facultative - default: empty)
+- `insecureSkipVerify`: Disable the server certificate check (facultative - default: false)
+- `cert`: A certificate that can be used to authenticate the request to the response server (mandatory when `key` is defined - default: empty)
+- `key`: The key associated with the certificate declared in `cert_pem` field (mandatory when `cert` is defined - default: empty)
+
+The tls block should be facultative. However, if the tls block is set, at least of it subfield should be present.
+
+Doing this, the Grafana CRD will evolve to look into something like this:
+```yaml
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: external-grafana
+  labels:
+    dashboards: "external-grafana"
+spec:
+  external:
+    url: https://test.io
+    adminPassword:
+      name: grafana-admin-credentials
+      key: GF_SECURITY_ADMIN_PASSWORD
+    adminUser:
+      name: grafana-admin-credentials
+      key: GF_SECURITY_ADMIN_USER
+    tls:
+      caBundle:
+        name: tls-certificate
+        key: ca-bundle.pem
+      insecureSkipVerify: false
+      cert:
+        name: tls-certificate
+        key: cert.crt
+      key:
+        name: tls-certificate
+        key: key.key
+```
+
+## Impact on the already existing CRD
+
+Because this block is an addition to the existing Grafana CRD, the already deployed Grafana CR will not be impacted.
+However, because this functionality touch to the Grafana client, we need to be sure the evolution does not introduce regression in the product.
+
+## Decision Outcome
+
+<!-- TODO: to be discussed with maintainer -->
+
+## Related discussions
+
+- [PR 1590](https://github.com/grafana/grafana-operator/pull/1590)

--- a/docs/docs/proposals/006-ssl-specification-in-grafanaexternal.md
+++ b/docs/docs/proposals/006-ssl-specification-in-grafanaexternal.md
@@ -14,7 +14,7 @@ The suggested new feature is:
 
 ## Info
 
-status: Suggested <!-- TODO: to be discussed with maintainer -->
+status: Decided
 
 ## Motivation
 
@@ -59,8 +59,9 @@ However, because this functionality touch to the Grafana client, we need to be s
 
 ## Decision Outcome
 
-<!-- TODO: to be discussed with maintainer -->
+We're going to implement CA verification simmilar to [the way flux does it](https://fluxcd.io/flux/components/source/helmrepositories/#cert-secret-reference) to keep in line with the rest of the Kubernetes ecosystem
 
 ## Related discussions
 
 - [PR 1590](https://github.com/grafana/grafana-operator/pull/1590)
+- [PR 1594](https://github.com/grafana/grafana-operator/pull/1594)

--- a/docs/docs/proposals/006-ssl-specification-in-grafanaexternal.md
+++ b/docs/docs/proposals/006-ssl-specification-in-grafanaexternal.md
@@ -14,7 +14,7 @@ The suggested new feature is:
 
 ## Info
 
-status: Suggested
+status: Suggested <!-- TODO: to be discussed with maintainer -->
 
 ## Motivation
 
@@ -23,10 +23,8 @@ Currently, the operator does not permits to connect with a Grafana with a not th
 ## Proposal
 
 This document proposes to extend the Grafana CRD external block to add a block with tls information. In this block, we will find:
-- `caBundle`: This block will contain the name of the secret where the CA bundle is currently stored. To do this, we could use the `*v1.SecretKeySelector` mechanism already used in the Grafana CRD. (facultative - default: empty)
+- `certSecretRef`: This block will contains the name of a secret which will contained certificates based on the `kubernetes.io/tls` format (e.g. `ca.crt`, `tls.crt` and `tls.key`). This secret can contains only `ca.crt` or `tls.crt` and `tls.key` at the same time. Both solution are not mutually exclusive.
 - `insecureSkipVerify`: Disable the server certificate check (facultative - default: false)
-- `cert`: A certificate that can be used to authenticate the request to the response server (mandatory when `key` is defined - default: empty)
-- `key`: The key associated with the certificate declared in `cert_pem` field (mandatory when `cert` is defined - default: empty)
 
 The tls block should be facultative. However, if the tls block is set, at least of it subfield should be present.
 
@@ -49,16 +47,8 @@ spec:
       name: grafana-admin-credentials
       key: GF_SECURITY_ADMIN_USER
     tls:
-      caBundle:
-        name: tls-certificate
-        key: ca-bundle.pem
+      certSecretRef: tls-certificate
       insecureSkipVerify: false
-      cert:
-        name: tls-certificate
-        key: cert.crt
-      key:
-        name: tls-certificate
-        key: key.key
 ```
 
 ## Impact on the already existing CRD

--- a/docs/docs/proposals/006-ssl-specification-in-grafanaexternal.md
+++ b/docs/docs/proposals/006-ssl-specification-in-grafanaexternal.md
@@ -47,7 +47,8 @@ spec:
       name: grafana-admin-credentials
       key: GF_SECURITY_ADMIN_USER
     tls:
-      certSecretRef: tls-certificate
+      certSecretRef:
+        name: tls-certificate
       insecureSkipVerify: false
 ```
 


### PR DESCRIPTION
## Aim of the merge request

This MR aims to create a document to propose an evolution on the Grafana CR to permits to give certificate to the Grafana external block.

## Breaking change

There is no breaking change because it is just a proposal document. Nothing is implemented yet.

This should be discussed during a maintainer meeting.