### PR TITLE
fix: remove rules requirement for ingress

### DIFF
--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -45,7 +45,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 }
 
 func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
-	if cr.Spec.Ingress == nil || len(cr.Spec.Ingress.Spec.Rules) == 0 {
+	if cr.Spec.Ingress == nil {
 		return v1beta1.OperatorStageResultSuccess, nil
 	}
 


### PR DESCRIPTION
This spec prevents our default rules from being used, as a merge will always override them.

Fixes #1774