### PR TITLE
feat(config): set rule version record limit by default, bump grafana to 11.3.0

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,7 +66,7 @@ spec:
               memory: 20Mi
           env:
             - name: RELATED_IMAGE_GRAFANA
-              value: "docker.io/grafana/grafana:10.4.3"
+              value: "docker.io/grafana/grafana:11.3.0"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/controllers/config/grafana_ini.go
+++ b/controllers/config/grafana_ini.go
@@ -31,6 +31,14 @@ func WriteIni(cfg map[string]map[string]string) (string, string) {
 		cfg["dashboards"]["versions_to_keep"] = "20"
 	}
 
+	if cfg["unified_alerting"] == nil {
+		cfg["unified_alerting"] = make(map[string]string)
+	}
+
+	if cfg["unified_alerting"]["rule_version_record_limit"] == "" {
+		cfg["unified_alerting"]["rule_version_record_limit"] = "5"
+	}
+
 	sections := make([]string, 0, len(cfg))
 	for key := range cfg {
 		sections = append(sections, key)

--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -3,7 +3,7 @@ package config
 const (
 	// Grafana
 	GrafanaImage   = "docker.io/grafana/grafana"
-	GrafanaVersion = "10.4.3"
+	GrafanaVersion = "11.3.0"
 
 	// Paths
 	GrafanaDataPath               = "/var/lib/grafana"

--- a/examples/alertrulegroups/resources.yaml
+++ b/examples/alertrulegroups/resources.yaml
@@ -15,8 +15,12 @@ spec:
       admin_user: root
       admin_password: secret
 
-    ## Starting from Grafana 11.3.0, it is possible to enforce a limit on how many alert rule versions should be stored in a database (including the current version of the rule).
-    ## The default value in Grafana is "0", which means no limit. To mitigate that behaviour, the operator sets it to 5 by default starting from v5.16.0
+    ## Starting from Grafana 11.3.0, it is possible to enforce
+    ## a limit on how many alert rule versions should be stored
+    ## in a database (including the current version of the rule).
+    ## The default value in Grafana is "0", which means no limit.
+    ## To mitigate that behaviour, the operator sets it to 5
+    ## by default starting from v5.16.0
     # unified_alerting:
     #   rule_version_record_limit: "5"
 ---
@@ -45,8 +49,8 @@ spec:
         - datasourceUid: grafanacloud-demoinfra-prom
           model:
             datasource:
-                type: prometheus
-                uid: grafanacloud-demoinfra-prom
+              type: prometheus
+              uid: grafanacloud-demoinfra-prom
             editorMode: code
             expr: weather_temp_c{}
             instant: true
@@ -61,22 +65,22 @@ spec:
         - datasourceUid: __expr__
           model:
             conditions:
-                - evaluator:
-                    params:
-                        - 0
-                    type: lt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                        - C
-                  reducer:
-                    params: []
-                    type: last
-                  type: query
+              - evaluator:
+                  params:
+                    - 0
+                  type: lt
+                operator:
+                  type: and
+                query:
+                  params:
+                    - C
+                reducer:
+                  params: []
+                  type: last
+                type: query
             datasource:
-                type: __expr__
-                uid: __expr__
+              type: __expr__
+              uid: __expr__
             expression: A
             intervalMs: 1000
             maxDataPoints: 43200

--- a/examples/alertrulegroups/resources.yaml
+++ b/examples/alertrulegroups/resources.yaml
@@ -14,6 +14,11 @@ spec:
     security:
       admin_user: root
       admin_password: secret
+
+    ## Starting from Grafana 11.3.0, it is possible to enforce a limit on how many alert rule versions should be stored in a database (including the current version of the rule).
+    ## The default value in Grafana is "0", which means no limit. To mitigate that behaviour, the operator sets it to 5 by default starting from v5.16.0
+    # unified_alerting:
+    #   rule_version_record_limit: "5"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder

--- a/tests/e2e/example-test/00-assert.yaml
+++ b/tests/e2e/example-test/00-assert.yaml
@@ -3,12 +3,12 @@ kind: Grafana
 metadata:
   name: grafana
 spec:
-  version: 10.4.3
+  version: 11.3.0
 status:
   (wildcard('http://grafana-service.*:3000', adminUrl || '')): true
   stage: complete
   stageStatus: success
-  version: 10.4.3
+  version: 11.3.0
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
@@ -18,7 +18,7 @@ status:
   adminUrl: (join('',['http://grafana-internal-service.',$namespace,':3000']))
   stage: complete
   stageStatus: success
-  version: 10.4.3
+  version: 11.3.0
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana

--- a/tests/e2e/example-test/11-assert.yaml
+++ b/tests/e2e/example-test/11-assert.yaml
@@ -3,9 +3,9 @@ kind: Grafana
 metadata:
   name: grafana-tls
 spec:
-  version: 10.4.3
+  version: 11.3.0
 status:
   (wildcard('https://grafana-tls-service.*:3000', adminUrl || '')): true
   stage: complete
   stageStatus: success
-  version: 10.4.3
+  version: 11.3.0


### PR DESCRIPTION
## Changes

- set `rule_version_record_limit` to `5` by default:
  - Prior to Grafana 11.3.0, `alert_rule_version` table would uncontrollably grow to accommodate multiple copies of alert rules;
  - In Grafana 11.3.0, a new field (`rule_version_record_limit`, which is part of `unified_alerting` section) was introduced to enforce a limit on the rule versions. It is set to `0` there by default. To mitigate the behaviour, this PR instructs the operator to set the value to 5 by default;
- Other changes:
  - bumped the default Grafana version to 11.3.0 (I can drop that commit if needed).

## Backwards compatibility

If someone wants to preserve the previous behaviour or postpone initial database cleanup, it's possible to pass:

```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
# omitted
spec:
  config:
    # omitted
    unified_alerting:
      rule_version_record_limit: "0"
```

Fixes: #1639
