### PR TITLE
chore: cleanup Makefile, update docs regarding default resyncPeriod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ KUSTOMIZE_VERSION ?= v5.1.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.3
 OPM_VERSION ?= v1.23.2
 YQ_VERSION ?= v4.35.2
+KO_VERSION ?= v0.16.0
 KIND_VERSION ?= v0.24.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
@@ -320,7 +321,7 @@ ko:
 ifeq (, $(shell which ko))
 	@{ \
 	set -e ;\
-	go install github.com/google/ko@v0.13.0 ;\
+	go install github.com/google/ko@${KO_VERSION} ;\
 	}
 KO=$(GOBIN)/ko
 else

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-CHAINSAW_VERSION ?= v0.2.10
-
-# Checks if chainsaw is in your PATH
-ifneq ($(shell which chainsaw),)
-CHAINSAW=$(shell which chainsaw)
-else
-CHAINSAW=$(shell pwd)/bin/chainsaw
-endif
-
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
@@ -163,6 +154,7 @@ OPM_VERSION ?= v1.23.2
 YQ_VERSION ?= v4.35.2
 KO_VERSION ?= v0.16.0
 KIND_VERSION ?= v0.24.0
+CHAINSAW_VERSION ?= v0.2.10
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -11,7 +11,7 @@ Due to this the Grafana operator has to constantly poll the Grafana API to test 
 To control how often this polling should occur, you can set the `spec.resyncPeriod` field.
 This field tells the operator how often it should poll the Grafana instance for changes.
 
-So, if for example, a dashboard has changed, the operator comes in and overwrite those settings after `5m` by default.
+So, if for example, a dashboard has changed, the operator comes in and overwrite those settings after `10m` by default.
 If you never want the operator to poll for changes in the dashboards you need to set this value to `0m`:
 
 ```yaml


### PR DESCRIPTION
- With #1765 the default resyncPeriod for all resources was updated to `10m0s`
- I ran into an issue building with Ko after #1700 added the .ko.yaml
- The Makefile searched the PATH for Chainsaw twice: 
https://github.com/grafana/grafana-operator/blob/1c2641cbec8d2185421300f3cf75f0cae6a9e8aa/Makefile#L35-L40
https://github.com/grafana/grafana-operator/blob/1c2641cbec8d2185421300f3cf75f0cae6a9e8aa/Makefile#L279-L287