### PR TITLE
fix: use correct folder uid to update permissions

### DIFF
--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -389,7 +389,12 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 			return fmt.Errorf("failed to unmarshal spec.permissions: %w", err)
 		}
 
-		_, err = grafanaClient.FolderPermissions.UpdateFolderPermissions(uid, &permissions) //nolint
+		targetUID := uid
+		if exists {
+			targetUID = remoteUID
+		}
+
+		_, err = grafanaClient.FolderPermissions.UpdateFolderPermissions(targetUID, &permissions) //nolint
 		if err != nil {
 			return fmt.Errorf("failed to update folder permissions: %w", err)
 		}

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -332,6 +332,8 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 	}
 
 	if exists {
+		// make sure we use the correct UID
+		uid = remoteUID
 		// Add to status to cover cases:
 		// - operator have previously failed to update status
 		// - the folder was created outside of operator
@@ -389,12 +391,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 			return fmt.Errorf("failed to unmarshal spec.permissions: %w", err)
 		}
 
-		targetUID := uid
-		if exists {
-			targetUID = remoteUID
-		}
-
-		_, err = grafanaClient.FolderPermissions.UpdateFolderPermissions(targetUID, &permissions) //nolint
+		_, err = grafanaClient.FolderPermissions.UpdateFolderPermissions(uid, &permissions) //nolint
 		if err != nil {
 			return fmt.Errorf("failed to update folder permissions: %w", err)
 		}


### PR DESCRIPTION
Currently grafanafolder controller tries to update folder permission using CR UID no matter if the folder was created by dashboard controller earlier.