### PR TITLE
feat(helm): add option to disable rbac creation

### DIFF
--- a/deploy/helm/grafana-operator/Chart.yaml
+++ b/deploy/helm/grafana-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -7,7 +7,7 @@ linkTitle: "Helm installation"
 
 [grafana-operator](https://github.com/grafana/grafana-operator) for Kubernetes to manage Grafana instances and grafana resources.
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.12.0](https://img.shields.io/badge/AppVersion-v5.12.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.12.0](https://img.shields.io/badge/AppVersion-v5.12.0-informational?style=flat-square)
 
 ## Installation
 
@@ -83,6 +83,8 @@ It's easier to just manage this configuration outside of the operator.
 | podAnnotations | object | `{}` | pod annotations |
 | podSecurityContext | object | `{}` | pod security context |
 | priorityClassName | string | `""` | pod priority class name |
+| rbac.create | bool | `true` | Specifies whether to create the ClusterRole and ClusterRoleBinding. If "namescapeScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead. |
+| rbac.rules | list | `[]` | The rules affected to the ClusterRole. If not set and create is true, the rules are recovered from files/rbac.yaml or files/rbac-openshift.yaml. |
 | resources | object | `{}` | grafana operator container resources |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | grafana operator container security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -83,7 +83,7 @@ It's easier to just manage this configuration outside of the operator.
 | podAnnotations | object | `{}` | pod annotations |
 | podSecurityContext | object | `{}` | pod security context |
 | priorityClassName | string | `""` | pod priority class name |
-| rbac.create | bool | `true` | Specifies whether to create the ClusterRole and ClusterRoleBinding. If "namescapeScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead. |
+| rbac.create | bool | `true` | Specifies whether to create the ClusterRole and ClusterRoleBinding. If "namespaceScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead. |
 | resources | object | `{}` | grafana operator container resources |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | grafana operator container security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -84,7 +84,6 @@ It's easier to just manage this configuration outside of the operator.
 | podSecurityContext | object | `{}` | pod security context |
 | priorityClassName | string | `""` | pod priority class name |
 | rbac.create | bool | `true` | Specifies whether to create the ClusterRole and ClusterRoleBinding. If "namescapeScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead. |
-| rbac.rules | list | `[]` | The rules affected to the ClusterRole. If not set and create is true, the rules are recovered from files/rbac.yaml or files/rbac-openshift.yaml. |
 | resources | object | `{}` | grafana operator container resources |
 | securityContext | object | `{"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | grafana operator container security context |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -24,13 +24,9 @@ metadata:
     {{- include "grafana-operator.labels" $ | nindent 4 }}
     app.kubernetes.io/component: operator
 rules:
-  {{- if gt (len $.Values.rbac.rules) 0 }}
-  {{- toYaml $.Values.rbac.rules | nindent 2 }}
-  {{- else }}
   {{- toYaml $rbac.rules | nindent 2 }}
   {{- if $isOpenShift }}
   {{- toYaml $rbacOpenShift.rules | nindent 2 -}}
-  {{- end }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 {{ $rbac := .Files.Get "files/rbac.yaml" | fromYaml  }}
 {{ $rbacOpenShift := .Files.Get "files/rbac-openshift.yaml" | fromYaml  }}
 {{- $watchNamespaces := coalesce .Values.watchNamespaces .Values.namespaceOverride .Release.Namespace  }}
@@ -23,9 +24,13 @@ metadata:
     {{- include "grafana-operator.labels" $ | nindent 4 }}
     app.kubernetes.io/component: operator
 rules:
+  {{- if gt (len $.Values.rbac.rules) 0 }}
+  {{- toYaml $.Values.rbac.rules | nindent 2 }}
+  {{- else }}
   {{- toYaml $rbac.rules | nindent 2 }}
   {{- if $isOpenShift }}
   {{- toYaml $rbacOpenShift.rules | nindent 2 -}}
+  {{- end }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -46,4 +51,5 @@ roleRef:
   kind: {{ if not $namespaceScoped }}Cluster{{ end }}Role
   name: {{ include "grafana-operator.fullname" $ }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -57,7 +57,7 @@ serviceAccount:
 
 rbac:
   # -- Specifies whether to create the ClusterRole and ClusterRoleBinding.
-  # If "namescapeScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead.
+  # If "namespaceScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead.
   create: true
 
 metricsService:

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -55,6 +55,15 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  # -- Specifies whether to create the ClusterRole and ClusterRoleBinding.
+  # If "namescapeScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead.
+  create: true
+
+  # -- The rules affected to the ClusterRole.
+  # If not set and create is true, the rules are recovered from files/rbac.yaml or files/rbac-openshift.yaml.
+  rules: []
+
 metricsService:
   # -- metrics service type
   type: ClusterIP

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -60,10 +60,6 @@ rbac:
   # If "namescapeScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead.
   create: true
 
-  # -- The rules affected to the ClusterRole.
-  # If not set and create is true, the rules are recovered from files/rbac.yaml or files/rbac-openshift.yaml.
-  rules: []
-
 metricsService:
   # -- metrics service type
   type: ClusterIP


### PR DESCRIPTION
Enable or disable ClusterRole and RoleBinding creation and add the ability to custom the ClusterRole rules

## Aim of the merge request
Enabling the user to use existing ClusterRole and ClusterRoleBinding. The use case for us is to allow users to use this chart in clusters where creating such objetcs is not allowed by helm deployment but must go throught something else (eg Terraform).

Also, it's adding the ability to customise the rules, as not all of them are required for the operator to work.

## Breaking change
None - this just adds a new feature

## Testing process

Tested by hand, by trying different values in `values.yaml`

```sh
cd deploy/helm/grafana-operator
helm dependency build
helm template . --output-dir /tmp/grafana-operator
```

Test case with no creation of roles:
```yaml
[...]
rbac:
  create: false
  rules:
    - apiGroups:
      - ""
      resources:
      - configmaps
      verbs:
      - create
```

Test case with creation of roles and custom rules:
```yaml
[...]
rbac:
  create: true
  rules:
    - apiGroups:
      - ""
      resources:
      - configmaps
      verbs:
      - create
```

Test case with creation of roles (current behavior):
```yaml
[...]
rbac:
  create: true
  rules: []
```

## Related documents
N/A

## Additional comments

Leaving `rbac.rules` at `[]` mimics the current behavior of fetching the rules from the file `deploy/helm/grafana-operator/files/rbac.yaml`. This could be a problem as the user might expect an empty list not give any rules.

It's explained in the documentation, but we could change this behaviour by putting as default the rules listed in the file mentioned (instead of `[]`), and discarding the file (which would be breaking change ?). We could do something similar with the additional "OpenShift" rules.