### PR TITLE
feat: add parentFolderRef field in GrafanaFolder

### DIFF
--- a/api/folderreferencer.go
+++ b/api/folderreferencer.go
@@ -1,4 +1,4 @@
-package v1beta1
+package api
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/api/v1beta1/folderreferencer.go
+++ b/api/v1beta1/folderreferencer.go
@@ -1,0 +1,15 @@
+package v1beta1
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type FolderReferencer interface {
+	FolderRef() string
+	FolderUID() string
+	FolderNamespace() string
+	ConditionsResource
+}
+
+type ConditionsResource interface {
+	Conditions() *[]metav1.Condition
+	CurrentGeneration() int64
+}

--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -135,6 +135,33 @@ type GrafanaAlertRuleGroup struct {
 	Status GrafanaAlertRuleGroupStatus `json:"status,omitempty"`
 }
 
+// CurrentGeneration implements FolderReferencer.
+func (in *GrafanaAlertRuleGroup) CurrentGeneration() int64 {
+	return in.Generation
+}
+
+// Conditions implements FolderReferencer.
+func (in *GrafanaAlertRuleGroup) Conditions() *[]metav1.Condition {
+	return &in.Status.Conditions
+}
+
+// FolderNamespace implements FolderReferencer.
+func (in *GrafanaAlertRuleGroup) FolderNamespace() string {
+	return in.Namespace
+}
+
+// FolderRef implements FolderReferencer.
+func (in *GrafanaAlertRuleGroup) FolderRef() string {
+	return in.Spec.FolderRef
+}
+
+// FolderUID implements FolderReferencer.
+func (in *GrafanaAlertRuleGroup) FolderUID() string {
+	return in.Spec.FolderUID
+}
+
+var _ FolderReferencer = (*GrafanaAlertRuleGroup)(nil)
+
 //+kubebuilder:object:root=true
 
 // GrafanaAlertRuleGroupList contains a list of GrafanaAlertRuleGroup

--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"github.com/grafana/grafana-openapi-client-go/models"
+	operatorapi "github.com/grafana/grafana-operator/v5/api"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -160,7 +161,7 @@ func (in *GrafanaAlertRuleGroup) FolderUID() string {
 	return in.Spec.FolderUID
 }
 
-var _ FolderReferencer = (*GrafanaAlertRuleGroup)(nil)
+var _ operatorapi.FolderReferencer = (*GrafanaAlertRuleGroup)(nil)
 
 //+kubebuilder:object:root=true
 

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -45,8 +45,14 @@ type GrafanaFolderSpec struct {
 	AllowCrossNamespaceImport *bool `json:"allowCrossNamespaceImport,omitempty"`
 
 	// UID of the folder in which the current folder should be created
+	// should not be defined when parentFolderRef is already defined
 	// +optional
 	ParentFolderUID string `json:"parentFolderUID,omitempty"`
+
+	// Reference to an existing GrafanaFolder CR in the same namespace
+	// should not be defined when parentFolderUID is already defined
+	// +optional
+	ParentFolderRef string `json:"parentFolderRef,omitempty"`
 
 	// how often the folder is synced, defaults to 5m if not set
 	// +optional

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	operatorapi "github.com/grafana/grafana-operator/v5/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -113,7 +114,7 @@ func (in *GrafanaFolder) FolderUID() string {
 	return in.Spec.ParentFolderUID
 }
 
-var _ FolderReferencer = (*GrafanaFolder)(nil)
+var _ operatorapi.FolderReferencer = (*GrafanaFolder)(nil)
 
 //+kubebuilder:object:root=true
 

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -88,6 +88,33 @@ type GrafanaFolder struct {
 	Status GrafanaFolderStatus `json:"status,omitempty"`
 }
 
+// Conditions implements FolderReferencer.
+func (in *GrafanaFolder) Conditions() *[]metav1.Condition {
+	return &in.Status.Conditions
+}
+
+// CurrentGeneration implements FolderReferencer.
+func (in *GrafanaFolder) CurrentGeneration() int64 {
+	return in.Generation
+}
+
+// FolderNamespace implements FolderReferencer.
+func (in *GrafanaFolder) FolderNamespace() string {
+	return in.Namespace
+}
+
+// FolderRef implements FolderReferencer.
+func (in *GrafanaFolder) FolderRef() string {
+	return in.Spec.ParentFolderRef
+}
+
+// FolderUID implements FolderReferencer.
+func (in *GrafanaFolder) FolderUID() string {
+	return in.Spec.ParentFolderUID
+}
+
+var _ FolderReferencer = (*GrafanaFolder)(nil)
+
 //+kubebuilder:object:root=true
 
 // GrafanaFolderList contains a list of GrafanaFolder

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -28,6 +28,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // GrafanaFolderSpec defines the desired state of GrafanaFolder
+// +kubebuilder:validation:XValidation:rule="(has(self.parentFolderUID) && !(has(self.parentFolderRef))) || (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef) && (has(self.parentFolderUID)))", message="Only one of parentFolderUID or parentFolderRef can be set"
 type GrafanaFolderSpec struct {
 	// +optional
 	Title string `json:"title,omitempty"`
@@ -45,12 +46,10 @@ type GrafanaFolderSpec struct {
 	AllowCrossNamespaceImport *bool `json:"allowCrossNamespaceImport,omitempty"`
 
 	// UID of the folder in which the current folder should be created
-	// should not be defined when parentFolderRef is already defined
 	// +optional
 	ParentFolderUID string `json:"parentFolderUID,omitempty"`
 
 	// Reference to an existing GrafanaFolder CR in the same namespace
-	// should not be defined when parentFolderUID is already defined
 	// +optional
 	ParentFolderRef string `json:"parentFolderRef,omitempty"`
 

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -100,14 +100,12 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
               parentFolderRef:
-                description: |-
-                  Reference to an existing GrafanaFolder CR in the same namespace
-                  should not be defined when parentFolderUID is already defined
+                description: Reference to an existing GrafanaFolder CR in the same
+                  namespace
                 type: string
               parentFolderUID:
-                description: |-
-                  UID of the folder in which the current folder should be created
-                  should not be defined when parentFolderRef is already defined
+                description: UID of the folder in which the current folder should
+                  be created
                 type: string
               permissions:
                 description: raw json with folder permissions
@@ -124,6 +122,11 @@ spec:
             required:
             - instanceSelector
             type: object
+            x-kubernetes-validations:
+            - message: Only one of parentFolderUID or parentFolderRef can be set
+              rule: (has(self.parentFolderUID) && !(has(self.parentFolderRef))) ||
+                (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef)
+                && (has(self.parentFolderUID)))
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -99,9 +99,15 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
+              parentFolderRef:
+                description: |-
+                  Reference to an existing GrafanaFolder CR in the same namespace
+                  should not be defined when parentFolderUID is already defined
+                type: string
               parentFolderUID:
-                description: UID of the folder in which the current folder should
-                  be created
+                description: |-
+                  UID of the folder in which the current folder should be created
+                  should not be defined when parentFolderRef is already defined
                 type: string
               permissions:
                 description: raw json with folder permissions

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	operatorapi "github.com/grafana/grafana-operator/v5/api"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	grafanav1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers/model"
@@ -55,7 +56,7 @@ func GetMatchingInstances(ctx context.Context, k8sClient client.Client, labelSel
 }
 
 // getFolderUID fetches the folderUID from an existing GrafanaFolder CR declared in the specified namespace
-func getFolderUID(ctx context.Context, k8sClient client.Client, ref v1beta1.FolderReferencer) (string, error) {
+func getFolderUID(ctx context.Context, k8sClient client.Client, ref operatorapi.FolderReferencer) (string, error) {
 	if ref.FolderUID() != "" {
 		return ref.FolderUID(), nil
 	}

--- a/controllers/grafanaalertrulegroup_controller.go
+++ b/controllers/grafanaalertrulegroup_controller.go
@@ -275,7 +275,7 @@ func (r *GrafanaAlertRuleGroupReconciler) finalize(ctx context.Context, group *g
 	folderUID, err := getFolderUID(ctx, r.Client, group)
 	if err != nil {
 		r.Log.Info("ignoring finalization logic as folder no longer exists")
-		return nil
+		return nil //nolint:nilerr
 	}
 	instances, err := r.GetMatchingInstances(ctx, group, r.Client)
 	if err != nil {

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -39,7 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	grafanav1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 )
 
@@ -328,7 +327,6 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 	}
 
 	exists, remoteUID, remoteParent, err := r.Exists(grafanaClient, cr)
-
 	if err != nil {
 		return err
 	}
@@ -412,7 +410,7 @@ func (r *GrafanaFolderReconciler) retrieveParentFolderUID(ctx context.Context, c
 		return "", fmt.Errorf("error folderRef and folderUID cannot be declared at the same time in the CR %s (%s)", cr.Name, cr.Namespace)
 	}
 	if cr.Spec.ParentFolderRef != "" {
-		folder := &v1beta1.GrafanaFolder{}
+		folder := &grafanav1beta1.GrafanaFolder{}
 
 		err := r.Client.Get(ctx, client.ObjectKey{
 			Namespace: cr.Namespace,

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -321,9 +321,9 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 		return err
 	}
 
-	parentFolderUID := cr.Spec.ParentFolderUID
-	if cr.Spec.ParentFolderRef != "" {
-		parentFolderUID = retrieveFolderUID(ctx, r.Client, cr.Spec.ParentFolderRef, cr.Namespace, &cr.Status.Conditions, cr.Generation)
+	parentFolderUID, err := getFolderUID(ctx, r.Client, cr)
+	if err != nil {
+		return err
 	}
 
 	exists, remoteUID, remoteParent, err := r.Exists(grafanaClient, cr)

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -100,14 +100,12 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
               parentFolderRef:
-                description: |-
-                  Reference to an existing GrafanaFolder CR in the same namespace
-                  should not be defined when parentFolderUID is already defined
+                description: Reference to an existing GrafanaFolder CR in the same
+                  namespace
                 type: string
               parentFolderUID:
-                description: |-
-                  UID of the folder in which the current folder should be created
-                  should not be defined when parentFolderRef is already defined
+                description: UID of the folder in which the current folder should
+                  be created
                 type: string
               permissions:
                 description: raw json with folder permissions
@@ -124,6 +122,11 @@ spec:
             required:
             - instanceSelector
             type: object
+            x-kubernetes-validations:
+            - message: Only one of parentFolderUID or parentFolderRef can be set
+              rule: (has(self.parentFolderUID) && !(has(self.parentFolderRef))) ||
+                (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef)
+                && (has(self.parentFolderUID)))
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -99,9 +99,15 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
+              parentFolderRef:
+                description: |-
+                  Reference to an existing GrafanaFolder CR in the same namespace
+                  should not be defined when parentFolderUID is already defined
+                type: string
               parentFolderUID:
-                description: UID of the folder in which the current folder should
-                  be created
+                description: |-
+                  UID of the folder in which the current folder should be created
+                  should not be defined when parentFolderRef is already defined
                 type: string
               permissions:
                 description: raw json with folder permissions

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -1245,14 +1245,12 @@ spec:
                 - message: Value is immutable
                   rule: self == oldSelf
               parentFolderRef:
-                description: |-
-                  Reference to an existing GrafanaFolder CR in the same namespace
-                  should not be defined when parentFolderUID is already defined
+                description: Reference to an existing GrafanaFolder CR in the same
+                  namespace
                 type: string
               parentFolderUID:
-                description: |-
-                  UID of the folder in which the current folder should be created
-                  should not be defined when parentFolderRef is already defined
+                description: UID of the folder in which the current folder should
+                  be created
                 type: string
               permissions:
                 description: raw json with folder permissions
@@ -1269,6 +1267,11 @@ spec:
             required:
             - instanceSelector
             type: object
+            x-kubernetes-validations:
+            - message: Only one of parentFolderUID or parentFolderRef can be set
+              rule: (has(self.parentFolderUID) && !(has(self.parentFolderRef))) ||
+                (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef)
+                && (has(self.parentFolderUID)))
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -1244,9 +1244,15 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
+              parentFolderRef:
+                description: |-
+                  Reference to an existing GrafanaFolder CR in the same namespace
+                  should not be defined when parentFolderUID is already defined
+                type: string
               parentFolderUID:
-                description: UID of the folder in which the current folder should
-                  be created
+                description: |-
+                  UID of the folder in which the current folder should be created
+                  should not be defined when parentFolderRef is already defined
                 type: string
               permissions:
                 description: raw json with folder permissions

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -2473,10 +2473,19 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>parentFolderRef</b></td>
+        <td>string</td>
+        <td>
+          Reference to an existing GrafanaFolder CR in the same namespace
+should not be defined when parentFolderUID is already defined<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>parentFolderUID</b></td>
         <td>string</td>
         <td>
-          UID of the folder in which the current folder should be created<br/>
+          UID of the folder in which the current folder should be created
+should not be defined when parentFolderRef is already defined<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -2427,6 +2427,8 @@ GrafanaFolder is the Schema for the grafanafolders API
         <td>object</td>
         <td>
           GrafanaFolderSpec defines the desired state of GrafanaFolder<br/>
+          <br/>
+            <i>Validations</i>:<li>(has(self.parentFolderUID) && !(has(self.parentFolderRef))) || (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef) && (has(self.parentFolderUID))): Only one of parentFolderUID or parentFolderRef can be set</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2476,16 +2478,14 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         <td><b>parentFolderRef</b></td>
         <td>string</td>
         <td>
-          Reference to an existing GrafanaFolder CR in the same namespace
-should not be defined when parentFolderUID is already defined<br/>
+          Reference to an existing GrafanaFolder CR in the same namespace<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>parentFolderUID</b></td>
         <td>string</td>
         <td>
-          UID of the folder in which the current folder should be created
-should not be defined when parentFolderRef is already defined<br/>
+          UID of the folder in which the current folder should be created<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
## Aim of the merge request

Implement the parentFolderRef functionality in the GrafanaFolder CRD.

## Breaking change

There is no breaking change in this MR

## Related documents

* [Design document: GrafanaFolder parent folder management](https://grafana.github.io/grafana-operator/docs/proposals/004-grafanafolder-parent-folder-management/#proposal-2-target-an-existing-grafanafolder-deployed-by-the-grafana-operator)

## Additional comments

I have made few tests on moving the folder with dashboard inside by changing the parentFolderRef/parentFolderUID. I have adapted the implementation based on #1600 changes.