### PR TITLE
Chore: Enable concurrent golangci and Update `PrintedColumns` and log messages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ endif
 
 .PHONY: code/golangci-lint
 code/golangci-lint: golangci
-	$(GOLANGCI) run ./...
+	$(GOLANGCI) run --allow-parallel-runners ./...
 
 gofumpt:
 ifeq (, $(shell which gofumpt))

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -70,6 +70,7 @@ type GrafanaFolderStatus struct {
 
 // GrafanaFolder is the Schema for the grafanafolders API
 // +kubebuilder:printcolumn:name="No matching instances",type="boolean",JSONPath=".status.NoMatchingInstances",description=""
+// +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:resource:categories={grafana-operator}
 type GrafanaFolder struct {

--- a/api/v1beta1/grafananotificationtemplate_types.go
+++ b/api/v1beta1/grafananotificationtemplate_types.go
@@ -43,6 +43,8 @@ type GrafanaNotificationTemplateSpec struct {
 //+kubebuilder:subresource:status
 
 // GrafanaNotificationTemplate is the Schema for the GrafanaNotificationTemplate API
+// +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:resource:categories={grafana-operator}
 type GrafanaNotificationTemplate struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -20,6 +20,10 @@ spec:
     - jsonPath: .status.NoMatchingInstances
       name: No matching instances
       type: boolean
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationtemplates.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationtemplates.yaml
@@ -16,7 +16,15 @@ spec:
     singular: grafananotificationtemplate
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaNotificationTemplate is the Schema for the GrafanaNotificationTemplate

--- a/controllers/grafananotificationtemplate_controller.go
+++ b/controllers/grafananotificationtemplate_controller.go
@@ -101,7 +101,7 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 	if err != nil {
 		setNoMatchingInstancesCondition(&notificationTemplate.Status.Conditions, notificationTemplate.Generation, err)
 		meta.RemoveStatusCondition(&notificationTemplate.Status.Conditions, conditionNotificationTemplateSynchronized)
-		return ctrl.Result{}, fmt.Errorf("could not find matching instances: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed fetching instances: %w", err)
 	}
 
 	if len(instances) == 0 {

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -20,6 +20,10 @@ spec:
     - jsonPath: .status.NoMatchingInstances
       name: No matching instances
       type: boolean
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationtemplates.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationtemplates.yaml
@@ -16,7 +16,15 @@ spec:
     singular: grafananotificationtemplate
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaNotificationTemplate is the Schema for the GrafanaNotificationTemplate

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -1454,6 +1454,10 @@ spec:
     - jsonPath: .status.NoMatchingInstances
       name: No matching instances
       type: boolean
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -1934,7 +1938,15 @@ spec:
     singular: grafananotificationtemplate
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaNotificationTemplate is the Schema for the GrafanaNotificationTemplate

--- a/main.go
+++ b/main.go
@@ -168,7 +168,7 @@ func main() {
 	case strings.Contains(watchNamespace, ","):
 		// multi namespace scoped
 		controllerOptions.Cache.DefaultNamespaces = getNamespaceConfig(watchNamespace)
-		setupLog.Info("manager set up with multiple namespaces", "namespaces", watchNamespace)
+		setupLog.Info("operator running in namespace scoped mode for multiple namespaces", "namespaces", watchNamespace)
 	case watchNamespace != "":
 		// namespace scoped
 		controllerOptions.Cache.DefaultNamespaces = getNamespaceConfig(watchNamespace)
@@ -216,7 +216,6 @@ func main() {
 	if err = (&controllers.GrafanaDashboardReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("DashboardReconciler"),
 	}).SetupWithManager(mgr, ctx); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrafanaDashboard")
 		os.Exit(1)
@@ -224,7 +223,6 @@ func main() {
 	if err = (&controllers.GrafanaDatasourceReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("DatasourceReconciler"),
 	}).SetupWithManager(mgr, ctx); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrafanaDatasource")
 		os.Exit(1)

--- a/tests/example-resources.yaml
+++ b/tests/example-resources.yaml
@@ -15,6 +15,35 @@ spec:
       admin_password: secret
 ---
 apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationTemplate
+metadata:
+  name: testdata
+spec:
+  name: emailtestdata
+  instanceSelector:
+    matchLabels:
+      test: "testdata"
+  resyncPeriod: 3s
+  template: |
+    {{ define "emailAlert" }}
+      [{{.Status}}] {{ .Labels.alertname }}
+      {{ .Annotations.AlertValues }}
+    {{ end }}
+
+    {{ define "emailAlertMessage" }}
+      {{ if gt (len .Alerts.Firing) 0 }}
+        {{ len .Alerts.Firing }} firing:
+        {{ range .Alerts.Firing }} {{ template "emailAlert" . }} {{ end }}
+      {{ end }}
+      {{ if gt (len .Alerts.Resolved) 0 }}
+        {{ len .Alerts.Resolved }} resolved:
+        {{ range .Alerts.Resolved }} {{ template "emailAlert" . }} {{ end }}
+      {{ end }}
+    {{ end }}
+
+    {{ template "emailAlertMessage" . }}
+---
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaContactPoint
 metadata:
   name: testdata
@@ -26,9 +55,11 @@ spec:
   instanceSelector:
     matchLabels:
       test: "testdata"
+  resyncPeriod: 3s
   settings:
     addresses: "void@testdata.invalid"
-    subject: 'Grafana Alert'
+    subject: '{{ template "emailAlert" . }}'
+    message: '{{ template "emailAlertMessage" . }}'
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaNotificationPolicy
@@ -40,6 +71,7 @@ spec:
   instanceSelector:
     matchLabels:
       test: "testdata"
+  resyncPeriod: 3s
   route:
     receiver: testdata
     group_by:


### PR DESCRIPTION
- chore: Align an error message in Notification Template
- feat: Ensured`lastResync` and `Age` as a printed columns for `GrafanaFolder` and `GrafanaNotificationTemplate`
- chore: Align info log when watching a list of namespaces
- chore: Remove unused loggers in `main()`
- fix: Allow multiple golangci processes to run simultaneously
  (I can now run `make` with my editor open...)