### PR TITLE
Chore: Update default log level `Debug`->`Info`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build: generate code/gofumpt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate code/gofumpt vet ## Run a controller from your host.
-	go run ./main.go
+	go run ./main.go --zap-devel=true
 
 ##@ Deployment
 

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"syscall"
 
+	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -90,8 +92,11 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&pprofAddr, "pprof-addr", ":8888", "The address to expose the pprof server. Empty string disables the pprof server.")
+
+	logCfg := uberzap.NewProductionEncoderConfig()
+	logCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 	opts := zap.Options{
-		Development: true,
+		Encoder: zapcore.NewConsoleEncoder(logCfg),
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Switching to production mode has the side-effect that the default encoder also changed to `jsonEncoder`
It might make sense to keep the `consoleEncoder`, hence `Development mode` is explicitly enabled in the makefile.

Should I also create an overlay or similar configuration for the `make deploy` target which enables `Development mode` for outputting debug logs?
In case we start using them.