### PR TITLE
Implement `spec.uid` for `GrafanaContactPoint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate code/gofumpt api-docs vet envtest ## Run tests.
+test: manifests generate code/gofumpt code/golangci-lint api-docs vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build

--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -25,7 +25,13 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
+// +kubebuilder:validation:XValidation:rule="((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid)))", message="spec.uid is immutable"
 type GrafanaContactPointSpec struct {
+	// Manually specify the UID the Contact Point is created with
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.uid is immutable"
+	CustomUID string `json:"uid,omitempty"`
+
 	// +optional
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=duration
@@ -82,6 +88,14 @@ type GrafanaContactPointList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []GrafanaContactPoint `json:"items"`
+}
+
+// Wrapper around CustomUID or default metadata.uid
+func (in *GrafanaContactPoint) CustomUIDOrUID() string {
+	if in.Spec.CustomUID != "" {
+		return in.Spec.CustomUID
+	}
+	return string(in.ObjectMeta.UID)
 }
 
 func init() {

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -129,6 +129,13 @@ spec:
                 - hipchat
                 - oncall
                 type: string
+              uid:
+                description: Manually specify the UID the Contact Point is created
+                  with
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
               valuesFrom:
                 items:
                   properties:
@@ -199,6 +206,10 @@ spec:
             - name
             - settings
             type: object
+            x-kubernetes-validations:
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaContactPointStatus defines the observed state of GrafanaContactPoint
             properties:

--- a/controllers/grafanacontactpoint_controller.go
+++ b/controllers/grafanacontactpoint_controller.go
@@ -193,7 +193,7 @@ func (r *GrafanaContactPointReconciler) reconcileWithInstance(ctx context.Contex
 			Name:                  contactPoint.Spec.Name,
 			Type:                  &contactPoint.Spec.Type,
 			Settings:              settings,
-			UID:                   string(contactPoint.UID),
+			UID:                   contactPoint.CustomUIDOrUID(),
 		}
 		_, err := cl.Provisioning.PostContactpoints(provisioning.NewPostContactpointsParams().WithBody(cp)) //nolint:errcheck
 		if err != nil {
@@ -245,7 +245,7 @@ func (r *GrafanaContactPointReconciler) getContactPointFromUID(ctx context.Conte
 		return models.EmbeddedContactPoint{}, fmt.Errorf("getting contact points: %w", err)
 	}
 	for _, cp := range remote.Payload {
-		if cp.UID == string(contactPoint.UID) {
+		if cp.UID == contactPoint.CustomUIDOrUID() {
 			return *cp, nil
 		}
 	}
@@ -279,7 +279,7 @@ func (r *GrafanaContactPointReconciler) removeFromInstance(ctx context.Context, 
 	if err != nil {
 		return fmt.Errorf("getting contact point by UID: %w", err)
 	}
-	_, err = cl.Provisioning.DeleteContactpoints(string(contactPoint.UID)) //nolint:errcheck
+	_, err = cl.Provisioning.DeleteContactpoints(contactPoint.CustomUIDOrUID()) //nolint:errcheck
 	if err != nil {
 		return fmt.Errorf("deleting contact point: %w", err)
 	}

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -129,6 +129,13 @@ spec:
                 - hipchat
                 - oncall
                 type: string
+              uid:
+                description: Manually specify the UID the Contact Point is created
+                  with
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
               valuesFrom:
                 items:
                   properties:
@@ -199,6 +206,10 @@ spec:
             - name
             - settings
             type: object
+            x-kubernetes-validations:
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaContactPointStatus defines the observed state of GrafanaContactPoint
             properties:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -437,6 +437,13 @@ spec:
                 - hipchat
                 - oncall
                 type: string
+              uid:
+                description: Manually specify the UID the Contact Point is created
+                  with
+                type: string
+                x-kubernetes-validations:
+                - message: spec.uid is immutable
+                  rule: self == oldSelf
               valuesFrom:
                 items:
                   properties:
@@ -507,6 +514,10 @@ spec:
             - name
             - settings
             type: object
+            x-kubernetes-validations:
+            - message: spec.uid is immutable
+              rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
+                has(self.uid)))
           status:
             description: GrafanaContactPointStatus defines the observed state of GrafanaContactPoint
             properties:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -662,6 +662,8 @@ GrafanaContactPoint is the Schema for the grafanacontactpoints API
         <td>object</td>
         <td>
           GrafanaContactPointSpec defines the desired state of GrafanaContactPoint<br/>
+          <br/>
+            <i>Validations</i>:<li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -745,6 +747,15 @@ GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
           <br/>
           <br/>
             <i>Enum</i>: alertmanager, prometheus-alertmanager, dingding, discord, email, googlechat, kafka, line, opsgenie, pagerduty, pushover, sensugo, sensu, slack, teams, telegram, threema, victorops, webhook, wecom, hipchat, oncall<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>uid</b></td>
+        <td>string</td>
+        <td>
+          Manually specify the UID the Contact Point is created with<br/>
+          <br/>
+            <i>Validations</i>:<li>self == oldSelf: spec.uid is immutable</li>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
While implementing this, I noticed a lot of discrepancies between the `ContactPoint` CR and the others.
Once this is merged I'll open a PR fixing the missing error logs when ContactPoints fail to reconcile as well as implementing the same Status fields that other CRs use. (See: https://github.com/grafana/grafana-operator/commit/7e81cb417c4ae83bb851ade5b1973773f0958249)

### Manual Testing
```bash
make start-kind
kind export kubeconfig --name kind-grafana
kubectl delete grafana-operator --all
kubectl apply -f tests/example-resources.yaml
kubectl apply -f tmp.yml # See resources below
kubectl port-forward svc/grafana-testdata-service 3000 >/dev/null &
# Open http://localhost:3000/alerting/notifications
# username: root
# password: secret


# See that the default and two new contact points are present.
# Exporting all of them should show 3 UIDs
# Empty string, generated, and spec-uid
# Repeatedly deleting and applying tmp.yml should result in a new UID for the generated one.
```


### tmp.yml
```yaml
---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaContactPoint
metadata:
  name: metadata-uid
  namespace: default
spec:
  resyncPeriod: 3s
  instanceSelector:
    matchLabels:
      test: testdata
  name: metadata-uid
  type: email
  settings:
    addresses: "gf@example.invalid"
---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaContactPoint
metadata:
  name: constant-uid
  namespace: default
spec:
  resyncPeriod: 3s
  instanceSelector:
    matchLabels:
      test: testdata
  uid: spec-uid
  name: spec-uid
  type: email
  settings:
    addresses: "gf@example.invalid"
```