### PR TITLE
Local `yq` is not downloaded or referenced properly in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ endif
 manifests: yq controller-gen kustomize ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=config/crd/bases
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=deploy/helm/grafana-operator/crds
-	yq -i '(select(.kind == "Deployment") | .spec.template.spec.containers[0].env[] | select (.name == "RELATED_IMAGE_GRAFANA")).value="$(GRAFANA_IMAGE):$(GRAFANA_VERSION)"' config/manager/manager.yaml
+	$(YQ) -i '(select(.kind == "Deployment") | .spec.template.spec.containers[0].env[] | select (.name == "RELATED_IMAGE_GRAFANA")).value="$(GRAFANA_IMAGE):$(GRAFANA_VERSION)"' config/manager/manager.yaml
 
 	# NOTE: As we publish the whole kustomize folder structure (deploy/kustomize) as an OCI arfifact via flux, in kustomization.yaml, we cannot reference files that reside outside of deploy/kustomize. Thus, we need to maintain an additional copy of CRDs and the ClusterRole
 	$(KUSTOMIZE) build config/crd -o deploy/kustomize/base/crds.yaml
@@ -105,8 +105,8 @@ manifests: yq controller-gen kustomize ## Generate WebhookConfiguration, Cluster
 
 	# Sync role definitions to helm chart
 	mkdir -p deploy/helm/grafana-operator/files
-	cat config/rbac/role.yaml | yq -r 'del(.rules[] | select (.apiGroups | contains(["route.openshift.io"])))' > deploy/helm/grafana-operator/files/rbac.yaml
-	cat config/rbac/role.yaml | yq -r 'del(.rules[] | select (.apiGroups | contains(["route.openshift.io"]) | not))'  > deploy/helm/grafana-operator/files/rbac-openshift.yaml
+	cat config/rbac/role.yaml | $(YQ) -r 'del(.rules[] | select (.apiGroups | contains(["route.openshift.io"])))' > deploy/helm/grafana-operator/files/rbac.yaml
+	cat config/rbac/role.yaml | $(YQ) -r 'del(.rules[] | select (.apiGroups | contains(["route.openshift.io"]) | not))'  > deploy/helm/grafana-operator/files/rbac-openshift.yaml
 
 # Generate API reference documentation
 api-docs: manifests gen-crd-api-reference-docs

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ ifeq (,$(shell which yq 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(YQ)) ;\
-	OSTYPE=$(shell uname | awk '{print tolower($0)}') && ARCH=$(shell go env GOARCH) && \
+	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$${OSTYPE}_$${ARCH} ;\
 	chmod +x $(YQ) ;\
 	}


### PR DESCRIPTION
I was attempting to generate some CRD changes and I was unable to use the Makefile provided `yq` binary.

```bash
> git rev-parse HEAD
26fc2cb328892dda47b2af970882bfd049c06543

> make yq
awk: cmd. line:1: {print tolower()}
awk: cmd. line:1:                ^ 0 is invalid as number of arguments for tolower

> ./bin/yq --version
./bin/yq: 1: Not: not found

# Notice the size of 9 bytes
> ls -al ./bin/
-rwxr-xr-x  1 ste ste  22M Aug 12 20:58 controller-gen
-rwxr-xr-x  1 ste ste  15M Aug 12 20:43 kustomize
-rwxr-xr-x  1 ste ste 9.1M Aug 12 20:45 setup-envtest
-rwxr-xr-x  1 ste ste    9 Aug 12 21:42 yq
```

And the `manifests` target did not reference the YQ variable properly and instead relied on PATH
```bash
> make manifests
test -s /home/ste/grafana-operator/bin/controller-gen || GOBIN=/home/ste/grafana-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
test -s /home/ste/grafana-operator/bin/kustomize || { curl -Ss "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.1.1 /home/ste/grafana-operator/bin; }
/home/ste/grafana-operator/bin/controller-gen rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=config/crd/bases
/home/ste/grafana-operator/bin/controller-gen rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=deploy/helm/grafana-operator/crds
yq -i '(select(.kind == "Deployment") | .spec.template.spec.containers[0].env[] | select (.name == "RELATED_IMAGE_GRAFANA")).value="docker.io/grafana/grafana:10.4.3"' config/manager/manager.yaml
bash: line 1: yq: command not found
make: *** [Makefile:100: manifests] Error 127
```