### PR TITLE
Implement `spec.uid` for `GrafanaFolder`

### DIFF
--- a/api/v1beta1/grafanafolder_types_test.go
+++ b/api/v1beta1/grafanafolder_types_test.go
@@ -39,3 +39,36 @@ func TestGrafanaFolder_GetTitle(t *testing.T) {
 		})
 	}
 }
+
+func TestGrafanaFolder_GetUID(t *testing.T) {
+	tests := []struct {
+		name string
+		cr   GrafanaFolder
+		want string
+	}{
+		{
+			name: "No custom UID",
+			cr: GrafanaFolder{
+				ObjectMeta: metav1.ObjectMeta{UID: "92fd2e0a-ad63-4fcf-9890-68a527cbd674"},
+			},
+			want: "92fd2e0a-ad63-4fcf-9890-68a527cbd674",
+		},
+		{
+			name: "Custom UID",
+			cr: GrafanaFolder{
+				ObjectMeta: metav1.ObjectMeta{UID: "92fd2e0a-ad63-4fcf-9890-68a527cbd674"},
+				Spec: GrafanaFolderSpec{
+					CustomUID: "custom-uid",
+				},
+			},
+			want: "custom-uid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cr.CustomUIDOrUID()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -49,11 +49,11 @@ spec:
             description: GrafanaFolderSpec defines the desired state of GrafanaFolder
             properties:
               allowCrossNamespaceImport:
-                description: allow to import this resources from an operator in a
-                  different namespace
+                description: Enable matching Grafana instances outside the current
+                  namespace
                 type: boolean
               instanceSelector:
-                description: selects Grafanas for import
+                description: Selects Grafanas for import
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -110,17 +110,25 @@ spec:
                   be created
                 type: string
               permissions:
-                description: raw json with folder permissions
+                description: Raw json with folder permissions, potentially exported
+                  from Grafana
                 type: string
               resyncPeriod:
                 default: 5m
-                description: how often the folder is synced, defaults to 5m if not
+                description: How often the folder is synced, defaults to 5m if not
                   set
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               title:
+                description: Display name of the folder in Grafana
                 type: string
+              uid:
+                description: Manually specify the UID the Folder is created with
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
             required:
             - instanceSelector
             type: object
@@ -129,6 +137,9 @@ spec:
               rule: (has(self.parentFolderUID) && !(has(self.parentFolderRef))) ||
                 (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef)
                 && (has(self.parentFolderUID)))
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -82,7 +82,7 @@ func getFolderUID(ctx context.Context, k8sClient client.Client, ref operatorapi.
 	}
 	removeNoMatchingFolder(ref.Conditions())
 
-	return string(folder.ObjectMeta.UID), nil
+	return folder.CustomUIDOrUID(), nil
 }
 
 func labelsSatisfyMatchExpressions(labels map[string]string, matchExpressions []metav1.LabelSelectorRequirement) bool {

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -699,15 +699,16 @@ func (r *GrafanaDashboardReconciler) GetFolderUID(
 	limit := int64(1000)
 	for {
 		params := folders.NewGetFoldersParams().WithPage(&page).WithLimit(&limit)
-		resp, err := client.Folders.GetFolders(params)
+
+		foldersResp, err := client.Folders.GetFolders(params)
 		if err != nil {
 			return false, "", err
 		}
-		folders := resp.GetPayload()
+		folders := foldersResp.GetPayload()
 
-		for _, folder := range folders {
-			if strings.EqualFold(folder.Title, title) {
-				return true, folder.UID, nil
+		for _, remoteFolder := range folders {
+			if strings.EqualFold(remoteFolder.Title, title) {
+				return true, remoteFolder.UID, nil
 			}
 		}
 		if len(folders) < int(limit) {

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -49,11 +49,11 @@ spec:
             description: GrafanaFolderSpec defines the desired state of GrafanaFolder
             properties:
               allowCrossNamespaceImport:
-                description: allow to import this resources from an operator in a
-                  different namespace
+                description: Enable matching Grafana instances outside the current
+                  namespace
                 type: boolean
               instanceSelector:
-                description: selects Grafanas for import
+                description: Selects Grafanas for import
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -110,17 +110,25 @@ spec:
                   be created
                 type: string
               permissions:
-                description: raw json with folder permissions
+                description: Raw json with folder permissions, potentially exported
+                  from Grafana
                 type: string
               resyncPeriod:
                 default: 5m
-                description: how often the folder is synced, defaults to 5m if not
+                description: How often the folder is synced, defaults to 5m if not
                   set
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               title:
+                description: Display name of the folder in Grafana
                 type: string
+              uid:
+                description: Manually specify the UID the Folder is created with
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
             required:
             - instanceSelector
             type: object
@@ -129,6 +137,9 @@ spec:
               rule: (has(self.parentFolderUID) && !(has(self.parentFolderRef))) ||
                 (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef)
                 && (has(self.parentFolderUID)))
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -1348,11 +1348,11 @@ spec:
             description: GrafanaFolderSpec defines the desired state of GrafanaFolder
             properties:
               allowCrossNamespaceImport:
-                description: allow to import this resources from an operator in a
-                  different namespace
+                description: Enable matching Grafana instances outside the current
+                  namespace
                 type: boolean
               instanceSelector:
-                description: selects Grafanas for import
+                description: Selects Grafanas for import
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1409,17 +1409,25 @@ spec:
                   be created
                 type: string
               permissions:
-                description: raw json with folder permissions
+                description: Raw json with folder permissions, potentially exported
+                  from Grafana
                 type: string
               resyncPeriod:
                 default: 5m
-                description: how often the folder is synced, defaults to 5m if not
+                description: How often the folder is synced, defaults to 5m if not
                   set
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               title:
+                description: Display name of the folder in Grafana
                 type: string
+              uid:
+                description: Manually specify the UID the Folder is created with
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
             required:
             - instanceSelector
             type: object
@@ -1428,6 +1436,9 @@ spec:
               rule: (has(self.parentFolderUID) && !(has(self.parentFolderRef))) ||
                 (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef)
                 && (has(self.parentFolderUID)))
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -2807,7 +2807,7 @@ GrafanaFolder is the Schema for the grafanafolders API
         <td>
           GrafanaFolderSpec defines the desired state of GrafanaFolder<br/>
           <br/>
-            <i>Validations</i>:<li>(has(self.parentFolderUID) && !(has(self.parentFolderRef))) || (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef) && (has(self.parentFolderUID))): Only one of parentFolderUID or parentFolderRef can be set</li>
+            <i>Validations</i>:<li>(has(self.parentFolderUID) && !(has(self.parentFolderRef))) || (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef) && (has(self.parentFolderUID))): Only one of parentFolderUID or parentFolderRef can be set</li><li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2841,7 +2841,7 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         <td><b><a href="#grafanafolderspecinstanceselector">instanceSelector</a></b></td>
         <td>object</td>
         <td>
-          selects Grafanas for import<br/>
+          Selects Grafanas for import<br/>
           <br/>
             <i>Validations</i>:<li>self == oldSelf: Value is immutable</li>
         </td>
@@ -2850,7 +2850,7 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         <td><b>allowCrossNamespaceImport</b></td>
         <td>boolean</td>
         <td>
-          allow to import this resources from an operator in a different namespace<br/>
+          Enable matching Grafana instances outside the current namespace<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2871,14 +2871,14 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         <td><b>permissions</b></td>
         <td>string</td>
         <td>
-          raw json with folder permissions<br/>
+          Raw json with folder permissions, potentially exported from Grafana<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>resyncPeriod</b></td>
         <td>string</td>
         <td>
-          how often the folder is synced, defaults to 5m if not set<br/>
+          How often the folder is synced, defaults to 5m if not set<br/>
           <br/>
             <i>Format</i>: duration<br/>
             <i>Default</i>: 5m<br/>
@@ -2888,7 +2888,16 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         <td><b>title</b></td>
         <td>string</td>
         <td>
+          Display name of the folder in Grafana<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>uid</b></td>
+        <td>string</td>
+        <td>
+          Manually specify the UID the Folder is created with<br/>
           <br/>
+            <i>Validations</i>:<li>self == oldSelf: spec.uid is immutable</li>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2900,7 +2909,7 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
 
 
 
-selects Grafanas for import
+Selects Grafanas for import
 
 <table>
     <thead>

--- a/hack/kind/start-kind.sh
+++ b/hack/kind/start-kind.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+KIND=${KIND:-kind}
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kind-grafana}
 KUBECONFIG=${KUBECONFIG:-~/.kube/kind-grafana-operator}
 CRD_NS=${CRD_NS:-grafana-crds}
@@ -6,19 +7,19 @@ CRD_NS=${CRD_NS:-grafana-crds}
 set -eu
 
 # Find the script directory
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 # Make sure there is no current cluster
 echo "Delete existing cluster"
-kind --kubeconfig="${KUBECONFIG}" delete cluster --name "${KIND_CLUSTER_NAME}" \
-  || echo "There was no existing cluster"
+${KIND} --kubeconfig="${KUBECONFIG}" delete cluster --name "${KIND_CLUSTER_NAME}" ||
+  echo "There was no existing cluster"
 
 # Start kind cluster
 echo ""
 echo "###############################"
 echo "# 1. Start kind cluster       #"
 echo "###############################"
-kind --kubeconfig "${KUBECONFIG}" create cluster \
+${KIND} --kubeconfig "${KUBECONFIG}" create cluster \
   --name "${KIND_CLUSTER_NAME}" \
   --wait 120s \
   --config="${SCRIPT_DIR}/resources/cluster.yaml"
@@ -34,10 +35,10 @@ echo "###############################"
 kubectl --kubeconfig="${KUBECONFIG}" \
   apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 kubectl --kubeconfig="${KUBECONFIG}" \
-        -n ingress-nginx \
-        wait deploy ingress-nginx-controller \
-        --for condition=Available \
-        --timeout=90s
+  -n ingress-nginx \
+  wait deploy ingress-nginx-controller \
+  --for condition=Available \
+  --timeout=90s
 
 # Will install the CRD:s
 echo ""


### PR DESCRIPTION
Disclaimer: I'm not a Go developer in any capacity, feel free to address any issues as I will gladly modify the PR to suit the project.

I took a stab at #1636 and limited it to the GrafanaFolder resource for now, I'm planning a separate PR for both `GrafanaNotificationPolicy` and `GrafanaContactPoint` with almost identical changes once the design in this PR has been approved.

The Makefile changes were mainly due to me trying to figure out how to work with the Operator locally and I found a lot of discrepancies with the `make help` target.

I struggled a fair bit with testing and validating as I'm unfamiliar with the project, hence I spent a lot of time in the Makefile.
For now, I have yet to find an existing way to easily deploy the most recently built ko-image into my local kind cluster, specifically due to the default `imagePullPolicy: Always` that is default in the `config/manager/manager.yaml`

<details>
<summary>Local procedure for testing</summary>

```bash
make start-kind
make install
make ko-build-kind
IMG=ko.local/grafana/grafana-operator make deploy
# Change imagePullPolicy
kubectl patch deploy -n grafana-operator-system grafana-operator-controller-manager-v5  --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value":"IfNotPresent"}]'

# Test resources
kubectl apply -f https://raw.githubusercontent.com/grafana-operator/grafana-operator/master/examples/basic/resources.yaml
kubectl apply -f ../test-folders.yaml
```

`../test-folders.yaml`
```yaml---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaFolder
metadata:
  name: test-folder
spec:
  instanceSelector:
    matchLabels:
      dashboards: grafana
  title: Folder
---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaFolder
metadata:
  name: test-folder2
spec:
  instanceSelector:
    matchLabels:
      dashboards: grafana
  # uid: custom-uid # I repeatedly changed this to ensure immutability rules worked as expected
  title: Folder2
```
- Changing the uid: `The GrafanaFolder "test-folder2" is invalid: spec.uid: Invalid value: "string": Value is immutable`
- Adding/Removing uid: `The GrafanaFolder "test-folder2" is invalid: spec: Invalid value: "object": uid is immutable`

</details>

<details>
<summary>Old vs new make help</summary>

```diff
Usage:
  make <target>

General
  help             Display this help.
<  yq               Download yq locally if necessary.

Development
  manifests        Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
  generate         Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
  vet              Run go vet against code.
  test             Run tests.

Build
  build            Build manager binary.
  run              Run a controller from your host.

Deployment
  install          Install CRDs into the K8s cluster specified in ~/.kube/config.
  uninstall        Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
  deploy           Deploy controller to the K8s cluster specified in ~/.kube/config.
  deploy-chainsaw  Deploy controller to the K8s cluster specified in ~/.kube/config.
  undeploy         Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
>  start-kind       Start kind cluster locally

Build Dependencies
  kustomize        Download kustomize locally if necessary.
  controller-gen   Download controller-gen locally if necessary.
  envtest          Download envtest-setup locally if necessary.
  operator-sdk     Download operator-sdk locally if necessary.
>  yq               Download yq locally if necessary.
>  kind             Download kind locally if necessary.
  bundle           Generate bundle manifests and metadata, then validate generated files.
  e2e              Run e2e tests using chainsaw.
>  ko-build-local   Build Docker image with KO
>  ko-build-kind    Build and Load Docker image into kind cluster
  bundle-build     Build the bundle image.
  bundle-push      Push the bundle image.
  opm              Download opm locally if necessary.
  catalog-build    Build a catalog image.
  catalog-push     Push a catalog image.
```

</details>