### PR TITLE
Chore(Internal): Add new shared reconciliation functions and migrate `GrafanaFolder`

### DIFF
--- a/api/common_interfaces.go
+++ b/api/common_interfaces.go
@@ -1,7 +1,0 @@
-package api
-
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-type CommonResource interface {
-	MatchConditions() (*metav1.LabelSelector, string, *bool)
-}

--- a/api/common_interfaces.go
+++ b/api/common_interfaces.go
@@ -1,0 +1,7 @@
+package api
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+type CommonResource interface {
+	MatchConditions() (*metav1.LabelSelector, string, *bool)
+}

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -39,3 +39,12 @@ type GrafanaCommonSpec struct {
 	// +optional
 	AllowCrossNamespaceImport *bool `json:"allowCrossNamespaceImport,omitempty"`
 }
+
+// Common Functions that all CRs should implement, excluding Grafana
+// +kubebuilder:object:generate=false
+type CommonResource interface {
+	MatchLabels() *metav1.LabelSelector
+	MatchNamespace() string
+	AllowCrossNamespace() bool
+	ResyncPeriodHasElapsed() bool
+}

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -164,6 +164,17 @@ func (in *GrafanaFolder) ResyncPeriodHasElapsed() bool {
 	return time.Now().After(deadline)
 }
 
-func (in *GrafanaFolder) MatchConditions() (*metav1.LabelSelector, string, *bool) {
-	return in.Spec.InstanceSelector, in.ObjectMeta.Namespace, in.Spec.AllowCrossNamespaceImport
+func (in *GrafanaFolder) MatchLabels() *metav1.LabelSelector {
+	return in.Spec.InstanceSelector
+}
+
+func (in *GrafanaFolder) MatchNamespace() string {
+	return in.ObjectMeta.Namespace
+}
+
+func (in *GrafanaFolder) AllowCrossNamespace() bool {
+	if in.Spec.AllowCrossNamespaceImport != nil {
+		return *in.Spec.AllowCrossNamespaceImport
+	}
+	return false
 }

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -151,13 +151,6 @@ func (in *GrafanaFolder) Unchanged() bool {
 	return in.Hash() == in.Status.Hash
 }
 
-func (in *GrafanaFolder) IsAllowCrossNamespaceImport() bool {
-	if in.Spec.AllowCrossNamespaceImport != nil {
-		return *in.Spec.AllowCrossNamespaceImport
-	}
-	return false
-}
-
 func (in *GrafanaFolder) GetTitle() string {
 	if in.Spec.Title != "" {
 		return in.Spec.Title
@@ -169,4 +162,8 @@ func (in *GrafanaFolder) GetTitle() string {
 func (in *GrafanaFolder) ResyncPeriodHasElapsed() bool {
 	deadline := in.Status.LastResync.Add(in.Spec.ResyncPeriod.Duration)
 	return time.Now().After(deadline)
+}
+
+func (in *GrafanaFolder) MatchConditions() (*metav1.LabelSelector, string, *bool) {
+	return in.Spec.InstanceSelector, in.ObjectMeta.Namespace, in.Spec.AllowCrossNamespaceImport
 }

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -32,8 +32,6 @@ const (
 	conditionInvalidSpec        = "InvalidSpec"
 )
 
-const annotationAppliedNotificationPolicy = "operator.grafana.com/applied-notificationpolicy"
-
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 // Gets all instances matching labelSelector

--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"testing"
 
+	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestLabelsSatisfyMatchExpressions(t *testing.T) {
@@ -226,3 +233,122 @@ func TestLabelsSatisfyMatchExpressions(t *testing.T) {
 		})
 	}
 }
+
+var _ = Describe("GetMatchingInstances functions", Ordered, func() {
+	refTrue := true
+	refFalse := false
+	namespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "get-matching-test",
+		},
+	}
+	allowFolder := v1beta1.GrafanaFolder{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "grafana.integreatly.org/v1beta1",
+			Kind:       "GrafanaFolder",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "allow-cross-namespace",
+			Namespace: namespace.Name,
+		},
+		Spec: v1beta1.GrafanaFolderSpec{
+			GrafanaCommonSpec: v1beta1.GrafanaCommonSpec{
+				AllowCrossNamespaceImport: &refTrue,
+				InstanceSelector: &v1.LabelSelector{
+					MatchLabels: map[string]string{
+						"test": "folder",
+					},
+				},
+			},
+		},
+	}
+	// Create duplicate resources, changing key fields
+	denyFolder := allowFolder.DeepCopy()
+	denyFolder.Name = "deny-cross-namespace"
+	denyFolder.Spec.AllowCrossNamespaceImport = &refFalse
+
+	matchAllFolder := allowFolder.DeepCopy()
+	matchAllFolder.Name = "invalid-match-labels"
+	matchAllFolder.Spec.InstanceSelector = &metav1.LabelSelector{} // InstanceSelector is never nil
+
+	DefaultGrafana := v1beta1.Grafana{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "grafana.integreatly.org/v1beta1",
+			Kind:       "Grafana",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "instance",
+			Namespace: "default",
+			Labels: map[string]string{
+				"test": "folder",
+			},
+		},
+		Spec: v1beta1.GrafanaSpec{},
+	}
+	matchesNothingGrafana := DefaultGrafana.DeepCopy()
+	matchesNothingGrafana.Name = "match-nothing-instance"
+	matchesNothingGrafana.Labels = nil
+
+	secondNamespaceGrafana := DefaultGrafana.DeepCopy()
+	secondNamespaceGrafana.Name = "second-namespace-instance"
+	secondNamespaceGrafana.Namespace = namespace.Name
+
+	// Status update is skipped for this
+	unreadyGrafana := DefaultGrafana.DeepCopy()
+	unreadyGrafana.Name = "unready-instance"
+
+	ctx := context.Background()
+	// Pre-create all resources
+	BeforeAll(func() { // Necessary to use assertions
+		Expect(k8sClient.Create(ctx, &namespace)).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, &allowFolder)).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, denyFolder)).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, matchAllFolder)).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, unreadyGrafana)).NotTo(HaveOccurred())
+
+		grafanas := []v1beta1.Grafana{DefaultGrafana, *matchesNothingGrafana, *secondNamespaceGrafana}
+		for _, instance := range grafanas {
+			Expect(k8sClient.Create(ctx, &instance)).NotTo(HaveOccurred())
+
+			// Apply status to pass instance ready check
+			instance.Status.Stage = v1beta1.OperatorStageComplete
+			instance.Status.StageStatus = v1beta1.OperatorStageResultSuccess
+			Expect(k8sClient.Status().Update(ctx, &instance)).ToNot(HaveOccurred())
+		}
+	})
+
+	Context("Ensure AllowCrossNamespaceImport is upheld by GetScopedMatchingInstances", func() {
+		testLog := log.FromContext(ctx).WithSink(log.NullLogSink{})
+		It("Finds all ready instances when instanceSelector is empty", func() {
+			instances, err := GetScopedMatchingInstances(testLog, ctx, k8sClient, matchAllFolder)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instances).To(HaveLen(3))
+		})
+		It("Finds all ready and Matching instances", func() {
+			instances, err := GetScopedMatchingInstances(testLog, ctx, k8sClient, &allowFolder)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instances).ToNot(BeEmpty())
+			Expect(instances).To(HaveLen(2))
+		})
+		It("Finds matching and ready and matching instance in namespace", func() {
+			instances, err := GetScopedMatchingInstances(testLog, ctx, k8sClient, denyFolder)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instances).ToNot(BeEmpty())
+			Expect(instances).To(HaveLen(1))
+		})
+	})
+
+	Context("Ensure AllowCrossNamespaceImport is ignored by GetAllMatchingInstances", func() {
+		It("Finds all ready instances when instanceSelector is empty", func() {
+			instances, err := GetAllMatchingInstances(ctx, k8sClient, matchAllFolder)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instances).To(HaveLen(3))
+		})
+		It("Finds matching and ready instances ignoring AllowCrossNamespaceImport", func() {
+			instances, err := GetAllMatchingInstances(ctx, k8sClient, denyFolder)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(instances).ToNot(BeEmpty())
+			Expect(instances).To(HaveLen(2))
+		})
+	})
+})

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -39,6 +39,7 @@ import (
 
 const (
 	conditionNotificationPolicySynchronized = "NotificationPolicySynchronized"
+	annotationAppliedNotificationPolicy     = "operator.grafana.com/applied-notificationpolicy"
 )
 
 // GrafanaNotificationPolicyReconciler reconciles a GrafanaNotificationPolicy object


### PR DESCRIPTION
This PR aims to improve how reconciliation functions are written going forward, starting with the folder controller.

The goal is to reduce duplicated code by moving more logic into matching Grafana instances.
This is achieved by namespacing the client to limit the scope of the search when resources do not specify `allowCrossNamespaceImport: true`

Additional functions have been added for simplifying building conditions when no matching instances are found.

Lastly, it aligns the existing folder reconcile error logging with other resources