### PR TITLE
HELM: Enable deploying additional objects with helm chart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ But if you generate new RBAC rules or create new deployment options for the oper
 
 Chart.yaml `appVersion` follows the grafana-operator version but the helm chart is versioned separately.
 
-If you add update the chart don't forget to run `make helm-docs`, which will update the helm specific README file.
+If you add update the chart don't forget to run `make helm/docs`, which will update the helm specific README file.
 
 ### Kustomize
 

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -65,6 +65,7 @@ It's easier to just manage this configuration outside of the operator.
 | additionalLabels | object | `{}` | additional labels to add to all resources |
 | affinity | object | `{}` | pod affinity |
 | env | list | `[]` | Additional environment variables |
+| extraObjects | list | `[]` | Array of extra K8s objects to deploy |
 | fullnameOverride | string | `""` | Overrides the fully qualified app name. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in grafana operator container |
 | image.repository | string | `"ghcr.io/grafana/grafana-operator"` | grafana operator image repository |

--- a/deploy/helm/grafana-operator/templates/extraobjects.yaml
+++ b/deploy/helm/grafana-operator/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -114,4 +114,20 @@ serviceMonitor:
 
 # -- Array of extra K8s objects to deploy
 extraObjects: []
+# - apiVersion: external-secrets.io/v1beta1
+#   kind: ExternalSecret
+#   metadata:
+#     name: grafana-operator-apikey
+#   spec:
+#     refreshInterval: 1h
+#     secretStoreRef:
+#       kind: SecretStore
+#       name: my-secret-store
+#     target:
+#       template:
+#         data:
+#           GRAFANA_CLOUD_INSTANCE_TOKEN: "{{`{{ .Token }}`}}"
+#     dataFrom:
+#     - extract:
+#         key: my-secret-store-secret
 

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -111,3 +111,7 @@ serviceMonitor:
   metricRelabelings: []
   # -- Set relabel_configs as per https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
   relabelings: []
+
+# -- Array of extra K8s objects to deploy
+extraObjects: []
+


### PR DESCRIPTION
Sometimes additional objects are needed, such as  ExternalSecret for Grafana api token, (Cilium) Network policies etc.
