### PR TITLE
Fix: Force recreate when disabling `spec.allowCrossNamespaceImport`

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -24,6 +24,7 @@ type ValueFromSource struct {
 
 // Common Options that all CRs should embed, excluding GrafanaSpec
 // Ensure alignment on handling ResyncPeriod, InstanceSelector, and AllowCrossNamespaceImport
+// +kubebuilder:validation:XValidation:rule="!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport && self.allowCrossNamespaceImport)", message="disabling spec.allowCrossNamespaceImport requires a recreate to ensure desired state"
 type GrafanaCommonSpec struct {
 	// How often the resource is synced, defaults to 10m0s if not set
 	// +optional

--- a/api/v1beta1/common_test.go
+++ b/api/v1beta1/common_test.go
@@ -1,0 +1,91 @@
+package v1beta1
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("GrafanaCommonSpec#AllowCrossNamespaceImport Validation rule tests", func() {
+	undefinedCrossImportFolder := &GrafanaFolder{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: APIVersion,
+			Kind:       "GrafanaFolder",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "default",
+		},
+		Spec: GrafanaFolderSpec{
+			GrafanaCommonSpec: GrafanaCommonSpec{
+				InstanceSelector: &v1.LabelSelector{},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	Context("Enabling allowCrossNamespaceImport", func() {
+		It("Allows setting allowCrossNamespaceImport after creation", func() {
+			copyOfundefinedCrossImportFolder := undefinedCrossImportFolder.DeepCopy()
+			copyOfundefinedCrossImportFolder.Name = "disabled-from-undefined"
+			By("Creating a Folder without allowCrossNamespaceImport")
+			Expect(k8sClient.Create(ctx, copyOfundefinedCrossImportFolder)).To(Succeed())
+
+			By("Setting allowCrossNamespaceImport false")
+			copyOfundefinedCrossImportFolder.Spec.AllowCrossNamespaceImport = false
+			Expect(k8sClient.Update(ctx, copyOfundefinedCrossImportFolder)).To(Succeed())
+		})
+
+		It("Allows enabling allowCrossNamespaceImport from undefined", func() {
+			secondUndfinedCrossImportFolder := undefinedCrossImportFolder.DeepCopy()
+			secondUndfinedCrossImportFolder.Name = "enabled-from-undefined"
+
+			By("Creating a Folder with false allowCrossNamespaceImport")
+			Expect(k8sClient.Create(ctx, secondUndfinedCrossImportFolder)).To(Succeed())
+
+			By("Setting allowCrossNamespaceImport true")
+			secondUndfinedCrossImportFolder.Spec.AllowCrossNamespaceImport = true
+			Expect(k8sClient.Update(ctx, secondUndfinedCrossImportFolder)).To(Succeed())
+		})
+
+		It("Allows enabling allowCrossNamespaceImport when false", func() {
+			explicitNoCrossImportFolder := undefinedCrossImportFolder.DeepCopy()
+			explicitNoCrossImportFolder.Name = "enabled-from-false"
+			explicitNoCrossImportFolder.Spec.AllowCrossNamespaceImport = false
+			By("Creating a Folder with allowCrossNamespaceImport false")
+			Expect(k8sClient.Create(ctx, explicitNoCrossImportFolder)).To(Succeed())
+
+			By("Setting allowCrossNamespaceImport true")
+			explicitNoCrossImportFolder.Spec.AllowCrossNamespaceImport = true
+			Expect(k8sClient.Update(ctx, explicitNoCrossImportFolder)).To(Succeed())
+		})
+	})
+
+	Context("Disabling allowCrossNamespaceImport is blocked", func() {
+		It("Blocks disabling allowCrossNamespaceImport after creation with false", func() {
+			crossImportFolder := undefinedCrossImportFolder.DeepCopy()
+			crossImportFolder.Name = "disabled-from-true"
+			crossImportFolder.Spec.AllowCrossNamespaceImport = true
+			By("Creating a Folder with allowCrossNamespaceImport")
+			Expect(k8sClient.Create(ctx, crossImportFolder)).To(Succeed())
+
+			By("Setting allowCrossNamespaceImport false")
+			crossImportFolder.Spec.AllowCrossNamespaceImport = false
+			Expect(k8sClient.Update(ctx, crossImportFolder)).To(HaveOccurred())
+		})
+
+		It("Blocks disabling allowCrossNamespaceImport after creation with undefined", func() {
+			secondCrossImportFolder := undefinedCrossImportFolder.DeepCopy()
+			secondCrossImportFolder.Name = "unset-from-true"
+			secondCrossImportFolder.Spec.AllowCrossNamespaceImport = true
+			By("Creating a Folder with allowCrossNamespaceImport")
+			Expect(k8sClient.Create(ctx, secondCrossImportFolder)).To(Succeed())
+
+			By("Setting allowCrossNamespaceImport false")
+			unsetCrossImportFolder := undefinedCrossImportFolder.DeepCopy()
+			unsetCrossImportFolder.Name = "unset-from-true" // Needs the same name as above
+			Expect(k8sClient.Update(ctx, unsetCrossImportFolder)).To(HaveOccurred())
+		})
+	})
+})

--- a/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -247,6 +247,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -216,6 +216,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
@@ -409,6 +409,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaDashboardStatus defines the observed state of GrafanaDashboard
             properties:

--- a/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
@@ -245,6 +245,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaDatasourceStatus defines the observed state of GrafanaDatasource
             properties:

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -141,6 +141,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -191,6 +191,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationtemplates.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationtemplates.yaml
@@ -125,6 +125,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -247,6 +247,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -216,6 +216,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
@@ -409,6 +409,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaDashboardStatus defines the observed state of GrafanaDashboard
             properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
@@ -245,6 +245,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaDatasourceStatus defines the observed state of GrafanaDatasource
             properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -141,6 +141,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -191,6 +191,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationtemplates.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationtemplates.yaml
@@ -125,6 +125,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -246,6 +246,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:
@@ -535,6 +539,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:
@@ -1017,6 +1025,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaDashboardStatus defines the observed state of GrafanaDashboard
             properties:
@@ -1351,6 +1363,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaDatasourceStatus defines the observed state of GrafanaDatasource
             properties:
@@ -1575,6 +1591,10 @@ spec:
             - message: spec.uid is immutable
               rule: ((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) &&
                 has(self.uid)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: GrafanaFolderStatus defines the observed state of GrafanaFolder
             properties:
@@ -1845,6 +1865,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:
@@ -2043,6 +2067,10 @@ spec:
             - message: spec.editable is immutable
               rule: ((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable)
                 && has(self.editable)))
+            - message: disabling spec.allowCrossNamespaceImport requires a recreate
+                to ensure desired state
+              rule: '!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport
+                && self.allowCrossNamespaceImport)'
           status:
             description: The most recent observed state of a Grafana resource
             properties:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -72,7 +72,7 @@ GrafanaAlertRuleGroup is the Schema for the grafanaalertrulegroups API
         <td>
           GrafanaAlertRuleGroupSpec defines the desired state of GrafanaAlertRuleGroup<br/>
           <br/>
-            <i>Validations</i>:<li>(has(self.folderUID) && !(has(self.folderRef))) || (has(self.folderRef) && !(has(self.folderUID))): Only one of FolderUID or FolderRef can be set</li><li>((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable) && has(self.editable))): spec.editable is immutable</li>
+            <i>Validations</i>:<li>(has(self.folderUID) && !(has(self.folderRef))) || (has(self.folderRef) && !(has(self.folderUID))): Only one of FolderUID or FolderRef can be set</li><li>((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable) && has(self.editable))): spec.editable is immutable</li><li>!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport && self.allowCrossNamespaceImport): disabling spec.allowCrossNamespaceImport requires a recreate to ensure desired state</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -676,7 +676,7 @@ GrafanaContactPoint is the Schema for the grafanacontactpoints API
         <td>
           GrafanaContactPointSpec defines the desired state of GrafanaContactPoint<br/>
           <br/>
-            <i>Validations</i>:<li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li>
+            <i>Validations</i>:<li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li><li>!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport && self.allowCrossNamespaceImport): disabling spec.allowCrossNamespaceImport requires a recreate to ensure desired state</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1184,7 +1184,7 @@ GrafanaDashboard is the Schema for the grafanadashboards API
         <td>
           GrafanaDashboardSpec defines the desired state of GrafanaDashboard<br/>
           <br/>
-            <i>Validations</i>:<li>(has(self.folderUID) && !(has(self.folderRef))) || (has(self.folderRef) && !(has(self.folderUID))) || !(has(self.folderRef) && (has(self.folderUID))): Only one of folderUID or folderRef can be declared at the same time</li><li>(has(self.folder) && !(has(self.folderRef) || has(self.folderUID))) || !(has(self.folder)): folder field cannot be set when folderUID or folderRef is already declared</li><li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li>
+            <i>Validations</i>:<li>(has(self.folderUID) && !(has(self.folderRef))) || (has(self.folderRef) && !(has(self.folderUID))) || !(has(self.folderRef) && (has(self.folderUID))): Only one of folderUID or folderRef can be declared at the same time</li><li>(has(self.folder) && !(has(self.folderRef) || has(self.folderUID))) || !(has(self.folder)): folder field cannot be set when folderUID or folderRef is already declared</li><li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li><li>!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport && self.allowCrossNamespaceImport): disabling spec.allowCrossNamespaceImport requires a recreate to ensure desired state</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2295,7 +2295,7 @@ GrafanaDatasource is the Schema for the grafanadatasources API
         <td>
           GrafanaDatasourceSpec defines the desired state of GrafanaDatasource<br/>
           <br/>
-            <i>Validations</i>:<li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li>
+            <i>Validations</i>:<li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li><li>!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport && self.allowCrossNamespaceImport): disabling spec.allowCrossNamespaceImport requires a recreate to ensure desired state</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2969,7 +2969,7 @@ GrafanaFolder is the Schema for the grafanafolders API
         <td>
           GrafanaFolderSpec defines the desired state of GrafanaFolder<br/>
           <br/>
-            <i>Validations</i>:<li>(has(self.parentFolderUID) && !(has(self.parentFolderRef))) || (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef) && (has(self.parentFolderUID))): Only one of parentFolderUID or parentFolderRef can be set</li><li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li>
+            <i>Validations</i>:<li>(has(self.parentFolderUID) && !(has(self.parentFolderRef))) || (has(self.parentFolderRef) && !(has(self.parentFolderUID))) || !(has(self.parentFolderRef) && (has(self.parentFolderUID))): Only one of parentFolderUID or parentFolderRef can be set</li><li>((!has(oldSelf.uid) && !has(self.uid)) || (has(oldSelf.uid) && has(self.uid))): spec.uid is immutable</li><li>!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport && self.allowCrossNamespaceImport): disabling spec.allowCrossNamespaceImport requires a recreate to ensure desired state</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3318,7 +3318,7 @@ GrafanaNotificationPolicy is the Schema for the GrafanaNotificationPolicy API
         <td>
           GrafanaNotificationPolicySpec defines the desired state of GrafanaNotificationPolicy<br/>
           <br/>
-            <i>Validations</i>:<li>((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable) && has(self.editable))): spec.editable is immutable</li>
+            <i>Validations</i>:<li>((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable) && has(self.editable))): spec.editable is immutable</li><li>!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport && self.allowCrossNamespaceImport): disabling spec.allowCrossNamespaceImport requires a recreate to ensure desired state</li>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3784,7 +3784,7 @@ GrafanaNotificationTemplate is the Schema for the GrafanaNotificationTemplate AP
         <td>
           GrafanaNotificationTemplateSpec defines the desired state of GrafanaNotificationTemplate<br/>
           <br/>
-            <i>Validations</i>:<li>((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable) && has(self.editable))): spec.editable is immutable</li>
+            <i>Validations</i>:<li>((!has(oldSelf.editable) && !has(self.editable)) || (has(oldSelf.editable) && has(self.editable))): spec.editable is immutable</li><li>!oldSelf.allowCrossNamespaceImport || (oldSelf.allowCrossNamespaceImport && self.allowCrossNamespaceImport): disabling spec.allowCrossNamespaceImport requires a recreate to ensure desired state</li>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
Figured out a validation rule that accomplishes to block `true -> false` and `true -> undefined`
Added tests for validating the behavior as well