### PR TITLE
Enable forced deletion of `GrafanaFolder`

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -1,9 +1,17 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
+apiVersion: chainsaw.kyverno.io/v1alpha2
 kind: Configuration
 metadata:
   name: configuration
 spec:
+  error:
+    catch:
+      - describe:
+          apiVersion: grafana.integreatly.org/v1beta1
+          kind: grafana-operator
+      - podLogs:
+          namespace: grafana-operator-system
+          tail: 100
   timeouts:
     assert: 2m0s
     cleanup: 3m0s

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -113,7 +113,8 @@ func (r *GrafanaFolderReconciler) syncFolders(ctx context.Context) (ctrl.Result,
 
 			namespace, name, uid := folder.Split()
 
-			params := folders.NewDeleteFolderParams().WithFolderUID(uid)
+			reftrue := true
+			params := folders.NewDeleteFolderParams().WithFolderUID(uid).WithForceDeleteRules(&reftrue)
 			_, err = grafanaClient.Folders.DeleteFolder(params) //nolint
 			if err != nil {
 				var notFound *folders.DeleteFolderNotFound
@@ -292,7 +293,8 @@ func (r *GrafanaFolderReconciler) onFolderDeleted(ctx context.Context, namespace
 			if err != nil {
 				return err
 			}
-			params := folders.NewDeleteFolderParams().WithFolderUID(*uid)
+			reftrue := true
+			params := folders.NewDeleteFolderParams().WithFolderUID(*uid).WithForceDeleteRules(&reftrue)
 			_, err = grafanaClient.Folders.DeleteFolder(params) //nolint
 			if err != nil {
 				var notFound *folders.DeleteFolderNotFound

--- a/tests/e2e/force_delete_folder/chainsaw-test.yaml
+++ b/tests/e2e/force_delete_folder/chainsaw-test.yaml
@@ -1,0 +1,130 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: force-delete-folders
+spec:
+  bindings:
+    - name: USER
+      value: root
+    - name: PASS
+      value: secret
+  steps:
+    - name: Create Grafana with testdata resources
+      try:
+        - apply:
+            file: ../testdata-resources.yaml
+
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                (contains(name, 'testdata-deployment')): true
+
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            timeout: 1m
+            for:
+              condition:
+                name: Ready
+                value: 'true'
+
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: Grafana
+              metadata:
+                name: testdata
+              status:
+                stage: complete
+                stageStatus: success
+
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaFolder
+              metadata:
+                name: testdata
+              status:
+                conditions:
+                - reason: ApplySuccessful
+                  status: "True"
+                  type: FolderSynchronized
+
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaAlertRuleGroup
+              metadata:
+                name: testdata
+              status:
+                conditions:
+                - reason: ApplySuccessful
+                  status: "True"
+                  type: AlertGroupSynchronized
+
+    - name: Ensure folder exists in Grafana
+      try:
+        - apply: &curlJob
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: folder-curl
+              spec:
+                backoffLimit: 1
+                template:
+                  spec:
+                    restartPolicy: Never
+                    containers:
+                      - name: curl
+                        image: alpine/curl:latest
+                        command: ["ash", "-c"]
+                        args:
+                          - |
+                            curl --fail --silent --show-error \
+                              -u ${BASIC_USER}:${BASIC_PASS} \
+                              "http://testdata-service.${NS}.svc:3000/api/folders/testdata-uid"
+                        env:
+                          - name: BASIC_USER
+                            value: ($USER)
+                          - name: BASIC_PASS
+                            value: ($PASS)
+                          - name: NS
+                            value: ($namespace)
+        - assert:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: folder-curl
+              status:
+                (conditions[?type == 'Complete']):
+                  - status: "True"
+        - delete:
+            ref:
+              apiVersion: batch/v1
+              kind: Job
+              name: folder-curl
+
+    - name: Delete Folder and verify it's removed in Grafana
+      try:
+        - delete:
+            ref:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: GrafanaFolder
+              name: testdata
+
+        - apply: *curlJob
+
+        - assert:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                name: folder-curl
+              status:
+                (conditions[?type == 'Failed']):
+                  - status: "True"

--- a/tests/e2e/force_delete_folder/chainsaw-test.yaml
+++ b/tests/e2e/force_delete_folder/chainsaw-test.yaml
@@ -4,6 +4,7 @@ kind: Test
 metadata:
   name: force-delete-folders
 spec:
+  concurrent: false
   bindings:
     - name: USER
       value: root

--- a/tests/e2e/immutable_uids/grafanadashboard/chainsaw-test.yaml
+++ b/tests/e2e/immutable_uids/grafanadashboard/chainsaw-test.yaml
@@ -4,6 +4,7 @@ kind: Test
 metadata:
   name: dashboards-uids
 spec:
+  concurrent: false
   bindings:
     - name: dashboardModel
       value: |

--- a/tests/e2e/testdata-resources.yaml
+++ b/tests/e2e/testdata-resources.yaml
@@ -1,0 +1,351 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: testdata
+  labels:
+    test: ($test.metadata.name)
+spec:
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: ($USER)
+      admin_password: ($PASS)
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: testdata
+spec:
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: ($test.metadata.name)
+  uid: testdata-uid
+  title: "Test Data"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: testdata
+spec:
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "($test.metadata.name)"
+  datasource:
+    orgId: 1
+    isDefault: true
+    uid: grafana-testdata
+    name: grafana-testdata-datasource
+    type: grafana-testdata-datasource
+    access: proxy
+    basicAuth: false
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: testdata
+spec:
+  folderRef: testdata
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: ($test.metadata.name)
+  interval: 5m
+  rules:
+    - uid: ae1rhq
+      title: Test
+      condition: C
+      data:
+        - refId: A
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: grafana-testdata
+          model:
+            drop: 0
+            intervalMs: 1000
+            labels: ""
+            max: 50
+            maxDataPoints: 43200
+            min: -50
+            noise: 0
+            refId: A
+            scenarioId: random_walk
+            seriesCount: 3
+            spread: 5
+            startValue: 0
+            stringInput: 1,20,90,30,5,0
+        - refId: B
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            conditions:
+              - evaluator:
+                  params:
+                    - 0
+                    - 0
+                  type: gt
+                operator:
+                  type: and
+                query:
+                  params: []
+                reducer:
+                  params: []
+                  type: avg
+                type: query
+            datasource:
+              name: Expression
+              type: __expr__
+              uid: __expr__
+            expression: A
+            hide: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+            reducer: max
+            refId: B
+            settings:
+              mode: dropNN
+            type: reduce
+        - refId: C
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            conditions:
+              - evaluator:
+                  params:
+                    - 45
+                    - 0
+                  type: gt
+                operator:
+                  type: and
+                query:
+                  params: []
+                reducer:
+                  params: []
+                  type: avg
+                type: query
+            datasource:
+              name: Expression
+              type: __expr__
+              uid: __expr__
+            expression: B
+            hide: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+            refId: C
+            type: threshold
+      noDataState: NoData
+      execErrState: Error
+      for: 5m
+      annotations: {}
+      labels: {}
+      isPaused: false
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: testdata
+spec:
+  folderRef: testdata
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "($test.metadata.name)"
+  json: >
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "grafana-testdata"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "id"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "10.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-testdata-datasource",
+                "uid": "grafana-testdata"
+              },
+              "refId": "A",
+              "scenarioId": "grafana_api",
+              "stringInput": "datasources"
+            }
+          ],
+          "title": "Panel Title",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "grafana-testdata"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "id": 1,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "10.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-testdata-datasource",
+                "uid": "grafana-testdata"
+              },
+              "hide": false,
+              "refId": "A",
+              "scenarioId": "grafana_api",
+              "stringInput": "search"
+            }
+          ],
+          "title": "Panel Title",
+          "type": "table"
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "New dashboard",
+      "version": 0,
+      "weekStart": ""
+    }

--- a/tests/example-resources.yaml
+++ b/tests/example-resources.yaml
@@ -1,0 +1,351 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana-testdata
+  labels:
+    test: "testdata"
+spec:
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: root
+      admin_password: secret
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: testdata
+spec:
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "testdata"
+  uid: testdata
+  title: "Test Data testdata"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: testdata
+spec:
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "testdata"
+  datasource:
+    orgId: 1
+    isDefault: true
+    uid: grafana-testdata
+    name: grafana-testdata-datasource
+    type: grafana-testdata-datasource
+    access: proxy
+    basicAuth: false
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: testdata
+spec:
+  folderRef: testdata
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "testdata"
+  interval: 5m
+  rules:
+    - uid: ae1rhq
+      title: Test
+      condition: C
+      data:
+        - refId: A
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: grafana-testdata
+          model:
+            drop: 0
+            intervalMs: 1000
+            labels: ""
+            max: 50
+            maxDataPoints: 43200
+            min: -50
+            noise: 0
+            refId: A
+            scenarioId: random_walk
+            seriesCount: 3
+            spread: 5
+            startValue: 0
+            stringInput: 1,20,90,30,5,0
+        - refId: B
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            conditions:
+              - evaluator:
+                  params:
+                    - 0
+                    - 0
+                  type: gt
+                operator:
+                  type: and
+                query:
+                  params: []
+                reducer:
+                  params: []
+                  type: avg
+                type: query
+            datasource:
+              name: Expression
+              type: __expr__
+              uid: __expr__
+            expression: A
+            hide: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+            reducer: max
+            refId: B
+            settings:
+              mode: dropNN
+            type: reduce
+        - refId: C
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            conditions:
+              - evaluator:
+                  params:
+                    - 45
+                    - 0
+                  type: gt
+                operator:
+                  type: and
+                query:
+                  params: []
+                reducer:
+                  params: []
+                  type: avg
+                type: query
+            datasource:
+              name: Expression
+              type: __expr__
+              uid: __expr__
+            expression: B
+            hide: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+            refId: C
+            type: threshold
+      noDataState: NoData
+      execErrState: Error
+      for: 5m
+      annotations: {}
+      labels: {}
+      isPaused: false
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: testdata
+spec:
+  folderRef: testdata
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "testdata"
+  json: >
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "grafana-testdata"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "id"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "10.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-testdata-datasource",
+                "uid": "grafana-testdata"
+              },
+              "refId": "A",
+              "scenarioId": "grafana_api",
+              "stringInput": "datasources"
+            }
+          ],
+          "title": "Panel Title",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "grafana-testdata"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "id": 1,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "10.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-testdata-datasource",
+                "uid": "grafana-testdata"
+              },
+              "hide": false,
+              "refId": "A",
+              "scenarioId": "grafana_api",
+              "stringInput": "search"
+            }
+          ],
+          "title": "Panel Title",
+          "type": "table"
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "New dashboard",
+      "version": 0,
+      "weekStart": ""
+    }


### PR DESCRIPTION
Usually the Grafana folder API will reject a `DELETE` if the folder contains alert rules, this can be overwritten with the [`forceDeleteRules=true`](https://grafana.com/docs/grafana/latest/developers/http_api/folder/#delete-folder) query parameter.

Which luckily is included in the Generated [Grafana openapi client](https://github.com/grafana/grafana-openapi-client-go/blob/main/client/folders/delete_folder_parameters.go#L150-L154)

This PR enables the forced deletion of folders specifically when declared with a CR.
Folders created from the `GrafanaDashboard#spec.folder` field are currently not forced as there is no CR declaring them.
See: [link](https://github.com/grafana/grafana-operator/blob/master/controllers/dashboard_controller.go#L739)

I spent 10 times as longer writing the tests for this new behaviour than the actual code.
Now there should be some a pretty extensive Chainsaw example snippets available for others in the future.
Additionally, I created an easy to use configuration for local testing in: [./tests/e2e/testdata-resources.yaml](https://github.com/grafana/grafana-operator/pull/1728/files#diff-a31a28feaf8b45526988bd957659da0b2c1f094462d4eef167b137cbad5ff4e3)