### PR TITLE
Fix: Invalid `if` condition in `GetScopedMatchingInstances` when only 1 instance is unready

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -49,7 +49,6 @@ type CommonResource interface {
 	MatchLabels() *metav1.LabelSelector
 	MatchNamespace() string
 	AllowCrossNamespace() bool
-	ResyncPeriodHasElapsed() bool
 }
 
 // The most recent observed state of a Grafana resource

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -102,7 +102,7 @@ func GetScopedMatchingInstances(log logr.Logger, ctx context.Context, k8sClient 
 		}
 		selectedList = append(selectedList, instance)
 	}
-	if len(unready_instances) > 1 {
+	if len(unready_instances) > 0 {
 		log.Info("Grafana instances not ready", "instances", unready_instances)
 	}
 

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -69,6 +69,7 @@ type GrafanaReconciler struct {
 
 func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	controllerLog := log.FromContext(ctx).WithName("GrafanaReconciler")
+	r.Log = controllerLog
 
 	grafana := &grafanav1beta1.Grafana{}
 	err := r.Get(ctx, req.NamespacedName, grafana)


### PR DESCRIPTION
I spotted a mistake in #1770 resulting in unready instances not being logged if there's only one.
Additionally, the log [`version not yet found`](https://github.com/grafana/grafana-operator/blob/master/controllers/grafana_controller.go#L215) in the `Grafanas` controller was sent to a null sink due to `r.Log` being `nil`.
lastly, I removed the `ResyncPeriodHasElapsed` requirement for `CommonResource` as it is not required in the functions defined in [controllers_shared.go](./controllers/controllers_shared.go)