### PR TITLE
Update TLS to support custom secret namespaces

### DIFF
--- a/controllers/client/tls.go
+++ b/controllers/client/tls.go
@@ -38,7 +38,7 @@ func buildTLSConfiguration(ctx context.Context, c client.Client, grafana *v1beta
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 	secretName := tlsConfigBlock.CertSecretRef.Name
 	secretNamespace := grafana.Namespace
-	if len(tlsConfigBlock.CertSecretRef.Namespace) > 0 {
+	if tlsConfigBlock.CertSecretRef.Namespace != "" {
 		secretNamespace = tlsConfigBlock.CertSecretRef.Namespace
 	}
 

--- a/controllers/client/tls.go
+++ b/controllers/client/tls.go
@@ -36,11 +36,16 @@ func buildTLSConfiguration(ctx context.Context, c client.Client, grafana *v1beta
 	}
 
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	secretName := tlsConfigBlock.CertSecretRef.Name
+	secretNamespace := grafana.Namespace
+	if len(tlsConfigBlock.CertSecretRef.Namespace) > 0 {
+		secretNamespace = tlsConfigBlock.CertSecretRef.Namespace
+	}
 
 	secret := &v1.Secret{}
 	selector := client.ObjectKey{
-		Name:      tlsConfigBlock.CertSecretRef.Name,
-		Namespace: grafana.Namespace,
+		Name:      secretName,
+		Namespace: secretNamespace,
 	}
 	err := c.Get(ctx, selector, secret)
 	if err != nil {


### PR DESCRIPTION
- Modified `tls.go` to dynamically set the secret namespace based on the `CertSecretRef.Namespace`

These changes were made to support the use of TLS secrets in different namespaces, which is important for multi-tenant environments.