### PR TITLE
Fix: Move finalizers away from `GetAllMatchingInstances`

### DIFF
--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -335,18 +335,4 @@ var _ = Describe("GetMatchingInstances functions", Ordered, func() {
 			Expect(instances).To(HaveLen(1))
 		})
 	})
-
-	Context("Ensure AllowCrossNamespaceImport is ignored by GetAllMatchingInstances", func() {
-		It("Finds all ready instances when instanceSelector is empty", func() {
-			instances, err := GetAllMatchingInstances(ctx, k8sClient, matchAllFolder)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(instances).To(HaveLen(3))
-		})
-		It("Finds matching and ready instances ignoring AllowCrossNamespaceImport", func() {
-			instances, err := GetAllMatchingInstances(ctx, k8sClient, denyFolder)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(instances).ToNot(BeEmpty())
-			Expect(instances).To(HaveLen(2))
-		})
-	})
 })

--- a/controllers/grafananotificationtemplate_controller.go
+++ b/controllers/grafananotificationtemplate_controller.go
@@ -160,7 +160,7 @@ func (r *GrafanaNotificationTemplateReconciler) reconcileWithInstance(ctx contex
 func (r *GrafanaNotificationTemplateReconciler) finalize(ctx context.Context, notificationTemplate *grafanav1beta1.GrafanaNotificationTemplate) error {
 	r.Log.Info("Finalizing GrafanaNotificationTemplate")
 
-	instances, err := GetAllMatchingInstances(ctx, r.Client, notificationTemplate)
+	instances, err := GetScopedMatchingInstances(r.Log, ctx, r.Client, notificationTemplate)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}


### PR DESCRIPTION
- chore: Only fetch scoped matching instances in `GrafanaFolder` finalize
- chore: Only fetch scoped matching instances in `GrafanaNotificationTemplate` finalize
- chore: remove `GetAllMatchingInstances` and relevant tests