### PR TITLE
docs: update security context in docs

### DIFF
--- a/examples/grafana_deployment/resources.yaml
+++ b/examples/grafana_deployment/resources.yaml
@@ -7,10 +7,6 @@ metadata:
     dashboards: "grafana"
 spec:
   config:
-    log:
-      mode: "console"
-    auth:
-      disable_login_form: "false"
     security:
       admin_user: root
       admin_password: secret
@@ -20,9 +16,13 @@ spec:
         spec:
           containers:
             - name: grafana
-              image: grafana/grafana:9.4.3
               securityContext:
-                allowPrivilegeEscalation: true
-                readOnlyRootFilesystem: false
+                # Customize this in case your volume provider needs specific UIDs/GIDs
+                runAsUser: 1001
+                runAsGroup: 1001
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
               readinessProbe:
                 failureThreshold: 3

--- a/examples/persistent_volume/resources.yaml
+++ b/examples/persistent_volume/resources.yaml
@@ -28,10 +28,6 @@ spec:
         spec:
           containers:
             - name: grafana
-              image: grafana/grafana:9.4.3
-              securityContext:
-                allowPrivilegeEscalation: true
-                readOnlyRootFilesystem: false
               readinessProbe:
                 failureThreshold: 3
           volumes:


### PR DESCRIPTION
Rewrites the examples in accordance to #1768. Security context overrides are not needed in a working k8s setup and will only confuse if left in examples uncommented