### PR TITLE
Refactor: Reconcile loggers, prepare for concurrent reconcilers

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	operatorapi "github.com/grafana/grafana-operator/v5/api"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	grafanav1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -23,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -75,7 +75,8 @@ func GetMatchingInstances(ctx context.Context, k8sClient client.Client, labelSel
 // Only matching instances in the scope of the resource are returned
 // Resources with allowCrossNamespaceImport expands the scope to the entire cluster
 // Intended to be used in reconciler functions
-func GetScopedMatchingInstances(log logr.Logger, ctx context.Context, k8sClient client.Client, cr v1beta1.CommonResource) ([]v1beta1.Grafana, error) {
+func GetScopedMatchingInstances(ctx context.Context, k8sClient client.Client, cr v1beta1.CommonResource) ([]v1beta1.Grafana, error) {
+	log := logf.FromContext(ctx)
 	instanceSelector := cr.MatchLabels()
 
 	// Should never happen, sanity check

--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -297,7 +297,7 @@ var _ = Describe("GetMatchingInstances functions", Ordered, func() {
 
 	ctx := context.Background()
 	testLog := logf.FromContext(ctx).WithSink(logf.NullLogSink{})
-	logf.IntoContext(ctx, testLog)
+	ctx = logf.IntoContext(ctx, testLog)
 
 	// Pre-create all resources
 	BeforeAll(func() { // Necessary to use assertions

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -160,7 +160,7 @@ func getDashboardsToDelete(allDashboards *v1beta1.GrafanaDashboardList, grafanas
 
 func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaDashboardReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	// periodic sync reconcile
 	if req.Namespace == "" && req.Name == "" {

--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -23,8 +23,6 @@ import (
 	"syscall"
 	"testing"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,7 +148,6 @@ func TestGetDashboardEnvs(t *testing.T) {
 
 	reconciler := &GrafanaDashboardReconciler{
 		Client: k8sClient,
-		Log:    ctrl.Log.WithName("TestDashboardReconciler"),
 	}
 
 	envs, err := reconciler.getDashboardEnvs(ctx, &dashboard)

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -146,7 +146,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 
 func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaDatasourceReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	// periodic sync reconcile
 	if req.Namespace == "" && req.Name == "" {

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -7,13 +7,11 @@ import (
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestGetDatasourceContent(t *testing.T) {
 	reconciler := &GrafanaDatasourceReconciler{
 		Client: k8sClient,
-		Log:    ctrl.Log.WithName("TestDatasourceReconciler"),
 	}
 
 	t.Run("secureJsonData is preserved", func(t *testing.T) {

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -62,7 +62,7 @@ type GrafanaReconciler struct {
 
 func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	grafana := &grafanav1beta1.Grafana{}
 	err := r.Get(ctx, req.NamespacedName, grafana)

--- a/controllers/grafanaalertrulegroup_controller.go
+++ b/controllers/grafanaalertrulegroup_controller.go
@@ -60,7 +60,7 @@ type GrafanaAlertRuleGroupReconciler struct {
 
 func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaAlertRuleGroupReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	group := &grafanav1beta1.GrafanaAlertRuleGroup{}
 	err := r.Client.Get(ctx, client.ObjectKey{

--- a/controllers/grafanacontactpoint_controller.go
+++ b/controllers/grafanacontactpoint_controller.go
@@ -65,7 +65,7 @@ type GrafanaContactPointReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *GrafanaContactPointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaContactPointReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	contactPoint := &grafanav1beta1.GrafanaContactPoint{}
 	err := r.Client.Get(ctx, client.ObjectKey{

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -149,7 +149,7 @@ func (r *GrafanaFolderReconciler) syncFolders(ctx context.Context) (ctrl.Result,
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaFolderReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	// periodic sync reconcile
 	if req.Namespace == "" && req.Name == "" {

--- a/controllers/grafanamutetiming_controller.go
+++ b/controllers/grafanamutetiming_controller.go
@@ -53,7 +53,7 @@ type GrafanaMuteTimingReconciler struct {
 
 func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaMuteTimingReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	muteTiming := &grafanav1beta1.GrafanaMuteTiming{}
 	err := r.Client.Get(ctx, client.ObjectKey{

--- a/controllers/grafananotificationtemplate_controller.go
+++ b/controllers/grafananotificationtemplate_controller.go
@@ -52,7 +52,7 @@ type GrafanaNotificationTemplateReconciler struct {
 
 func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaNotificationTemplateReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	notificationTemplate := &grafanav1beta1.GrafanaNotificationTemplate{}
 	err := r.Client.Get(ctx, client.ObjectKey{

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -55,7 +55,7 @@ type GrafanaNotificationPolicyReconciler struct {
 
 func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithName("GrafanaNotificationPolicyReconciler")
-	logf.IntoContext(ctx, log)
+	ctx = logf.IntoContext(ctx, log)
 
 	notificationPolicy := &grafanav1beta1.GrafanaNotificationPolicy{}
 	err := r.Client.Get(ctx, client.ObjectKey{

--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers/reconcilers"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type CompleteReconciler struct{}
@@ -16,7 +16,8 @@ func NewCompleteReconciler() reconcilers.OperatorGrafanaReconciler {
 }
 
 func (r *CompleteReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
-	logger := log.FromContext(ctx).WithName("CompleteReconciler")
-	logger.Info("grafana installation complete")
+	log := logf.FromContext(ctx).WithName("CompleteReconciler")
+	log.Info("grafana installation complete")
+
 	return v1beta1.OperatorStageResultSuccess, nil
 }

--- a/controllers/reconcilers/grafana/config_reconciler.go
+++ b/controllers/reconcilers/grafana/config_reconciler.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type ConfigReconciler struct {
@@ -24,7 +24,7 @@ func NewConfigReconciler(client client.Client) reconcilers.OperatorGrafanaReconc
 }
 
 func (r *ConfigReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
-	_ = log.FromContext(ctx)
+	_ = logf.FromContext(ctx)
 
 	config, hash := config.WriteIni(cr.Spec.Config)
 	vars.ConfigHash = hash

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -45,10 +45,10 @@ func NewDeploymentReconciler(client client.Client, isOpenShift bool) reconcilers
 }
 
 func (r *DeploymentReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
-	logger := log.FromContext(ctx).WithName("DeploymentReconciler")
+	log := logf.FromContext(ctx).WithName("DeploymentReconciler")
 
 	openshiftPlatform := r.isOpenShift
-	logger.Info("reconciling deployment", "openshift", openshiftPlatform)
+	log.Info("reconciling deployment", "openshift", openshiftPlatform)
 
 	deployment := model.GetGrafanaDeployment(cr, scheme)
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, deployment, func() error {

--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type ServiceReconciler struct {
@@ -28,7 +28,7 @@ func NewServiceReconciler(client client.Client) reconcilers.OperatorGrafanaRecon
 }
 
 func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
-	_ = log.FromContext(ctx)
+	_ = logf.FromContext(ctx)
 
 	service := model.GetGrafanaService(cr, scheme)
 

--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -33,13 +33,13 @@ func NewIngressReconciler(client client.Client, isOpenShift bool) reconcilers.Op
 }
 
 func (r *IngressReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
-	logger := log.FromContext(ctx).WithName("IngressReconciler")
+	log := logf.FromContext(ctx).WithName("IngressReconciler")
 
 	if r.isOpenShift {
-		logger.Info("reconciling route", "platform", "openshift")
+		log.Info("reconciling route", "platform", "openshift")
 		return r.reconcileRoute(ctx, cr, status, vars, scheme)
 	} else {
-		logger.Info("reconciling ingress", "platform", "kubernetes")
+		log.Info("reconciling ingress", "platform", "kubernetes")
 		return r.reconcileIngress(ctx, cr, status, vars, scheme)
 	}
 }

--- a/controllers/reconcilers/grafana/plugins_reconciler.go
+++ b/controllers/reconcilers/grafana/plugins_reconciler.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type PluginsReconciler struct {
@@ -24,7 +24,7 @@ func NewPluginsReconciler(client client.Client) reconcilers.OperatorGrafanaRecon
 }
 
 func (r *PluginsReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
-	logger := log.FromContext(ctx).WithName("PluginsReconciler")
+	log := logf.FromContext(ctx).WithName("PluginsReconciler")
 
 	vars.Plugins = ""
 
@@ -34,7 +34,7 @@ func (r *PluginsReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 		return nil
 	})
 	if err != nil {
-		logger.Error(err, "error getting plugins config map", "name", plugins.Name, "namespace", plugins.Namespace)
+		log.Error(err, "error getting plugins config map", "name", plugins.Name, "namespace", plugins.Namespace)
 		return v1beta1.OperatorStageResultFailed, err
 	}
 
@@ -49,7 +49,7 @@ func (r *PluginsReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 		var dashboardPlugins v1beta1.PluginList
 		err = json.Unmarshal(plugins, &dashboardPlugins)
 		if err != nil {
-			logger.Error(err, "error consolidating plugins", "dashboard", dashboard)
+			log.Error(err, "error consolidating plugins", "dashboard", dashboard)
 			return v1beta1.OperatorStageResultFailed, err
 		}
 
@@ -64,12 +64,12 @@ func (r *PluginsReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 			// newer version of plugin already installed
 			hasNewer, err := consolidatedPlugins.HasNewerVersionOf(&plugin)
 			if err != nil {
-				logger.Error(err, "error checking existing plugins", "dashboard", dashboard)
+				log.Error(err, "error checking existing plugins", "dashboard", dashboard)
 				return v1beta1.OperatorStageResultFailed, err
 			}
 
 			if hasNewer {
-				logger.Info("skipping plugin", "dashboard", dashboard, "plugin",
+				log.Info("skipping plugin", "dashboard", dashboard, "plugin",
 					plugin.Name, "version", plugin.Version)
 				continue
 			}

--- a/controllers/reconcilers/grafana/pvc_reconciler.go
+++ b/controllers/reconcilers/grafana/pvc_reconciler.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type PvcReconciler struct {
@@ -23,10 +23,10 @@ func NewPvcReconciler(client client.Client) reconcilers.OperatorGrafanaReconcile
 }
 
 func (r *PvcReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
-	logger := log.FromContext(ctx).WithName("PvcReconciler")
+	log := logf.FromContext(ctx).WithName("PvcReconciler")
 
 	if cr.Spec.PersistentVolumeClaim == nil {
-		logger.Info("skip creating persistent volume claim")
+		log.Info("skip creating persistent volume claim")
 		return v1beta1.OperatorStageResultSuccess, nil
 	}
 


### PR DESCRIPTION
Was looking to implement an option for configuring `MaxConcurrentReconciles` when registering controllers.
But realised that the Reconciler structs seem to be shared across reconcile requests, meaning `r.Log` could be replaced with context values from a later reconcileRequest.
This is especially likely for `GrafanaContactPoints` due to the `Watches` in [`GrafanaNotificationPolicy`](https://github.com/grafana/grafana-operator/blob/0d53646ac1952e891d164a85a0d52d23836cdaf1/controllers/notificationpolicy_controller.go#L207-L223).

Kubebuilder suggests using the plain [`log := log.FromContext(ctx)`](https://book.kubebuilder.io/cronjob-tutorial/controller-implementation#implementing-a-controller)

Kubebuilder  recommends to always have the ctx as the first argument and I have ensured that is the case as much as possible: [kubebuilder controller-implementation](https://book.kubebuilder.io/cronjob-tutorial/controller-implementation#1-load-the-cronjob-by-name)