### PR TITLE
Move category annotation to the correct struct in GrafanaDashboard and Grafanas

### DIFF
--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -53,7 +53,6 @@ type OperatorReconcileVars struct {
 }
 
 // GrafanaSpec defines the desired state of Grafana
-// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// Config defines how your grafana ini file should looks like.
@@ -144,6 +143,7 @@ type GrafanaStatus struct {
 // +kubebuilder:printcolumn:name="Stage",type="string",JSONPath=".status.stage",description=""
 // +kubebuilder:printcolumn:name="Stage status",type="string",JSONPath=".status.stageStatus",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
+// +kubebuilder:resource:categories={grafana-operator}
 type Grafana struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -60,7 +60,6 @@ type GrafanaDashboardUrlAuthorization struct {
 // GrafanaDashboardSpec defines the desired state of GrafanaDashboard
 // +kubebuilder:validation:XValidation:rule="(has(self.folderUID) && !(has(self.folderRef))) || (has(self.folderRef) && !(has(self.folderUID))) || !(has(self.folderRef) && (has(self.folderUID)))", message="Only one of folderUID or folderRef can be declared at the same time"
 // +kubebuilder:validation:XValidation:rule="(has(self.folder) && !(has(self.folderRef) || has(self.folderUID))) || !(has(self.folder))", message="folder field cannot be set when folderUID or folderRef is already declared"
-// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaDashboardSpec struct {
 	// dashboard json
 	// +optional
@@ -195,6 +194,7 @@ type GrafanaDashboardStatus struct {
 // +kubebuilder:printcolumn:name="No matching instances",type="boolean",JSONPath=".status.NoMatchingInstances",description=""
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
+// +kubebuilder:resource:categories={grafana-operator}
 type GrafanaDashboard struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaDashboard
     listKind: GrafanaDashboardList
     plural: grafanadashboards

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: Grafana
     listKind: GrafanaList
     plural: grafanas

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaDashboard
     listKind: GrafanaDashboardList
     plural: grafanadashboards

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: Grafana
     listKind: GrafanaList
     plural: grafanas

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -537,6 +537,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: GrafanaDashboard
     listKind: GrafanaDashboardList
     plural: grafanadashboards
@@ -1781,6 +1783,8 @@ metadata:
 spec:
   group: grafana.integreatly.org
   names:
+    categories:
+    - grafana-operator
     kind: Grafana
     listKind: GrafanaList
     plural: grafanas


### PR DESCRIPTION
Looks like I was too hasty when I redid my changes for #1650 
Here's a quick fix to ensure GrafanaDashboards and Grafanas also get the `grafana-operator` category
