### PR TITLE
fix(helm): yaml indentation for ServiceMonitor

### DIFF
--- a/deploy/helm/grafana-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/grafana-operator/templates/servicemonitor.yaml
@@ -29,11 +29,11 @@ spec:
       {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings:
-      {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+      {{- toYaml .Values.serviceMonitor.metricRelabelings | indent 6 }}
       {{- end }}
       {{- if .Values.serviceMonitor.relabelings }}
       relabelings:
-      {{ toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   {{- if .Values.serviceMonitor.targetLabels }}
   targetLabels:

--- a/deploy/helm/grafana-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/grafana-operator/templates/servicemonitor.yaml
@@ -29,11 +29,11 @@ spec:
       {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings:
-      {{- toYaml .Values.serviceMonitor.metricRelabelings | indent 6 }}
+      {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
       {{- end }}
   {{- if .Values.serviceMonitor.targetLabels }}
   targetLabels:


### PR DESCRIPTION
```yaml
---
# Source: grafana-operator/templates/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-grafana-operator
  namespace: default
  labels:
    helm.sh/chart: grafana-operator-v5.15.1
    app.kubernetes.io/name: grafana-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v5.15.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: grafana-operator
    app.kubernetes.io/component: operator
spec:
  jobLabel: release-name
  namespaceSelector:
    matchNames:
      - default
  selector:
    matchLabels:
      app.kubernetes.io/name: grafana-operator
      app.kubernetes.io/instance: release-name
  endpoints:
    - port: metrics
      path: /metrics
      interval: 1m
      scrapeTimeout: 10s
      metricRelabelings:
        - action: replace
          replacement: my-cluster
          targetLabel: cluster
      relabelings:
        - action: replace
          replacement: my-cluster
          targetLabel: cluster
```