### PR TITLE
Implement `spec.uid` for `GrafanaDashboard`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 .PHONY: all
-all: manifests test api-docs
+all: manifests test api-docs helm/docs
 
 ##@ General
 

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -234,11 +234,11 @@ func (in *GrafanaDashboard) CustomUIDOrUID(dashboardUID string) string {
 		return in.Spec.CustomUID
 	}
 
-	if dashboardUID == "" {
-		return string(in.ObjectMeta.UID)
+	if dashboardUID != "" {
+		return dashboardUID
 	}
 
-	return dashboardUID
+	return string(in.ObjectMeta.UID)
 }
 
 // FolderNamespace implements FolderReferencer.

--- a/api/v1beta1/grafanadashboard_types_test.go
+++ b/api/v1beta1/grafanadashboard_types_test.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -105,61 +106,152 @@ func Test_Gzip(t *testing.T) {
 
 func TestGrafanaDashboardIsUpdatedUID(t *testing.T) {
 	crUID := "crUID"
+	dashUID := "dashUID"
+	specUID := "specUID"
 	tests := []struct {
 		name         string
 		crUID        string
 		statusUID    string
 		dashboardUID string
+		specUID      string
 		want         bool
 	}{
+		// Validate always false when statusUID is empty
+		// Since dashboardUID is ignoredk the only variable is customUID
 		{
-			name:         "Status.UID and dashboard UID are empty",
+			name:         "Empty StatusUID always results in false",
 			crUID:        crUID,
 			statusUID:    "",
-			dashboardUID: "newUID",
+			dashboardUID: "",
+			specUID:      "",
 			want:         false,
 		},
 		{
-			name:         "Status.UID is empty, dashboard UID is not",
+			name:         "Always false when statusUID is empty regardless of dashUID being set",
 			crUID:        crUID,
 			statusUID:    "",
-			dashboardUID: "newUID",
+			dashboardUID: dashUID,
+			specUID:      "",
 			want:         false,
 		},
 		{
-			name:         "Status.UID is not empty (same as CR uid), new UID is empty",
+			name:         "Always false when statusUID is empty regardless of customUID being set",
+			crUID:        crUID,
+			statusUID:    "",
+			dashboardUID: "",
+			specUID:      specUID,
+			want:         false,
+		},
+		{
+			name:         "Always false when statusUID is empty regardless of customUID or dashUID being set",
+			crUID:        crUID,
+			statusUID:    "",
+			dashboardUID: dashUID,
+			specUID:      specUID,
+			want:         false,
+		},
+		// Validate that crUID is always overwritten by dashUID or customUID
+		// dashboardUID is always overwritten by customUID which falls back to crUID
+		{
+			name:         "DashboardUID and customUID empty",
 			crUID:        crUID,
 			statusUID:    crUID,
 			dashboardUID: "",
+			specUID:      "",
 			want:         false,
 		},
 		{
-			name:         "Status.UID is not empty (different from CR uid), new UID is empty",
+			name:         "DashboardUID set and customUID empty",
 			crUID:        crUID,
-			statusUID:    "oldUID",
+			statusUID:    dashUID,
+			dashboardUID: dashUID,
+			specUID:      "",
+			want:         false,
+		},
+		{
+			name:         "DashboardUID set and customUID set",
+			crUID:        crUID,
+			statusUID:    specUID,
+			dashboardUID: dashUID,
+			specUID:      specUID,
+			want:         false,
+		},
+		{
+			name:         "DashboardUID empty and customUID set",
+			crUID:        crUID,
+			statusUID:    specUID,
 			dashboardUID: "",
+			specUID:      specUID,
+			want:         false,
+		},
+		// Validate updates are detected correctly
+		{
+			name:         "DashboardUID updated and customUID empty",
+			crUID:        crUID,
+			statusUID:    crUID,
+			dashboardUID: dashUID,
+			specUID:      "",
 			want:         true,
 		},
 		{
-			name:         "Status.UID is not empty, new UID is different",
+			name:         "DashboardUID updated and customUID set",
+			crUID:        crUID,
+			statusUID:    specUID,
+			dashboardUID: dashUID,
+			specUID:      specUID,
+			want:         false,
+		},
+		{
+			name:         "new dashUID and no customUID",
 			crUID:        crUID,
 			statusUID:    "oldUID",
-			dashboardUID: "newUID",
+			dashboardUID: dashUID,
+			specUID:      "",
+			want:         true,
+		},
+		{
+			name:         "dashUID removed and no customUID",
+			crUID:        crUID,
+			statusUID:    "oldUID",
+			dashboardUID: "",
+			specUID:      "",
+			want:         true,
+		},
+		// Validate that statusUID detection works even in impossible cases expecting cr or customUID to change
+		{
+			name:         "IMPOSSIBLE: Old status with new customUID",
+			crUID:        crUID,
+			statusUID:    "oldUID",
+			dashboardUID: "",
+			specUID:      specUID,
+			want:         true,
+		},
+		{
+			name:         "IMPOSSIBLE: Old Status with all UIDs being equal",
+			crUID:        crUID,
+			statusUID:    "oldUID",
+			dashboardUID: crUID,
+			specUID:      crUID,
 			want:         true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cr := getDashboardCR(t, tt.crUID, tt.statusUID)
-			got := cr.IsUpdatedUID(tt.dashboardUID)
+			cr := getDashboardCR(t, tt.crUID, tt.statusUID, tt.specUID, tt.dashboardUID)
+			uid := cr.CustomUIDOrUID(tt.dashboardUID)
+
+			got := cr.IsUpdatedUID(uid)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func getDashboardCR(t *testing.T, crUID string, statusUID string) GrafanaDashboard {
+func getDashboardCR(t *testing.T, crUID string, statusUID string, specUID string, dashUID string) GrafanaDashboard {
 	t.Helper()
+	var dashboardModel map[string]interface{} = make(map[string]interface{})
+	dashboardModel["uid"] = dashUID
+	dashboard, _ := json.Marshal(dashboardModel)
 
 	cr := GrafanaDashboard{
 		TypeMeta: metav1.TypeMeta{},
@@ -174,6 +266,8 @@ func getDashboardCR(t *testing.T, crUID string, statusUID string) GrafanaDashboa
 					"dashboard": "grafana",
 				},
 			},
+			CustomUID: specUID,
+			Json:      string(dashboard),
 		},
 		Status: GrafanaDashboardStatus{
 			UID: statusUID,

--- a/api/v1beta1/grafanadashboard_types_test.go
+++ b/api/v1beta1/grafanadashboard_types_test.go
@@ -251,7 +251,7 @@ func getDashboardCR(t *testing.T, crUID string, statusUID string, specUID string
 	t.Helper()
 	var dashboardModel map[string]interface{} = make(map[string]interface{})
 	dashboardModel["uid"] = dashUID
-	dashboard, _ := json.Marshal(dashboardModel)
+	dashboard, _ := json.Marshal(dashboardModel) //nolint:errcheck
 
 	cr := GrafanaDashboard{
 		TypeMeta: metav1.TypeMeta{},

--- a/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
@@ -155,7 +155,7 @@ spec:
                     name:
                       type: string
                     value:
-                      description: Inline evn value
+                      description: Inline env value
                       type: string
                     valueFrom:
                       description: Reference on value source, might be the reference
@@ -328,6 +328,13 @@ spec:
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              uid:
+                description: Manually specify the uid for the dashboard, overwrites
+                  uids already present in the json model
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
               url:
                 description: dashboard url
                 type: string
@@ -398,6 +405,9 @@ spec:
                 declared
               rule: (has(self.folder) && !(has(self.folderRef) || has(self.folderUID)))
                 || !(has(self.folder))
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaDashboardStatus defines the observed state of GrafanaDashboard
             properties:

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -207,6 +207,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 	}
 
+	// Retrieving the model before the loop ensures to exit early in case of failure and not fail once per matching instance
 	dashboardModel, hash, err := r.getDashboardModel(cr, dashboardJson)
 	if err != nil {
 		controllerLog.Error(err, "failed to prepare dashboard model", "dashboard", cr.Name)
@@ -579,11 +580,7 @@ func (r *GrafanaDashboardReconciler) getDashboardModel(cr *v1beta1.GrafanaDashbo
 	dashboardModel["id"] = nil
 
 	uid, _ := dashboardModel["uid"].(string) //nolint:errcheck
-	if uid == "" {
-		uid = string(cr.UID)
-	}
-
-	dashboardModel["uid"] = uid
+	dashboardModel["uid"] = cr.CustomUIDOrUID(uid)
 
 	return dashboardModel, fmt.Sprintf("%x", hash.Sum(nil)), nil
 }

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
@@ -155,7 +155,7 @@ spec:
                     name:
                       type: string
                     value:
-                      description: Inline evn value
+                      description: Inline env value
                       type: string
                     valueFrom:
                       description: Reference on value source, might be the reference
@@ -328,6 +328,13 @@ spec:
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              uid:
+                description: Manually specify the uid for the dashboard, overwrites
+                  uids already present in the json model
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
               url:
                 description: dashboard url
                 type: string
@@ -398,6 +405,9 @@ spec:
                 declared
               rule: (has(self.folder) && !(has(self.folderRef) || has(self.folderUID)))
                 || !(has(self.folder))
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaDashboardStatus defines the observed state of GrafanaDashboard
             properties:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -718,7 +718,7 @@ spec:
                     name:
                       type: string
                     value:
-                      description: Inline evn value
+                      description: Inline env value
                       type: string
                     valueFrom:
                       description: Reference on value source, might be the reference
@@ -891,6 +891,13 @@ spec:
                 format: duration
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              uid:
+                description: Manually specify the uid for the dashboard, overwrites
+                  uids already present in the json model
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
               url:
                 description: dashboard url
                 type: string
@@ -961,6 +968,9 @@ spec:
                 declared
               rule: (has(self.folder) && !(has(self.folderRef) || has(self.folderUID)))
                 || !(has(self.folder))
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaDashboardStatus defines the observed state of GrafanaDashboard
             properties:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -1132,7 +1132,7 @@ GrafanaDashboard is the Schema for the grafanadashboards API
         <td>
           GrafanaDashboardSpec defines the desired state of GrafanaDashboard<br/>
           <br/>
-            <i>Validations</i>:<li>(has(self.folderUID) && !(has(self.folderRef))) || (has(self.folderRef) && !(has(self.folderUID))) || !(has(self.folderRef) && (has(self.folderUID))): Only one of folderUID or folderRef can be declared at the same time</li><li>(has(self.folder) && !(has(self.folderRef) || has(self.folderUID))) || !(has(self.folder)): folder field cannot be set when folderUID or folderRef is already declared</li>
+            <i>Validations</i>:<li>(has(self.folderUID) && !(has(self.folderRef))) || (has(self.folderRef) && !(has(self.folderUID))) || !(has(self.folderRef) && (has(self.folderUID))): Only one of folderUID or folderRef can be declared at the same time</li><li>(has(self.folder) && !(has(self.folderRef) || has(self.folderUID))) || !(has(self.folder)): folder field cannot be set when folderUID or folderRef is already declared</li><li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1286,6 +1286,15 @@ GrafanaDashboardSpec defines the desired state of GrafanaDashboard
           <br/>
             <i>Format</i>: duration<br/>
             <i>Default</i>: 5m<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>uid</b></td>
+        <td>string</td>
+        <td>
+          Manually specify the uid for the dashboard, overwrites uids already present in the json model<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: spec.uid is immutable</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1624,7 +1633,7 @@ More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/nam
         <td><b>value</b></td>
         <td>string</td>
         <td>
-          Inline evn value<br/>
+          Inline env value<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/tests/e2e/example-test/05-dashboard.yaml
+++ b/tests/e2e/example-test/05-dashboard.yaml
@@ -24,7 +24,7 @@ spec:
     local myRange = std.extVar('CUSTOM_RANGE_ENV');
     {
       id: null,
-      title: "Simple Dashboard wht CM envs",
+      title: "Simple Dashboard with CM envs",
       tags: [],
       style: "dark",
       timezone: "browser",

--- a/tests/e2e/immutable_uids/grafanadashboard/base-resources.yaml
+++ b/tests/e2e/immutable_uids/grafanadashboard/base-resources.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana-immutable
+  labels:
+    immutable: "grafana"
+spec:
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: root
+      admin_password: secret
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: dashboard-uid
+spec:
+  instanceSelector:
+    matchLabels:
+      immutable: "grafana"
+  resyncPeriod: 3s
+  json: ($dashboardModel)
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: metadata-uid
+spec:
+  instanceSelector:
+    matchLabels:
+      immutable: "grafana"
+  resyncPeriod: 3s
+  json: ($dashboardModel)
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: spec-uid
+spec:
+  instanceSelector:
+    matchLabels:
+      immutable: "grafana"
+  resyncPeriod: 3s
+  json: ($dashboardModel)
+  uid: SpecUID

--- a/tests/e2e/immutable_uids/grafanadashboard/chainsaw-test.yaml
+++ b/tests/e2e/immutable_uids/grafanadashboard/chainsaw-test.yaml
@@ -1,0 +1,171 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: dashboards-uids
+spec:
+  bindings:
+    - name: dashboardModel
+      value: |
+        {
+          "id": null,
+          "title": "Simple Dashboard",
+          "tags": [],
+          "timezone": "browser",
+          "editable": true,
+          "graphTooltip": 1,
+          "panels": [],
+          "time": {
+            "from": "now-6h",
+            "to": "now"
+          },
+          "timepicker": {
+            "time_options": [],
+            "refresh_intervals": []
+          },
+          "templating": {
+            "list": []
+          },
+          "annotations": {
+            "list": []
+          },
+          "refresh": "5s",
+          "schemaVersion": 39,
+          "version": 0,
+          "links": [],
+          "fiscalYearStartMonth": 0,
+          "weekStart": ""
+        }
+    - name: dashboardModelPatch
+      value: |
+        {
+          "id": null,
+          "uid": "newDashUID",
+          "title": "Simple Dashboard2",
+          "tags": [],
+          "timezone": "browser",
+          "editable": true,
+          "graphTooltip": 1,
+          "panels": [],
+          "time": {
+            "from": "now-6h",
+            "to": "now"
+          },
+          "timepicker": {
+            "time_options": [],
+            "refresh_intervals": []
+          },
+          "templating": {
+            "list": []
+          },
+          "annotations": {
+            "list": []
+          },
+          "refresh": "5s",
+          "schemaVersion": 39,
+          "version": 0,
+          "links": [],
+          "fiscalYearStartMonth": 0,
+          "weekStart": ""
+        }
+
+  steps:
+    - name: Create dashboards and Grafana instance
+      try:
+        - apply:
+            file: base-resources.yaml
+
+    - name: Attempt patching uids
+      try:
+        - patch:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: dashboard-uid
+              spec:
+                json: ($dashboardModelPatch)
+
+        - patch:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: metadata-uid
+              spec:
+                uid: newCRUID
+            expect:
+              - check:
+                  ($error != null): true
+
+        - patch:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: spec-uid
+              spec:
+                uid: newSpecUID
+            expect:
+              - check:
+                  ($error != null): true
+
+    - name: Verify uid only changed for jsonModels
+      try:
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: dashboard-uid
+              spec:
+                json: ($dashboardModelPatch)
+
+        - script:
+            content: kubectl get grafanadashboards -n $NAMESPACE -o json metadata-uid
+            outputs:
+              - name: metadataUid
+                value: (json_parse($stdout))
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: metadata-uid
+                uid: "($metadataUid.metadata.uid)"
+
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: spec-uid
+              spec:
+                uid: SpecUID
+
+    - name: Verify uid in Grafana Instance status object
+      try:
+        - script:
+            content: kubectl get grafanadashboards -n $NAMESPACE -o json metadata-uid
+            outputs:
+              - name: metadataUid
+                value: (json_parse($stdout))
+        - script:
+            content: kubectl get grafanadashboards -n $NAMESPACE -o json spec-uid
+            outputs:
+              - name: specUid
+                value: (json_parse($stdout))
+
+        - sleep:
+            duration: 30s
+
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: Grafana
+              metadata:
+                name: grafana-immutable
+              status:
+                (contains(dashboards[*], join('/', [$namespace, 'dashboard-uid', 'newDashUID']))): true
+                (contains(dashboards[*], join('/', [$namespace, 'metadata-uid', $metadataUid.metadata.uid]))): true
+                (contains(dashboards[*], join('/', [$namespace, 'spec-uid', $specUid.spec.uid]))): true

--- a/tests/e2e/immutable_uids/grafanadashboard/chainsaw-test.yaml
+++ b/tests/e2e/immutable_uids/grafanadashboard/chainsaw-test.yaml
@@ -143,6 +143,52 @@ spec:
               spec:
                 uid: SpecUID
 
+    - name: Ensure Grafana and other resources are ready
+      try:
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: Grafana
+              metadata:
+                name: grafana-immutable
+              status:
+                stage: complete
+                stageStatus: success
+
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: dashboard-uid
+              status:
+                conditions:
+                - reason: ApplySuccessful
+                  status: "True"
+                  type: DashboardSynchronized
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: metadata-uid
+              status:
+                conditions:
+                - reason: ApplySuccessful
+                  status: "True"
+                  type: DashboardSynchronized
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaDashboard
+              metadata:
+                name: spec-uid
+              status:
+                conditions:
+                - reason: ApplySuccessful
+                  status: "True"
+                  type: DashboardSynchronized
+
     - name: Verify uid in Grafana Instance status object
       try:
         - script:
@@ -155,9 +201,6 @@ spec:
             outputs:
               - name: specUid
                 value: (json_parse($stdout))
-
-        - sleep:
-            duration: 30s
 
         - assert:
             resource:


### PR DESCRIPTION
Followed the same pattern as #1686 for the CustomUID.
As discussed in the weekly sync, `spec.uid` or `metadata.uid` will always overwrite `dashboardModel.uid`.

Thanks to the existing `Status.UID` update detection, existing dashboards are automatically migrated to using `metadata.uid` by the operator.

<details>
<summary>Local procedure for testing</summary>

### Chainsaw tests
```bash
make e2e-local-gh-actions TESTS=immutable_uids
```

### Manual
```bash
make start-kind
make deploy
kind export kubeconfig --name kind-grafana

# Test resources
kubectl apply -f https://raw.githubusercontent.com/grafana-operator/grafana-operator/master/examples/basic/resources.yaml
kubectl apply -f ../test-dashboard.yaml

# Check status:
# dashboards
#   - default/dashboard-uid/dashUID
kubectl get grafanas -A -o yaml

# Build and apply image to cluster
make ko-build-kind
IMG=ko.local/grafana/grafana-operator make deploy
kubectl patch deploy -n grafana-operator-system grafana-operator-controller-manager-v5  --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value":"IfNotPresent"}]'

# Check status:
# dashboards
#   - default/dashboard-uid/dashUID -> specUID
kubectl get grafanas -A -o yaml

```

`../test-dashboard.yaml`
```yaml---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDashboard
metadata:
  name: dashboard-uid
spec:
  instanceSelector:
    matchLabels:
      dashboards: "grafana"
  uid: specUID
  resyncPeriod: 10s
  json: >
    {
      "id": null,
      "uid": "dashUID",
      "title": "Simple Dashboard",
      "tags": [],
      "style": "dark",
      "timezone": "browser",
      "editable": true,
      "hideControls": false,
      "graphTooltip": 1,
      "panels": [],
      "time": {
        "from": "now-6h",
        "to": "now"
      },
      "timepicker": {
        "time_options": [],
        "refresh_intervals": []
      },
      "templating": {
        "list": []
      },
      "annotations": {
        "list": []
      },
      "refresh": "5s",
      "schemaVersion": 17,
      "version": 0,
      "links": []
    }
```

</details>

- [x] Chainsaw tests for immutability of `spec.uid`
- [x] Chainsaw tests for expected status on Grafana instance
- [ ] Update dashboard UID [documentation](https://grafana.github.io/grafana-operator/docs/dashboards/#dashboard-uid-management)