### PR TITLE
chore: Update `GrafanaContactPoint` reconcile loop

### DIFF
--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -79,6 +79,18 @@ func (in *GrafanaContactPoint) CustomUIDOrUID() string {
 	return string(in.ObjectMeta.UID)
 }
 
+func (in *GrafanaContactPoint) MatchLabels() *metav1.LabelSelector {
+	return in.Spec.InstanceSelector
+}
+
+func (in *GrafanaContactPoint) MatchNamespace() string {
+	return in.ObjectMeta.Namespace
+}
+
+func (in *GrafanaContactPoint) AllowCrossNamespace() bool {
+	return in.Spec.AllowCrossNamespaceImport
+}
+
 func init() {
 	SchemeBuilder.Register(&GrafanaContactPoint{}, &GrafanaContactPointList{})
 }

--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -53,6 +53,8 @@ type GrafanaContactPointSpec struct {
 //+kubebuilder:subresource:status
 
 // GrafanaContactPoint is the Schema for the grafanacontactpoints API
+// +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:resource:categories={grafana-operator}
 type GrafanaContactPoint struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -16,7 +16,15 @@ spec:
     singular: grafanacontactpoint
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaContactPoint is the Schema for the grafanacontactpoints

--- a/controllers/grafanacontactpoint_controller.go
+++ b/controllers/grafanacontactpoint_controller.go
@@ -205,6 +205,8 @@ func (r *GrafanaContactPointReconciler) buildSettings(ctx context.Context, conta
 		if err != nil {
 			return nil, fmt.Errorf("getting referenced value: %w", err)
 		}
+		r.Log.Info("overriding value", "key", override.TargetPath, "value", val)
+
 		simpleContent.SetPath(strings.Split(override.TargetPath, "."), val)
 	}
 	return simpleContent.Interface(), nil

--- a/controllers/grafanacontactpoint_controller.go
+++ b/controllers/grafanacontactpoint_controller.go
@@ -205,7 +205,7 @@ func (r *GrafanaContactPointReconciler) buildSettings(ctx context.Context, conta
 		if err != nil {
 			return nil, fmt.Errorf("getting referenced value: %w", err)
 		}
-		r.Log.Info("overriding value", "key", override.TargetPath, "value", val)
+		r.Log.V(1).Info("overriding value", "key", override.TargetPath, "value", val)
 
 		simpleContent.SetPath(strings.Split(override.TargetPath, "."), val)
 	}

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -16,7 +16,15 @@ spec:
     singular: grafanacontactpoint
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaContactPoint is the Schema for the grafanacontactpoints

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -335,7 +335,15 @@ spec:
     singular: grafanacontactpoint
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaContactPoint is the Schema for the grafanacontactpoints


### PR DESCRIPTION
- fix: Warnings when returning `ctrl.Result` and an `error` and logging errors twice.
- fix: `status` subresource updates are now ignored
- feat: `status.lastResync` is now updated and registered as a printed column (for `GrafanaFolder` and `GrafanaNotificationTemplate` as well)
  It was not clear to me if `Age` should be added as well
