### PR TITLE
Adds `.svc` to internal grafana `adminUrl`

### DIFF
--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -49,7 +49,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 
 	// try to assign the admin url
 	if !cr.PreferIngress() {
-		status.AdminUrl = fmt.Sprintf("%v://%v.%v:%d", getGrafanaServerProtocol(cr), service.Name, cr.Namespace,
+		status.AdminUrl = fmt.Sprintf("%v://%v.%v.svc:%d", getGrafanaServerProtocol(cr), service.Name, cr.Namespace,
 			int32(GetGrafanaPort(cr)))
 	}
 

--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -49,6 +49,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 
 	// try to assign the admin url
 	if !cr.PreferIngress() {
+		// .svc suffix needed for automatic openshift certificates: https://docs.openshift.com/container-platform/4.17/security/certificates/service-serving-certificate.html#add-service-certificate_service-serving-certificate
 		status.AdminUrl = fmt.Sprintf("%v://%v.%v.svc:%d", getGrafanaServerProtocol(cr), service.Name, cr.Namespace,
 			int32(GetGrafanaPort(cr)))
 	}


### PR DESCRIPTION
This patch fixes #1712 where the issue is that the url used to connect to a Grafana instance through a Service is incorrectly generated by the reconciler. This causes errors like.
```
Get \"https://grafana-service.grafana:3000/api/folders?limit=1000&page=1\": tls: failed to verify certificate: x509: certificate is valid for grafana-service.grafana.svc, grafana-service.grafana.svc.cluster.local, not grafana-service.grafana
```