### PR TITLE
Annotate CRD structs with categories

### DIFF
--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -53,6 +53,7 @@ type OperatorReconcileVars struct {
 }
 
 // GrafanaSpec defines the desired state of Grafana
+// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// Config defines how your grafana ini file should looks like.

--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -128,6 +128,7 @@ type GrafanaAlertRuleGroupStatus struct {
 //+kubebuilder:subresource:status
 
 // GrafanaAlertRuleGroup is the Schema for the grafanaalertrulegroups API
+// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaAlertRuleGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -63,6 +63,7 @@ type GrafanaContactPointStatus struct {
 //+kubebuilder:subresource:status
 
 // GrafanaContactPoint is the Schema for the grafanacontactpoints API
+// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaContactPoint struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -51,6 +51,7 @@ type GrafanaDashboardDatasource struct {
 // GrafanaDashboardSpec defines the desired state of GrafanaDashboard
 // +kubebuilder:validation:XValidation:rule="(has(self.folderUID) && !(has(self.folderRef))) || (has(self.folderRef) && !(has(self.folderUID))) || !(has(self.folderRef) && (has(self.folderUID)))", message="Only one of folderUID or folderRef can be declared at the same time"
 // +kubebuilder:validation:XValidation:rule="(has(self.folder) && !(has(self.folderRef) || has(self.folderUID))) || !(has(self.folder))", message="folder field cannot be set when folderUID or folderRef is already declared"
+// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaDashboardSpec struct {
 	// dashboard json
 	// +optional

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -119,6 +119,7 @@ type GrafanaDatasourceStatus struct {
 // +kubebuilder:printcolumn:name="No matching instances",type="boolean",JSONPath=".status.NoMatchingInstances",description=""
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
+// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaDatasource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -81,6 +81,7 @@ type GrafanaFolderStatus struct {
 // GrafanaFolder is the Schema for the grafanafolders API
 // +kubebuilder:printcolumn:name="No matching instances",type="boolean",JSONPath=".status.NoMatchingInstances",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
+// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaFolder struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafananotificationpolicy_types.go
+++ b/api/v1beta1/grafananotificationpolicy_types.go
@@ -138,6 +138,7 @@ type GrafanaNotificationPolicyStatus struct {
 //+kubebuilder:subresource:status
 
 // GrafanaNotificationPolicy is the Schema for the GrafanaNotificationPolicy API
+// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaNotificationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaAlertRuleGroup
     listKind: GrafanaAlertRuleGroupList
     plural: grafanaalertrulegroups

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaContactPoint
     listKind: GrafanaContactPointList
     plural: grafanacontactpoints

--- a/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaDatasource
     listKind: GrafanaDatasourceList
     plural: grafanadatasources

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaFolder
     listKind: GrafanaFolderList
     plural: grafanafolders

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaNotificationPolicy
     listKind: GrafanaNotificationPolicyList
     plural: grafananotificationpolicies

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaAlertRuleGroup
     listKind: GrafanaAlertRuleGroupList
     plural: grafanaalertrulegroups

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaContactPoint
     listKind: GrafanaContactPointList
     plural: grafanacontactpoints

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaDatasource
     listKind: GrafanaDatasourceList
     plural: grafanadatasources

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaFolder
     listKind: GrafanaFolderList
     plural: grafanafolders

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaNotificationPolicy
     listKind: GrafanaNotificationPolicyList
     plural: grafananotificationpolicies

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaAlertRuleGroup
     listKind: GrafanaAlertRuleGroupList
     plural: grafanaalertrulegroups
@@ -316,6 +318,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaContactPoint
     listKind: GrafanaContactPointList
     plural: grafanacontactpoints
@@ -984,6 +988,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaDatasource
     listKind: GrafanaDatasourceList
     plural: grafanadatasources
@@ -1237,6 +1243,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaFolder
     listKind: GrafanaFolderList
     plural: grafanafolders
@@ -1457,6 +1465,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaNotificationPolicy
     listKind: GrafanaNotificationPolicyList
     plural: grafananotificationpolicies


### PR DESCRIPTION
### Background
Kubernetes CRD definitions support a nifty `categories` field which is a list of strings that can be used for grouping CRs together under umbrella terms.
An example of this is Istio resources all having the category [`istio-io`](https://github.com/istio/istio/blob/master/manifests/charts/base/crds/crd-all.gen.yaml#L17)

### Reason
Making use of categories allows for a pleasant way of listing all resources in a given scope.
And it is currently necessary to write pretty long commands to get an overview of all `Grafana-Operator` CRs in a cluster:
```sh
# Examples
kubectl get grafanas,grafanadashboards -A
# Or when using completions
kubectl get grafanas.grafana.integreatly.org,grafanadashboards.grafana.integreatly.org -A

> NAMESPACE    NAME                                           VERSION   STAGE      STAGE STATUS   AGE
> monitoring   grafana.grafana.integreatly.org/kind-grafana   11.1.3    complete   success        5d

> NAMESPACE   NAME                                            NO MATCHING INSTANCES   LAST RESYNC   AGE
> default     grafanadashboard.grafana.integreatly.org/dash                           38s           38s
```

### Solution
[Annotating CRD](https://book.kubebuilder.io/reference/markers/crd.html#crd-generation) structs to generate with categories: `grafanacrs` and `grafana-operator`
```diff
// GrafanaSpec defines the desired state of Grafana
+ // +kubebuilder:resource:categories={grafanacrs,grafana-operator}
type GrafanaSpec struct {
```
```bash
# Alternative command which finds everything
> kubectl get grafana-operator -A
NAMESPACE   NAME                                            NO MATCHING INSTANCES   LAST RESYNC   AGE
default     grafanadashboard.grafana.integreatly.org/dash                           57s           57s

NAMESPACE    NAME                                                 NO MATCHING INSTANCES   AGE
default      grafanafolder.grafana.integreatly.org/test-folder2                           9m13s
monitoring   grafanafolder.grafana.integreatly.org/test-folder                            9m13s

NAMESPACE    NAME                                           VERSION   STAGE      STAGE STATUS   AGE
monitoring   grafana.grafana.integreatly.org/kind-grafana   11.1.3    complete   success        5d
```

### Primary questions
- Is this wanted?
- Names of the categories?
- One category or multiple?
- What documentation would make sense to write on this?