### PR TITLE
Refactor: Update `GrafanaDatasource` reconcile loop

### DIFF
--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -86,7 +86,8 @@ type GrafanaDatasourceSpec struct {
 type GrafanaDatasourceStatus struct {
 	GrafanaCommonStatus `json:",inline"`
 
-	Hash        string `json:"hash,omitempty"`
+	Hash string `json:"hash,omitempty"`
+	// Deprecated: Check status.conditions or operator logs
 	LastMessage string `json:"lastMessage,omitempty"`
 	// The datasource instanceSelector can't find matching grafana instances
 	NoMatchingInstances bool   `json:"NoMatchingInstances,omitempty"`

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -149,10 +149,6 @@ func (in *GrafanaDatasource) CustomUIDOrUID() string {
 	return string(in.ObjectMeta.UID)
 }
 
-func (in *GrafanaDatasource) IsAllowCrossNamespaceImport() bool {
-	return in.Spec.AllowCrossNamespaceImport
-}
-
 func (in *GrafanaDatasourceList) Find(namespace string, name string) *GrafanaDatasource {
 	for _, datasource := range in.Items {
 		if datasource.Namespace == namespace && datasource.Name == name {
@@ -160,6 +156,18 @@ func (in *GrafanaDatasourceList) Find(namespace string, name string) *GrafanaDat
 		}
 	}
 	return nil
+}
+
+func (in *GrafanaDatasource) MatchLabels() *metav1.LabelSelector {
+	return in.Spec.InstanceSelector
+}
+
+func (in *GrafanaDatasource) MatchNamespace() string {
+	return in.ObjectMeta.Namespace
+}
+
+func (in *GrafanaDatasource) AllowCrossNamespace() bool {
+	return in.Spec.AllowCrossNamespaceImport
 }
 
 func init() {

--- a/api/v1beta1/grafanadatasource_types_test.go
+++ b/api/v1beta1/grafanadatasource_types_test.go
@@ -71,3 +71,27 @@ var _ = Describe("Datasource type", func() {
 		})
 	})
 })
+
+var _ = Describe("Fail on field behavior changes", func() {
+	emptyDatasource := &GrafanaDatasource{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: APIVersion,
+			Kind:       "GrafanaDatasource",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-nil-datasource",
+			Namespace: "default",
+		},
+		Spec: GrafanaDatasourceSpec{
+			GrafanaCommonSpec: GrafanaCommonSpec{
+				InstanceSelector: &v1.LabelSelector{},
+			},
+			Datasource: nil,
+		},
+	}
+
+	ctx := context.Background()
+	It("Fails creating GrafanaDatasource with undefined spec.datasource", func() {
+		Expect(k8sClient.Create(ctx, emptyDatasource)).To(HaveOccurred())
+	})
+})

--- a/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
@@ -320,6 +320,7 @@ spec:
               hash:
                 type: string
               lastMessage:
+                description: 'Deprecated: Check status.conditions or operator logs'
                 type: string
               lastResync:
                 description: Last time the resource was synchronized with Grafana

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -399,6 +399,7 @@ func (r *GrafanaDatasourceReconciler) Exists(client *genapi.GrafanaHTTPAPI, uid,
 func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, ctx context.Context) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.GrafanaDatasource{}).
+		WithEventFilter(ignoreStatusUpdates()).
 		Complete(r)
 
 	if err == nil {

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -174,12 +174,6 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("error getting grafana datasource cr: %w", err)
 	}
 
-	if cr.Spec.Datasource == nil {
-		log.Info("skipped datasource with empty spec", cr.Name, cr.Namespace)
-		// TODO: add a custom status around that?
-		return ctrl.Result{}, nil
-	}
-
 	defer func() {
 		cr.Status.LastResync = metav1.Time{Time: time.Now()}
 		if err := r.Status().Update(ctx, cr); err != nil {

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -67,9 +67,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 	var opts []client.ListOption
 	err := r.Client.List(ctx, grafanas, opts...)
 	if err != nil {
-		return ctrl.Result{
-			Requeue: true,
-		}, err
+		return ctrl.Result{}, err
 	}
 
 	// no instances, no need to sync
@@ -81,9 +79,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 	allDatasources := &v1beta1.GrafanaDatasourceList{}
 	err = r.Client.List(ctx, allDatasources, opts...)
 	if err != nil {
-		return ctrl.Result{
-			Requeue: true,
-		}, err
+		return ctrl.Result{}, err
 	}
 
 	// sync datasources, delete datasources from grafana that do no longer have a cr
@@ -102,7 +98,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 		grafana := grafana
 		grafanaClient, err := client2.NewGeneratedGrafanaClient(ctx, r.Client, grafana)
 		if err != nil {
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{}, err
 		}
 
 		for _, datasource := range existingDatasources {
@@ -118,7 +114,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 			if err != nil {
 				var notFound *datasources.GetDataSourceByUIDNotFound
 				if errors.As(err, &notFound) {
-					return ctrl.Result{Requeue: false}, err
+					return ctrl.Result{}, err
 				}
 				log.Info("datasource no longer exists", "namespace", namespace, "name", name)
 			} else {
@@ -126,7 +122,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 				if err != nil {
 					var notFound *datasources.DeleteDataSourceByUIDNotFound
 					if errors.As(err, &notFound) {
-						return ctrl.Result{Requeue: false}, err
+						return ctrl.Result{}, err
 					}
 				}
 			}
@@ -139,7 +135,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 		// so we should minimize those updates
 		err = r.Client.Status().Update(ctx, grafana)
 		if err != nil {
-			return ctrl.Result{Requeue: false}, err
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -171,12 +167,11 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if kuberr.IsNotFound(err) {
 			err = r.onDatasourceDeleted(ctx, req.Namespace, req.Name)
 			if err != nil {
-				return ctrl.Result{RequeueAfter: RequeueDelay}, err
+				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
 		}
-		log.Error(err, "error getting grafana datasource cr")
-		return ctrl.Result{RequeueAfter: RequeueDelay}, err
+		return ctrl.Result{}, fmt.Errorf("error getting grafana datasource cr: %w", err)
 	}
 
 	if cr.Spec.Datasource == nil {
@@ -184,6 +179,13 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// TODO: add a custom status around that?
 		return ctrl.Result{}, nil
 	}
+
+	defer func() {
+		cr.Status.LastResync = metav1.Time{Time: time.Now()}
+		if err := r.Status().Update(ctx, cr); err != nil {
+			log.Error(err, "updating status")
+		}
+	}()
 
 	// Overwrite OrgID to ensure the field is useless
 	cr.Spec.Datasource.OrgID = nil
@@ -209,30 +211,25 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	datasource, hash, err := r.getDatasourceContent(ctx, cr)
 	if err != nil {
-		log.Error(err, "could not retrieve datasource contents", "name", cr.Name, "namespace", cr.Namespace)
-		return ctrl.Result{RequeueAfter: RequeueDelay}, err
+		return ctrl.Result{}, fmt.Errorf("could not retrieve datasource contents: %w", err)
 	}
 
 	if cr.IsUpdatedUID() {
 		log.Info("datasource uid got updated, deleting datasources with the old uid")
 		err = r.onDatasourceDeleted(ctx, req.Namespace, req.Name)
 		if err != nil {
-			return ctrl.Result{RequeueAfter: RequeueDelay}, err
+			return ctrl.Result{}, err
 		}
 
 		// Clean up uid, so further reconcilications can track changes there
 		cr.Status.UID = ""
 
-		err = r.Client.Status().Update(ctx, cr)
-		if err != nil {
-			return ctrl.Result{RequeueAfter: RequeueDelay}, err
-		}
-
-		// Status update should trigger the next reconciliation right away, no need to requeue for dashboard creation
-		return ctrl.Result{}, nil
+		// Force requeue for datasource creation
+		return ctrl.Result{Requeue: true}, nil
 	}
 
-	success := true
+	pluginErrors := make(map[string]string)
+	applyErrors := make(map[string]string)
 	for _, grafana := range instances {
 		grafana := grafana
 
@@ -242,33 +239,36 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			// grafana reconciler will pick them upi
 			err = ReconcilePlugins(ctx, r.Client, r.Scheme, &grafana, cr.Spec.Plugins, fmt.Sprintf("%v-datasource", cr.Name))
 			if err != nil {
-				success = false
-				log.Error(err, "error reconciling plugins", "datasource", cr.Name, "grafana", grafana.Name)
+				pluginErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 			}
 		}
 
 		// then import the datasource into the matching grafana instances
 		err = r.onDatasourceCreated(ctx, &grafana, cr, datasource, hash)
 		if err != nil {
-			success = false
 			cr.Status.LastMessage = err.Error()
-			log.Error(err, "error reconciling datasource", "datasource", cr.Name, "grafana", grafana.Name)
+			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 		}
 	}
 
-	// if the datasource was successfully synced in all instances, wait for its re-sync period
-	if success {
-		cr.Status.LastMessage = ""
-		cr.Status.Hash = hash
-		if cr.ResyncPeriodHasElapsed() {
-			cr.Status.LastResync = metav1.Time{Time: time.Now()}
-		}
-		cr.Status.UID = cr.CustomUIDOrUID()
-		return ctrl.Result{RequeueAfter: cr.Spec.ResyncPeriod.Duration}, r.Client.Status().Update(ctx, cr)
-	} else {
-		// if there was an issue with the datasource, update the status
-		return ctrl.Result{RequeueAfter: RequeueDelay}, r.Client.Status().Update(ctx, cr)
+	// Specific to datasources
+	if len(pluginErrors) > 0 {
+		err := fmt.Errorf("%v", pluginErrors)
+		log.Error(err, "failed to apply plugins to all instances")
 	}
+
+	if len(applyErrors) > 0 {
+		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
+	}
+
+	condition := buildSynchronizedCondition("Datasource", conditionDatasourceSynchronized, cr.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&cr.Status.Conditions, condition)
+
+	cr.Status.Hash = hash
+	cr.Status.LastMessage = ""
+	cr.Status.UID = cr.CustomUIDOrUID()
+
+	return ctrl.Result{RequeueAfter: cr.Spec.ResyncPeriod.Duration}, nil
 }
 
 func (r *GrafanaDatasourceReconciler) onDatasourceDeleted(ctx context.Context, namespace string, name string) error {
@@ -416,24 +416,6 @@ func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, ctx con
 	}
 
 	return err
-}
-
-func (r *GrafanaDatasourceReconciler) GetMatchingDatasourceInstances(ctx context.Context, datasource *v1beta1.GrafanaDatasource, k8sClient client.Client) (v1beta1.GrafanaList, error) {
-	log := logf.FromContext(ctx)
-	instances, err := GetMatchingInstances(ctx, k8sClient, datasource.Spec.InstanceSelector)
-	if err != nil || len(instances.Items) == 0 {
-		datasource.Status.NoMatchingInstances = true
-		if err := r.Client.Status().Update(ctx, datasource); err != nil {
-			log.Info("unable to update the status of %v, in %v", datasource.Name, datasource.Namespace)
-		}
-		return v1beta1.GrafanaList{}, err
-	}
-	datasource.Status.NoMatchingInstances = false
-	if err := r.Client.Status().Update(ctx, datasource); err != nil {
-		log.Info("unable to update the status of %v, in %v", datasource.Name, datasource.Namespace)
-	}
-
-	return instances, err
 }
 
 func (r *GrafanaDatasourceReconciler) getDatasourceContent(ctx context.Context, cr *v1beta1.GrafanaDatasource) (*models.UpdateDataSourceCommand, string, error) {

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -219,11 +219,6 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	cr.Status.NoMatchingInstances = false
 	log.Info("found matching Grafana instances for datasource", "count", len(instances))
 
-	datasource, hash, err := r.getDatasourceContent(ctx, cr)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("could not retrieve datasource contents: %w", err)
-	}
-
 	if cr.IsUpdatedUID() {
 		log.Info("datasource uid got updated, deleting datasources with the old uid")
 		if err = r.finalize(ctx, cr); err != nil {
@@ -236,6 +231,15 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// Force requeue for datasource creation
 		return ctrl.Result{Requeue: true}, nil
 	}
+
+	datasource, hash, err := r.buildDatasourceModel(ctx, cr)
+	if err != nil {
+		setInvalidSpec(&cr.Status.Conditions, cr.Generation, "InvalidModel", err.Error())
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDatasourceSynchronized)
+		return ctrl.Result{}, fmt.Errorf("could not build datasource model: %w", err)
+	}
+
+	removeInvalidSpec(&cr.Status.Conditions)
 
 	pluginErrors := make(map[string]string)
 	applyErrors := make(map[string]string)
@@ -259,6 +263,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
+	// NOTE New Condition?
 	// Specific to datasources
 	if len(pluginErrors) > 0 {
 		err := fmt.Errorf("%v", pluginErrors)
@@ -425,31 +430,30 @@ func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, ctx con
 	return err
 }
 
-func (r *GrafanaDatasourceReconciler) getDatasourceContent(ctx context.Context, cr *v1beta1.GrafanaDatasource) (*models.UpdateDataSourceCommand, string, error) {
+func (r *GrafanaDatasourceReconciler) buildDatasourceModel(ctx context.Context, cr *v1beta1.GrafanaDatasource) (*models.UpdateDataSourceCommand, string, error) {
 	// Overwrite OrgID to ensure the field is useless
 	cr.Spec.Datasource.OrgID = nil
 
 	initialBytes, err := json.Marshal(cr.Spec.Datasource)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("encoding existing datasource model as json: %w", err)
 	}
 
 	// Unstructured object for mutating target paths
 	simpleContent, err := simplejson.NewJson(initialBytes)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("parsing marshaled json as simplejson")
 	}
 
 	simpleContent.Set("uid", cr.CustomUIDOrUID())
 
-	for _, ref := range cr.Spec.ValuesFrom {
-		ref := ref
-		val, key, err := getReferencedValue(ctx, r.Client, cr, ref.ValueFrom)
+	for _, override := range cr.Spec.ValuesFrom {
+		val, key, err := getReferencedValue(ctx, r.Client, cr, override.ValueFrom)
 		if err != nil {
-			return nil, "", err
+			return nil, "", fmt.Errorf("getting referenced value: %w", err)
 		}
 
-		patternToReplace := simpleContent.GetPath(strings.Split(ref.TargetPath, ".")...)
+		patternToReplace := simpleContent.GetPath(strings.Split(override.TargetPath, ".")...)
 		patternString, err := patternToReplace.String()
 		if err != nil {
 			return nil, "", fmt.Errorf("pattern must be a string")
@@ -457,7 +461,9 @@ func (r *GrafanaDatasourceReconciler) getDatasourceContent(ctx context.Context, 
 
 		patternString = strings.ReplaceAll(patternString, fmt.Sprintf("${%v}", key), val)
 		patternString = strings.ReplaceAll(patternString, fmt.Sprintf("$%v", key), val)
-		simpleContent.SetPath(strings.Split(ref.TargetPath, "."), patternString)
+
+		r.Log.V(1).Info("overriding value", "key", override.TargetPath, "value", val)
+		simpleContent.SetPath(strings.Split(override.TargetPath, "."), patternString)
 	}
 
 	newBytes, err := simpleContent.MarshalJSON()

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -221,7 +221,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if cr.IsUpdatedUID() {
 		log.Info("datasource uid got updated, deleting datasources with the old uid")
-		if err = r.finalize(ctx, cr); err != nil {
+		if err = r.deleteOldDatasource(ctx, cr); err != nil {
 			return ctrl.Result{}, err
 		}
 
@@ -284,6 +284,45 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return ctrl.Result{RequeueAfter: cr.Spec.ResyncPeriod.Duration}, nil
 }
 
+func (r *GrafanaDatasourceReconciler) deleteOldDatasource(ctx context.Context, cr *v1beta1.GrafanaDatasource) error {
+	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
+	if err != nil {
+		return fmt.Errorf("fetching instances: %w", err)
+	}
+
+	for _, grafana := range instances {
+		grafana := grafana
+
+		found, uid := grafana.Status.Datasources.Find(cr.Namespace, cr.Name)
+		if !found {
+			continue
+		}
+
+		grafanaClient, err := client2.NewGeneratedGrafanaClient(ctx, r.Client, &grafana)
+		if err != nil {
+			return err
+		}
+
+		datasource, err := grafanaClient.Datasources.GetDataSourceByUID(*uid)
+		if err != nil {
+			var notFound *datasources.GetDataSourceByUIDNotFound
+			if !errors.As(err, &notFound) {
+				return err
+			}
+		} else {
+			_, err = grafanaClient.Datasources.DeleteDataSourceByUID(datasource.Payload.UID) //nolint
+			if err != nil {
+				return fmt.Errorf("deleting datasource to update uid %s: %w", *uid, err)
+			}
+		}
+
+		grafana.Status.Datasources = grafana.Status.Datasources.Remove(cr.Namespace, cr.Name)
+		return r.Client.Status().Update(ctx, &grafana)
+	}
+
+	return nil
+}
+
 func (r *GrafanaDatasourceReconciler) finalize(ctx context.Context, cr *v1beta1.GrafanaDatasource) error {
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
@@ -292,38 +331,35 @@ func (r *GrafanaDatasourceReconciler) finalize(ctx context.Context, cr *v1beta1.
 
 	for _, grafana := range instances {
 		grafana := grafana
-		if found, uid := grafana.Status.Datasources.Find(cr.Namespace, cr.Name); found {
-			grafanaClient, err := client2.NewGeneratedGrafanaClient(ctx, r.Client, &grafana)
+
+		found, uid := grafana.Status.Datasources.Find(cr.Namespace, cr.Name)
+		if !found {
+			continue
+		}
+
+		grafanaClient, err := client2.NewGeneratedGrafanaClient(ctx, r.Client, &grafana)
+		if err != nil {
+			return err
+		}
+
+		_, err = grafanaClient.Datasources.DeleteDataSourceByUID(*uid) // nolint:errcheck
+		if err != nil {
+			var notFound *datasources.DeleteDataSourceByUIDNotFound
+			if errors.As(err, &notFound) {
+				return nil
+			}
+			return fmt.Errorf("deleting datasource %s: %w", *uid, err)
+		}
+
+		if grafana.IsInternal() {
+			err = ReconcilePlugins(ctx, r.Client, r.Scheme, &grafana, nil, fmt.Sprintf("%v-datasource", cr.Name))
 			if err != nil {
 				return err
 			}
-
-			datasource, err := grafanaClient.Datasources.GetDataSourceByUID(*uid)
-			if err != nil {
-				var notFound *datasources.GetDataSourceByUIDNotFound
-				if errors.As(err, &notFound) {
-					return err
-				}
-			} else {
-				_, err = grafanaClient.Datasources.DeleteDataSourceByUID(datasource.Payload.UID) //nolint
-				if err != nil {
-					var notFound *datasources.DeleteDataSourceByUIDNotFound
-					if errors.As(err, &notFound) {
-						return err
-					}
-				}
-			}
-
-			if grafana.IsInternal() {
-				err = ReconcilePlugins(ctx, r.Client, r.Scheme, &grafana, nil, fmt.Sprintf("%v-datasource", cr.Name))
-				if err != nil {
-					return err
-				}
-			}
-
-			grafana.Status.Datasources = grafana.Status.Datasources.Remove(cr.Namespace, cr.Name)
-			return r.Client.Status().Update(ctx, &grafana)
 		}
+
+		grafana.Status.Datasources = grafana.Status.Datasources.Remove(cr.Namespace, cr.Name)
+		return r.Client.Status().Update(ctx, &grafana)
 	}
 
 	return nil
@@ -431,6 +467,7 @@ func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, ctx con
 }
 
 func (r *GrafanaDatasourceReconciler) buildDatasourceModel(ctx context.Context, cr *v1beta1.GrafanaDatasource) (*models.UpdateDataSourceCommand, string, error) {
+	log := logf.FromContext(ctx)
 	// Overwrite OrgID to ensure the field is useless
 	cr.Spec.Datasource.OrgID = nil
 
@@ -462,7 +499,7 @@ func (r *GrafanaDatasourceReconciler) buildDatasourceModel(ctx context.Context, 
 		patternString = strings.ReplaceAll(patternString, fmt.Sprintf("${%v}", key), val)
 		patternString = strings.ReplaceAll(patternString, fmt.Sprintf("$%v", key), val)
 
-		r.Log.V(1).Info("overriding value", "key", override.TargetPath, "value", val)
+		log.V(1).Info("overriding value", "key", override.TargetPath, "value", val)
 		simpleContent.SetPath(strings.Split(override.TargetPath, "."), patternString)
 	}
 

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -34,6 +34,7 @@ import (
 	genapi "github.com/grafana/grafana-openapi-client-go/client"
 	client2 "github.com/grafana/grafana-operator/v5/controllers/client"
 	kuberr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -41,6 +42,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
+)
+
+const (
+	conditionDatasourceSynchronized = "DatasourceSynchronized"
 )
 
 // GrafanaDatasourceReconciler reconciles a GrafanaDatasource object
@@ -183,13 +188,24 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// Overwrite OrgID to ensure the field is useless
 	cr.Spec.Datasource.OrgID = nil
 
-	instances, err := r.GetMatchingDatasourceInstances(ctx, cr, r.Client)
+	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
-		log.Error(err, "could not find matching instances", "name", cr.Name, "namespace", cr.Namespace)
-		return ctrl.Result{RequeueAfter: RequeueDelay}, err
+		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDatasourceSynchronized)
+		cr.Status.NoMatchingInstances = true
+		return ctrl.Result{}, fmt.Errorf("failed fetching instances: %w", err)
 	}
 
-	log.Info("found matching Grafana instances for datasource", "count", len(instances.Items))
+	if len(instances) == 0 {
+		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDatasourceSynchronized)
+		cr.Status.NoMatchingInstances = true
+		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
+	}
+
+	removeNoMatchingInstance(&cr.Status.Conditions)
+	cr.Status.NoMatchingInstances = false
+	log.Info("found matching Grafana instances for datasource", "count", len(instances))
 
 	datasource, hash, err := r.getDatasourceContent(ctx, cr)
 	if err != nil {
@@ -217,20 +233,8 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	success := true
-	for _, grafana := range instances.Items {
-		// check if this is a cross namespace import
-		if grafana.Namespace != cr.Namespace && !cr.IsAllowCrossNamespaceImport() {
-			continue
-		}
-
+	for _, grafana := range instances {
 		grafana := grafana
-		// an admin url is required to interact with grafana
-		// the instance or route might not yet be ready
-		if grafana.Status.Stage != v1beta1.OperatorStageComplete || grafana.Status.StageStatus != v1beta1.OperatorStageResultSuccess {
-			log.Info("grafana instance not ready", "grafana", grafana.Name)
-			success = false
-			continue
-		}
 
 		if grafana.IsInternal() {
 			// first reconcile the plugins

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -258,7 +258,6 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// then import the datasource into the matching grafana instances
 		err = r.onDatasourceCreated(ctx, &grafana, cr, datasource, hash)
 		if err != nil {
-			cr.Status.LastMessage = err.Error()
 			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 		}
 	}
@@ -277,7 +276,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	meta.SetStatusCondition(&cr.Status.Conditions, condition)
 
 	cr.Status.Hash = hash
-	cr.Status.LastMessage = ""
+	cr.Status.LastMessage = "" // nolint:staticcheck
 	cr.Status.UID = cr.CustomUIDOrUID()
 
 	return ctrl.Result{RequeueAfter: cr.Spec.ResyncPeriod.Duration}, nil
@@ -472,6 +471,7 @@ func (r *GrafanaDatasourceReconciler) getDatasourceContent(ctx context.Context, 
 		return nil, "", err
 	}
 
+	// TODO Remove hashing along with the Status.Hash field
 	hash := sha256.New()
 	hash.Write(newBytes)
 

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -200,9 +200,6 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}()
 
-	// Overwrite OrgID to ensure the field is useless
-	cr.Spec.Datasource.OrgID = nil
-
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
@@ -429,11 +426,15 @@ func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, ctx con
 }
 
 func (r *GrafanaDatasourceReconciler) getDatasourceContent(ctx context.Context, cr *v1beta1.GrafanaDatasource) (*models.UpdateDataSourceCommand, string, error) {
+	// Overwrite OrgID to ensure the field is useless
+	cr.Spec.Datasource.OrgID = nil
+
 	initialBytes, err := json.Marshal(cr.Spec.Datasource)
 	if err != nil {
 		return nil, "", err
 	}
 
+	// Unstructured object for mutating target paths
 	simpleContent, err := simplejson.NewJson(initialBytes)
 	if err != nil {
 		return nil, "", err

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -28,7 +28,7 @@ func TestGetDatasourceContent(t *testing.T) {
 			},
 		}
 
-		content, hash, err := reconciler.getDatasourceContent(context.TODO(), cr)
+		content, hash, err := reconciler.buildDatasourceModel(context.TODO(), cr)
 		got := content.SecureJSONData["httpHeaderValue1"]
 
 		assert.Nil(t, err)

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
@@ -320,6 +320,7 @@ spec:
               hash:
                 type: string
               lastMessage:
+                description: 'Deprecated: Check status.conditions or operator logs'
                 type: string
               lastResync:
                 description: Last time the resource was synchronized with Grafana

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -1465,6 +1465,7 @@ spec:
               hash:
                 type: string
               lastMessage:
+                description: 'Deprecated: Check status.conditions or operator logs'
                 type: string
               lastResync:
                 description: Last time the resource was synchronized with Grafana

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -2836,7 +2836,7 @@ GrafanaDatasourceStatus defines the observed state of GrafanaDatasource
         <td><b>lastMessage</b></td>
         <td>string</td>
         <td>
-          <br/>
+          Deprecated: Check status.conditions or operator logs<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/tests/e2e/example-test/01-assert.yaml
+++ b/tests/e2e/example-test/01-assert.yaml
@@ -4,3 +4,12 @@ metadata:
   name: grafana-deployment
 status:
   availableReplicas: 1
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: grafanadatasource-sample
+status:
+  conditions:
+    - type: DatasourceSynchronized
+      status: "True"

--- a/tests/e2e/example-test/06-assert.yaml
+++ b/tests/e2e/example-test/06-assert.yaml
@@ -8,4 +8,4 @@ binaryData:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name:  grafana-dashboard-secret-envs
+  name: grafana-dashboard-secret-envs

--- a/tests/e2e/example-test/07-assert.yaml
+++ b/tests/e2e/example-test/07-assert.yaml
@@ -1,4 +1,4 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name:  grafana-dashboard-jsonnet-project
+  name: grafana-dashboard-jsonnet-project

--- a/tests/e2e/examples/crossnamespace/assertions.yaml
+++ b/tests/e2e/examples/crossnamespace/assertions.yaml
@@ -42,4 +42,4 @@ metadata:
   name: example-grafanadatasource
   namespace: (join('-', ['cross', $namespace]))
 status:
-  (lastMessage != null): true
+  (conditions != null): true


### PR DESCRIPTION
This was a significantly more complex rewrite than earlier reconcile loops simply due to how different the controller was written.
I recommend to review this one commit at a time and to have at least 2 separate reviewers verify it due to the amount of changes.

I had to split `finalize` into two separate functions to get past a nasty "Not found" error loop that is correct on an updated uid, but a problem when trying to delete a crd.
I would like some comments on whether `ReconcilePlugins` is needed in both or just finalize?

See commit messages for detailed changes.

This should close #1681 and tick off GrafanaDatasource on #1450