### PR TITLE
Refactor: Update `GrafanaAlertRuleGroup` reconcile loop

### DIFF
--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -121,6 +121,8 @@ type AlertQuery struct {
 //+kubebuilder:subresource:status
 
 // GrafanaAlertRuleGroup is the Schema for the grafanaalertrulegroups API
+// +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:resource:categories={grafana-operator}
 type GrafanaAlertRuleGroup struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -162,6 +164,18 @@ func (in *GrafanaAlertRuleGroup) FolderRef() string {
 // FolderUID implements FolderReferencer.
 func (in *GrafanaAlertRuleGroup) FolderUID() string {
 	return in.Spec.FolderUID
+}
+
+func (in *GrafanaAlertRuleGroup) MatchLabels() *metav1.LabelSelector {
+	return in.Spec.InstanceSelector
+}
+
+func (in *GrafanaAlertRuleGroup) MatchNamespace() string {
+	return in.ObjectMeta.Namespace
+}
+
+func (in *GrafanaAlertRuleGroup) AllowCrossNamespace() bool {
+	return in.Spec.AllowCrossNamespaceImport
 }
 
 var _ operatorapi.FolderReferencer = (*GrafanaAlertRuleGroup)(nil)

--- a/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -16,7 +16,15 @@ spec:
     singular: grafanaalertrulegroup
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaAlertRuleGroup is the Schema for the grafanaalertrulegroups

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -235,19 +235,6 @@ func setNoMatchingInstancesCondition(conditions *[]metav1.Condition, generation 
 	})
 }
 
-func setNoMatchingInstance(conditions *[]metav1.Condition, generation int64, reason, message string) {
-	meta.SetStatusCondition(conditions, metav1.Condition{
-		Type:               conditionNoMatchingInstance,
-		Status:             metav1.ConditionTrue,
-		ObservedGeneration: generation,
-		LastTransitionTime: metav1.Time{
-			Time: time.Now(),
-		},
-		Reason:  reason,
-		Message: message,
-	})
-}
-
 func removeNoMatchingInstance(conditions *[]metav1.Condition) {
 	meta.RemoveStatusCondition(conditions, conditionNoMatchingInstance)
 }

--- a/controllers/grafanaalertrulegroup_controller.go
+++ b/controllers/grafanaalertrulegroup_controller.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	kuberr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -59,8 +61,7 @@ type GrafanaAlertRuleGroupReconciler struct {
 // move the current state of the cluster closer to the desired state.
 
 func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	controllerLog := log.FromContext(ctx).WithName("GrafanaAlertRuleGroupReconciler")
-	r.Log = log.FromContext(ctx)
+	r.Log = log.FromContext(ctx).WithName("GrafanaAlertRuleGroupReconciler")
 
 	group := &grafanav1beta1.GrafanaAlertRuleGroup{}
 	err := r.Client.Get(ctx, client.ObjectKey{
@@ -71,8 +72,7 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		controllerLog.Error(err, "error getting grafana alertrulegroup cr")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("error getting GrafanaAlertRuleGroup: %w", err)
 	}
 
 	if group.GetDeletionTimestamp() != nil {
@@ -89,6 +89,7 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	defer func() {
+		group.Status.LastResync = metav1.Time{Time: time.Now()}
 		if err := r.Client.Status().Update(ctx, group); err != nil {
 			r.Log.Error(err, "updating status")
 		}
@@ -103,21 +104,21 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}()
 
-	instances, err := r.GetMatchingInstances(ctx, group, r.Client)
+	instances, err := GetScopedMatchingInstances(r.Log, ctx, r.Client, group)
 	if err != nil {
-		setNoMatchingInstance(&group.Status.Conditions, group.Generation, "ErrFetchingInstances", fmt.Sprintf("error occurred during fetching of instances: %s", err.Error()))
+		setNoMatchingInstancesCondition(&group.Status.Conditions, group.Generation, err)
 		meta.RemoveStatusCondition(&group.Status.Conditions, conditionAlertGroupSynchronized)
-		r.Log.Error(err, "could not find matching instances")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed fetching instances: %w", err)
 	}
 
 	if len(instances) == 0 {
+		setNoMatchingInstancesCondition(&group.Status.Conditions, group.Generation, err)
 		meta.RemoveStatusCondition(&group.Status.Conditions, conditionAlertGroupSynchronized)
-		setNoMatchingInstance(&group.Status.Conditions, group.Generation, "EmptyAPIReply", "Instances could not be fetched, reconciliation will be retried")
-		return ctrl.Result{}, fmt.Errorf("no instances found")
+		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 	}
 
 	removeNoMatchingInstance(&group.Status.Conditions)
+	r.Log.Info("found matching Grafana instances for group", "count", len(instances))
 
 	folderUID, err := getFolderUID(ctx, r.Client, group)
 	if err != nil || folderUID == "" {
@@ -128,21 +129,20 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 	for _, grafana := range instances {
 		// can be removed in go 1.22+
 		grafana := grafana
-		if grafana.Status.Stage != grafanav1beta1.OperatorStageComplete || grafana.Status.StageStatus != grafanav1beta1.OperatorStageResultSuccess {
-			controllerLog.Info("grafana instance not ready", "grafana", grafana.Name)
-			continue
-		}
 
 		err := r.reconcileWithInstance(ctx, &grafana, group, folderUID)
 		if err != nil {
 			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 		}
 	}
-	condition := buildSynchronizedCondition("Alert Rule Group", conditionAlertGroupSynchronized, group.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&group.Status.Conditions, condition)
+
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
+
+	condition := buildSynchronizedCondition("Alert Rule Group", conditionAlertGroupSynchronized, group.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&group.Status.Conditions, condition)
+
 	return ctrl.Result{RequeueAfter: group.Spec.ResyncPeriod.Duration}, nil
 }
 
@@ -290,10 +290,12 @@ func (r *GrafanaAlertRuleGroupReconciler) finalize(ctx context.Context, group *g
 		r.Log.Info("ignoring finalization logic as folder no longer exists")
 		return nil //nolint:nilerr
 	}
-	instances, err := r.GetMatchingInstances(ctx, group, r.Client)
+
+	instances, err := GetScopedMatchingInstances(r.Log, ctx, r.Client, group)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}
+
 	for _, i := range instances {
 		instance := i
 		if err := r.removeFromInstance(ctx, &instance, group, folderUID); err != nil {
@@ -326,22 +328,4 @@ func (r *GrafanaAlertRuleGroupReconciler) removeFromInstance(ctx context.Context
 		}
 	}
 	return nil
-}
-
-func (r *GrafanaAlertRuleGroupReconciler) GetMatchingInstances(ctx context.Context, group *grafanav1beta1.GrafanaAlertRuleGroup, k8sClient client.Client) ([]grafanav1beta1.Grafana, error) {
-	instances, err := GetMatchingInstances(ctx, k8sClient, group.Spec.InstanceSelector)
-	if err != nil || len(instances.Items) == 0 {
-		return nil, err
-	}
-	if group.Spec.AllowCrossNamespaceImport {
-		return instances.Items, nil
-	}
-	items := []grafanav1beta1.Grafana{}
-	for _, i := range instances.Items {
-		if i.Namespace == group.Namespace {
-			items = append(items, i)
-		}
-	}
-
-	return items, err
 }

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -16,7 +16,15 @@ spec:
     singular: grafanaalertrulegroup
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaAlertRuleGroup is the Schema for the grafanaalertrulegroups

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -15,7 +15,15 @@ spec:
     singular: grafanaalertrulegroup
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GrafanaAlertRuleGroup is the Schema for the grafanaalertrulegroups


### PR DESCRIPTION
- Fix: Warnings when returning `ctrl.Result` and an `error` and logging some errors twice.
- Feat: `status.lastResync` is now updated and registered as a printed column
- Refactor: Use `GetScopedMatchingInstances` for `Reconcile` and `finalize`