### PR TITLE
feat: allow for images in spec.version

### DIFF
--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -3,7 +3,6 @@ package grafana
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -31,7 +30,6 @@ const (
 	ReadinessProbePeriodSeconds       int32 = 10
 	ReadinessProbeSuccessThreshold    int32 = 1
 	ReadinessProbeTimeoutSeconds      int32 = 3
-	RelatedImageGrafanaEnvVar               = "RELATED_IMAGE_GRAFANA"
 )
 
 type DeploymentReconciler struct {
@@ -44,10 +42,6 @@ func NewDeploymentReconciler(client client.Client, isOpenShift bool) reconcilers
 		client:      client,
 		isOpenShift: isOpenShift,
 	}
-}
-
-func IsImageSHA256(image string) bool {
-	return strings.Contains(image, "@sha256:")
 }
 
 func (r *DeploymentReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
@@ -141,19 +135,13 @@ func getVolumeMounts(cr *v1beta1.Grafana, scheme *runtime.Scheme) []v1.VolumeMou
 }
 
 func getGrafanaImage(cr *v1beta1.Grafana) string {
-	grafanaImg := os.Getenv(RelatedImageGrafanaEnvVar)
-	if IsImageSHA256(grafanaImg) {
-		return grafanaImg
+	if cr.Spec.Version == "" {
+		return fmt.Sprintf("%s:%s", config2.GrafanaImage, config2.GrafanaVersion)
 	}
-
-	if cr.Spec.Version != "" {
-		return fmt.Sprintf("%s:%s", config2.GrafanaImage, cr.Spec.Version)
+	if strings.ContainsAny(cr.Spec.Version, ":/@") {
+		return cr.Spec.Version
 	}
-
-	if grafanaImg == "" {
-		grafanaImg = fmt.Sprintf("%s:%s", config2.GrafanaImage, config2.GrafanaVersion)
-	}
-	return grafanaImg
+	return fmt.Sprintf("%s:%s", config2.GrafanaImage, cr.Spec.Version)
 }
 
 func getContainers(cr *v1beta1.Grafana, scheme *runtime.Scheme, vars *v1beta1.OperatorReconcileVars, openshiftPlatform bool) []v1.Container {

--- a/controllers/reconcilers/grafana/deployment_reconciler_test.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler_test.go
@@ -34,15 +34,13 @@ func Test_getGrafanaImage_specificVersion(t *testing.T) {
 	assert.Equal(t, expectedDeploymentImage, getGrafanaImage(cr))
 }
 
-func Test_getGrafanaImage_withEnvironmentOverride(t *testing.T) {
+func Test_getGrafanaImage_withImageInVersion(t *testing.T) {
+	expectedDeploymentImage := "docker.io/grafana/grafana@sha256:b7fcb534f7b3512801bb3f4e658238846435804deb479d105b5cdc680847c272"
 	cr := &v1beta1.Grafana{
 		Spec: v1beta1.GrafanaSpec{
-			Version: "",
+			Version: expectedDeploymentImage,
 		},
 	}
-
-	expectedDeploymentImage := "I want this grafana image"
-	t.Setenv("RELATED_IMAGE_GRAFANA", expectedDeploymentImage)
 
 	assert.Equal(t, expectedDeploymentImage, getGrafanaImage(cr))
 }


### PR DESCRIPTION
This allows for simpler replacement of images used.

Fixes #1758 by setting the version based on the RELATED_IMAGE_GRAFANA if it's a hash which allows for overrides later on