### PR TITLE
fix(helm): allow setting pod labels

### DIFF
--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "grafana-operator.selectorLabels" . | nindent 8 }}
+        {{- include "grafana-operator.labels" . | nindent 8 }}
         app.kubernetes.io/component: operator
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
Since #1538 landed, it's not possible to set additional pod labels. The only way of setting pod labels would be to change
`grafana-operator.selectorLabels`, but doing that breaks current deployments as selector labels are immutable.

`grafana-operator.labels` includes `grafana-operator.selectorLabels`, so it's safe to include them instead in the pod labels, and doing so fixes the current issue without causing side-effects as well as restores previous chart behavior.

This is the alternative fix discussed in PR #1560

fixes #1546 #1642