### PR TITLE
Refactor: Folder conditions not removed and ignore status updates.

### DIFF
--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -182,7 +182,8 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{RequeueAfter: RequeueDelay}, err
 	}
 	defer func() {
-		if err := r.UpdateStatus(ctx, folder); err != nil {
+		folder.Status.Hash = folder.Hash()
+		if err := r.Status().Update(ctx, folder); err != nil {
 			r.Log.Error(err, "updating status")
 		}
 	}()
@@ -392,11 +393,6 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 	}
 
 	return nil
-}
-
-func (r *GrafanaFolderReconciler) UpdateStatus(ctx context.Context, cr *grafanav1beta1.GrafanaFolder) error {
-	cr.Status.Hash = cr.Hash()
-	return r.Client.Status().Update(ctx, cr)
 }
 
 // Check if the folder exists. Matches UID first and fall back to title. Title matching only works for non-nested folders

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -178,8 +178,7 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 			return ctrl.Result{}, nil
 		}
-		controllerLog.Error(err, "error getting grafana folder cr")
-		return ctrl.Result{RequeueAfter: RequeueDelay}, err
+		return ctrl.Result{RequeueAfter: RequeueDelay}, fmt.Errorf("error getting grafana folder cr: %w", err)
 	}
 	defer func() {
 		folder.Status.Hash = folder.Hash()


### PR DESCRIPTION
1. Fix: When a Grafana instance is deleted, a folder will not remove the `ApplySuccessful` condition on a folder on a subsequent reconcile:
![image](https://github.com/user-attachments/assets/84d15cdb-d1fa-48ec-85c9-d57f80c8bbee)

2. Refactor: Filter status updates
3. Refactor: Remove useless helper function `UpdateStatus()`