### PR TITLE
Fix: `GrafanaNotificationPolicy` reconcile loop ignoring namespace boundaries

### DIFF
--- a/api/v1beta1/grafananotificationpolicy_types.go
+++ b/api/v1beta1/grafananotificationpolicy_types.go
@@ -130,6 +130,8 @@ func (r *Route) ToModelRoute() *models.Route {
 //+kubebuilder:subresource:status
 
 // GrafanaNotificationPolicy is the Schema for the GrafanaNotificationPolicy API
+// +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:resource:categories={grafana-operator}
 type GrafanaNotificationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -150,6 +152,18 @@ type GrafanaNotificationPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []GrafanaNotificationPolicy `json:"items"`
+}
+
+func (in *GrafanaNotificationPolicy) MatchLabels() *metav1.LabelSelector {
+	return in.Spec.InstanceSelector
+}
+
+func (in *GrafanaNotificationPolicy) MatchNamespace() string {
+	return in.ObjectMeta.Namespace
+}
+
+func (in *GrafanaNotificationPolicy) AllowCrossNamespace() bool {
+	return in.Spec.AllowCrossNamespaceImport
 }
 
 func init() {

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -16,7 +16,15 @@ spec:
     singular: grafananotificationpolicy
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaNotificationPolicy is the Schema for the GrafanaNotificationPolicy

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -16,7 +16,15 @@ spec:
     singular: grafananotificationpolicy
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaNotificationPolicy is the Schema for the GrafanaNotificationPolicy

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -1670,7 +1670,15 @@ spec:
     singular: grafananotificationpolicy
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaNotificationPolicy is the Schema for the GrafanaNotificationPolicy


### PR DESCRIPTION
I was done updating the reconciler when I realised that there was no cross namespace check to delete and I remembered #1762 existed.
I decided to open this regardless as it looked like it had stagnated.
Feel free to close this if progress will resume.

- fix: Warnings when returning `ctrl.Result` and an `error` and logging some errors twice.
- chore: Folded `r.resetInstance` under finalize to align with other finalize functions as it was only invoked from finalize.
- feat: `status.lastResync` is now updated and registered as a printed column (for `GrafanaFolder` and `GrafanaNotificationTemplate` as well)
  It was not clear to me if `Age` should be added as well

#### Labels matching, but instance is in a different namespace

`kubectl get grafanas -n default grafana-testdata -o yaml`
```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"grafana.integreatly.org/v1beta1","kind":"Grafana","metadata":{"annotations":{},"labels":{"test":"testdata"},"name":"grafana-testdata","namespace":"default"},"spec":{"config":{"auth":{"disable_login_form":"false"},"log":{"mode":"console"},"security":{"admin_password":"secret","admin_user":"root"}}}}
  creationTimestamp: "2025-01-10T01:50:51Z"
  generation: 2
  labels:
    test: testdata
  name: grafana-testdata
  namespace: default
  resourceVersion: "874"
  uid: 63d529df-c1c4-474e-a084-ec3c15f07a08
spec:
  config:
    auth:
      disable_login_form: "false"
    log:
      mode: console
    security:
      admin_password: secret
      admin_user: root
  version: 11.3.0
status:
  adminUrl: http://grafana-testdata-service.default.svc:3000
  dashboards:
  - default/testdata/testdata-dash
  datasources:
  - default/testdata/testdata-datasource
  folders:
  - default/testdata/testdata
  stage: complete
  stageStatus: success
  version: 11.3.0
```
`kubectl get grafananotificationpolicies -n new testdata -o yaml`
```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaNotificationPolicy
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"grafana.integreatly.org/v1beta1","kind":"GrafanaNotificationPolicy","metadata":{"annotations":{},"labels":{"test":"testdata"},"name":"testdata","namespace":"new"},"spec":{"instanceSelector":{"matchLabels":{"test":"testdata"}},"route":{"group_by":["grafana_folder","alertname"],"receiver":"testdata"}}}
  creationTimestamp: "2025-01-10T01:52:07Z"
  generation: 1
  labels:
    test: testdata
  name: testdata
  namespace: new
  resourceVersion: "1559"
  uid: 8ffe67b1-2748-4c02-9c79-083a621721d2
spec:
  allowCrossNamespaceImport: false
  instanceSelector:
    matchLabels:
      test: testdata
  resyncPeriod: 10m0s
  route:
    group_by:
    - grafana_folder
    - alertname
    receiver: testdata
status:
  conditions:
  - lastTransitionTime: "2025-01-10T01:52:07Z"
    message: Instances could not be fetched, reconciliation will be retried
    observedGeneration: 1
    reason: EmptyAPIReply
    status: "True"
    type: NoMatchingInstance
  lastResync: "2025-01-10T01:55:13Z"
```