### PR TITLE
feat: add user agent to requests made by operator

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Install ko
         uses: ko-build/setup-ko@v0.7
         with:
-          version: v0.13.0
+          version: v0.16.0
 
       - name: Install chainsaw
         uses: kyverno/action-install-chainsaw@v0.2.10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
 
       - uses: ko-build/setup-ko@v0.7
         with:
-          version: v0.15.1
+          version: v0.16.0
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.6.0

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,8 @@
+builds:
+- id: grafana-operator
+  dir: .
+  main: .
+  flags:
+  - '-trimpath'
+  ldflags:
+  - -X github.com/grafana/grafana-operator/v5/embeds.Version={{.Git.Tag}}

--- a/controllers/client/round_tripper.go
+++ b/controllers/client/round_tripper.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/grafana/grafana-operator/v5/embeds"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -36,6 +37,7 @@ func NewInstrumentedRoundTripper(relatedResource string, metric *prometheus.Coun
 }
 
 func (in *instrumentedRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Add("user-agent", "grafana-operator/"+embeds.Version)
 	resp, err := in.wrapped.RoundTrip(r)
 	if resp != nil {
 		in.metric.WithLabelValues(

--- a/embeds/README.md
+++ b/embeds/README.md
@@ -1,7 +1,11 @@
 # Embeds
 
-This directory is used for embedding FS structs into go code.
+This package contains static information compiled into the binary at build time.
 
 # Grafonnet
 
 The Grafonnet Jsonnet is used to allow users to define their dashboards using the jsonnet framework.
+
+# Version
+
+The `Version` variable is set during production builds by `ko`. Configuration for this can be found in `.ko.yaml`

--- a/embeds/grafana_embeds.go
+++ b/embeds/grafana_embeds.go
@@ -19,3 +19,6 @@ var TestDashboardEmbedWithEnvExpectedJSON []byte
 
 //go:embed testing/jsonnetProjectWithRuntimeRaw.tar.gz
 var TestJsonnetProjectBuildFolderGzip []byte
+
+// this variable is replaced during production builds
+var Version = "dev"

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	grafanav1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers"
 	"github.com/grafana/grafana-operator/v5/controllers/autodetect"
+	"github.com/grafana/grafana-operator/v5/embeds"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -66,7 +67,7 @@ const (
 
 var (
 	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	setupLog = ctrl.Log.WithName("setup").WithValues("version", embeds.Version)
 )
 
 func init() {


### PR DESCRIPTION
This adds a user agent which includes the operator version to all requests made by the operator. By doing this, Grafana administrators can better differentiate between requests that originated from humans and those performed by the operator