### PR TITLE
Fix: Apply error condition never registered due to early return

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -298,7 +298,7 @@ func buildSynchronizedCondition(resource string, syncType string, generation int
 		condition.Reason = conditionApplySuccessful
 		condition.Message = fmt.Sprintf("%s was successfully applied to %d instances", resource, total)
 	} else {
-		condition.Status = metav1.ConditionFalse
+		condition.Status = metav1.ConditionTrue
 		condition.Reason = conditionApplyFailed
 
 		var sb strings.Builder

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -270,12 +270,12 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		log.Error(err, "failed to apply plugins to all instances")
 	}
 
+	condition := buildSynchronizedCondition("Datasource", conditionDatasourceSynchronized, cr.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&cr.Status.Conditions, condition)
+
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
-
-	condition := buildSynchronizedCondition("Datasource", conditionDatasourceSynchronized, cr.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&cr.Status.Conditions, condition)
 
 	cr.Status.Hash = hash
 	cr.Status.LastMessage = "" // nolint:staticcheck

--- a/controllers/grafanaalertrulegroup_controller.go
+++ b/controllers/grafanaalertrulegroup_controller.go
@@ -135,12 +135,12 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
+	condition := buildSynchronizedCondition("Alert Rule Group", conditionAlertGroupSynchronized, group.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&group.Status.Conditions, condition)
+
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
-
-	condition := buildSynchronizedCondition("Alert Rule Group", conditionAlertGroupSynchronized, group.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&group.Status.Conditions, condition)
 
 	return ctrl.Result{RequeueAfter: group.Spec.ResyncPeriod.Duration}, nil
 }

--- a/controllers/grafanacontactpoint_controller.go
+++ b/controllers/grafanacontactpoint_controller.go
@@ -144,12 +144,12 @@ func (r *GrafanaContactPointReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 	}
 
+	condition := buildSynchronizedCondition("Contact point", conditionContactPointSynchronized, contactPoint.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&contactPoint.Status.Conditions, condition)
+
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
-
-	condition := buildSynchronizedCondition("Contact point", conditionContactPointSynchronized, contactPoint.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&contactPoint.Status.Conditions, condition)
 
 	return ctrl.Result{RequeueAfter: contactPoint.Spec.ResyncPeriod.Duration}, nil
 }

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -238,12 +238,12 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	condition := buildSynchronizedCondition("Folder", conditionFolderSynchronized, folder.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&folder.Status.Conditions, condition)
+
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
-
-	condition := buildSynchronizedCondition("Folder", conditionFolderSynchronized, folder.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&folder.Status.Conditions, condition)
 
 	return ctrl.Result{RequeueAfter: folder.Spec.ResyncPeriod.Duration}, nil
 }

--- a/controllers/grafanamutetiming_controller.go
+++ b/controllers/grafanamutetiming_controller.go
@@ -119,12 +119,14 @@ func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 		}
 	}
+
+	condition := buildSynchronizedCondition("Mute timing", conditionMuteTimingSynchronized, muteTiming.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&muteTiming.Status.Conditions, condition)
+
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
 
-	condition := buildSynchronizedCondition("Mute timing", conditionMuteTimingSynchronized, muteTiming.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&muteTiming.Status.Conditions, condition)
 	return ctrl.Result{RequeueAfter: muteTiming.Spec.ResyncPeriod.Duration}, nil
 }
 

--- a/controllers/grafananotificationtemplate_controller.go
+++ b/controllers/grafananotificationtemplate_controller.go
@@ -121,12 +121,14 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 		}
 	}
+
+	condition := buildSynchronizedCondition("Notification template", conditionNotificationTemplateSynchronized, notificationTemplate.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&notificationTemplate.Status.Conditions, condition)
+
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
 
-	condition := buildSynchronizedCondition("Notification template", conditionNotificationTemplateSynchronized, notificationTemplate.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&notificationTemplate.Status.Conditions, condition)
 	return ctrl.Result{RequeueAfter: notificationTemplate.Spec.ResyncPeriod.Duration}, nil
 }
 

--- a/tests/e2e/conditions/01-no-matching-instances-assertions.yaml
+++ b/tests/e2e/conditions/01-no-matching-instances-assertions.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationTemplate
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: EmptyAPIReply
+    status: "True"
+    type: NoMatchingInstance
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: EmptyAPIReply
+    status: "True"
+    type: NoMatchingInstance
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicy
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: EmptyAPIReply
+    status: "True"
+    type: NoMatchingInstance
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: EmptyAPIReply
+    status: "True"
+    type: NoMatchingInstance
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: EmptyAPIReply
+    status: "True"
+    type: NoMatchingInstance
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaMuteTiming
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: EmptyAPIReply
+    status: "True"
+    type: NoMatchingInstance
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: testdata
+status:
+  NoMatchingInstances: true
+# TODO Switch dashboard assert to conditions
+# status:
+#   conditions:
+#   - reason: EmptyAPIReply
+#     status: "True"
+#     type: NoMatchingInstance
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: testdata
+status:
+  uid: grafana-testdata
+status:
+  conditions:
+  - reason: EmptyAPIReply
+    status: "True"
+    type: NoMatchingInstance

--- a/tests/e2e/conditions/02-apply-failed-assertions.yaml
+++ b/tests/e2e/conditions/02-apply-failed-assertions.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationTemplate
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplyFailed
+    status: "True"
+    type: NotificationTemplateSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplyFailed
+    status: "True"
+    type: ContactPointSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicy
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplyFailed
+    status: "True"
+    type: NotificationPolicySynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplyFailed
+    status: "True"
+    type: FolderSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplyFailed
+    status: "True"
+    type: AlertGroupSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaMuteTiming
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplyFailed
+    status: "True"
+    type: MuteTimingSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: testdata
+status:
+  conditions:
+# TODO Status is never updated on failed apply
+#   - reason: ApplyFailed
+#     status: "True"
+#     type: DashboardSynchronized
+    - reason: ApplySuccessful
+      status: "True"
+      type: DashboardSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: testdata
+status:
+  uid: grafana-testdata
+status:
+  conditions:
+  - reason: ApplyFailed
+    status: "True"
+    type: DatasourceSynchronized

--- a/tests/e2e/conditions/03-additional-invalid-spec.yaml
+++ b/tests/e2e/conditions/03-additional-invalid-spec.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicy
+metadata:
+  name: additional-testdata-policy
+spec:
+  instanceSelector:
+    matchLabels:
+      test: ($test.metadata.name)
+  resyncPeriod: 3s
+  route:
+    receiver: testdata
+    group_by:
+      - grafana_folder
+      - alertname
+    routes:
+      - receiver: grafana-default-email
+        object_matchers:
+          - - type
+            - =
+            - static
+        routes:
+          - receiver: grafana-default-email
+            object_matchers:
+              - - type
+                - =
+                - static_child
+        routeSelector:
+          matchLabels:
+            dynamic: "child"

--- a/tests/e2e/conditions/03-invalid-spec-assertions.yaml
+++ b/tests/e2e/conditions/03-invalid-spec-assertions.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: testdata
+status:
+  conditions:
+    - reason: CyclicParent
+      status: "True"
+      type: InvalidSpec
+---
+# Reference non-existing secret
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: testdata
+status:
+  conditions:
+    - reason: InvalidSettings
+      status: "True"
+      type: InvalidSpec
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicy
+metadata:
+  name: testdata
+status:
+  conditions:
+    - reason: LoopDetected
+      status: "True"
+      type: NotificationPolicyLoopDetected
+---
+# Stays valid
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  name: team-b
+status: {}
+---
+# Has a loop breaking the above policy, unchanged
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  name: team-c
+status: {}
+---
+# Has both routes and routeSelector
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicy
+metadata:
+  name: additional-testdata-policy
+status:
+  conditions:
+    - reason: FieldsMutuallyExclusive
+      status: "True"
+      type: InvalidSpec
+---
+# TODO GrafanaDashboard when InvalidSpec is implemented for dashboards with an invalid model
+---
+# Reference non-existing secret
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: testdata
+status:
+  conditions:
+    - reason: InvalidModel
+      status: "True"
+      type: InvalidSpec
+# ---
+# TODO Grafana when InvalidSpec is implemented for external Grafana admin secret
+# Reference non-existing secret

--- a/tests/e2e/conditions/03-testdata-invalid-specs.yaml
+++ b/tests/e2e/conditions/03-testdata-invalid-specs.yaml
@@ -1,0 +1,51 @@
+---
+# Make folder reference itself as parent
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: testdata
+spec:
+  parentFolderUID: testdata-uid
+---
+# Reference non-existing secret
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: testdata
+spec:
+  # Override settings
+  settings: {}
+  valuesFrom:
+    - targetPath: addresses
+      valueFrom:
+        secretKeyRef:
+          name: contact-mails
+          key: alert-mails
+---
+# Introduce a loop and trigger loop detected
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  name: team-c
+spec:
+  routeSelector:
+    matchLabels:
+      team-b: "child"
+---
+# TODO GrafanaDashboard when InvalidSpec is triggered on invalid dashboard model
+---
+# Reference non-existing secret
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: testdata
+spec:
+  valuesFrom:
+    - targetPath: secureJsonData.httpHeaderValue1
+      valueFrom:
+        secretKeyRef:
+          name: credentials
+          key: "PROMETHEUS_TOKEN"
+
+# TODO Grafana when InvalidSpec is implemented for external Grafana admin secret
+# Reference non-existing secret

--- a/tests/e2e/conditions/chainsaw-test.yaml
+++ b/tests/e2e/conditions/chainsaw-test.yaml
@@ -1,0 +1,112 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: validate-conditions
+spec:
+  bindings:
+    - name: USER
+      value: root
+    - name: PASS
+      value: secret
+  steps:
+    # Normal everything works
+    - name: Create Grafana instance with testdata resources
+      try:
+        - apply:
+            file: ../testdata-resources.yaml
+
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                (contains(name, 'testdata-deployment')): true
+
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            timeout: 1m
+            for:
+              condition:
+                name: Ready
+                value: 'true'
+
+        - assert:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: Grafana
+              metadata:
+                name: testdata
+              status:
+                stage: complete
+                stageStatus: success
+
+        - assert:
+            file: "../testdata-assertions.yaml"
+
+    # reason: NoMatchingInstances
+    - name: Alter Grafana instance label
+      try:
+        - patch:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: Grafana
+              metadata:
+                name: testdata
+                labels:
+                  test: MatchNothing
+
+        - assert:
+            file: "./01-no-matching-instances-assertions.yaml"
+
+    - name: Revert Grafana instance to default
+      try: &RevertResources
+        - apply:
+            file: "../testdata-resources.yaml"
+
+        - assert:
+            file: "../testdata-assertions.yaml"
+
+    # reason: ApplyFailed
+    - name: Scale Grafana deployment to zero
+      try:
+        - patch:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: Grafana
+              metadata:
+                name: testdata
+              spec:
+                deployment:
+                  spec:
+                    replicas: 0
+
+        - assert:
+            file: "./02-apply-failed-assertions.yaml"
+
+        - patch:
+            resource:
+              apiVersion: grafana.integreatly.org/v1beta1
+              kind: Grafana
+              metadata:
+                name: testdata
+              spec:
+                deployment:
+                  spec:
+                    replicas: 1
+
+    - name: Revert Grafana instance to default
+      try: *RevertResources
+
+    # reason: InvalidSpec
+    - name: Invalidate resource specs
+      try:
+        - patch:
+            file: "./03-testdata-invalid-specs.yaml"
+
+        - apply:
+            file: "./03-additional-invalid-spec.yaml"
+
+        - assert:
+            file: "./03-invalid-spec-assertions.yaml"

--- a/tests/e2e/force_delete_folder/chainsaw-test.yaml
+++ b/tests/e2e/force_delete_folder/chainsaw-test.yaml
@@ -4,7 +4,6 @@ kind: Test
 metadata:
   name: force-delete-folders
 spec:
-  concurrent: false
   bindings:
     - name: USER
       value: root

--- a/tests/e2e/testdata-assertions.yaml
+++ b/tests/e2e/testdata-assertions.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationTemplate
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: NotificationTemplateSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: ContactPointSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicy
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: NotificationPolicySynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  name: team-b
+status: {}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  name: team-c
+status: {}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: FolderSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: AlertGroupSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaMuteTiming
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: MuteTimingSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: DashboardSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: testdata
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: DatasourceSynchronized

--- a/tests/e2e/testdata-resources.yaml
+++ b/tests/e2e/testdata-resources.yaml
@@ -1,18 +1,112 @@
+---
 apiVersion: grafana.integreatly.org/v1beta1
-kind: Grafana
+kind: GrafanaNotificationTemplate
 metadata:
   name: testdata
-  labels:
-    test: ($test.metadata.name)
 spec:
-  config:
-    log:
-      mode: "console"
-    auth:
-      disable_login_form: "false"
-    security:
-      admin_user: ($USER)
-      admin_password: ($PASS)
+  name: emailtestdata
+  instanceSelector:
+    matchLabels:
+      test: ($test.metadata.name)
+  resyncPeriod: 3s
+  template: |
+    {{ define "emailAlert" }}
+      [{{.Status}}] {{ .Labels.alertname }}
+      {{ .Annotations.AlertValues }}
+    {{ end }}
+
+    {{ define "emailAlertMessage" }}
+      {{ if gt (len .Alerts.Firing) 0 }}
+        {{ len .Alerts.Firing }} firing:
+        {{ range .Alerts.Firing }} {{ template "emailAlert" . }} {{ end }}
+      {{ end }}
+      {{ if gt (len .Alerts.Resolved) 0 }}
+        {{ len .Alerts.Resolved }} resolved:
+        {{ range .Alerts.Resolved }} {{ template "emailAlert" . }} {{ end }}
+      {{ end }}
+    {{ end }}
+
+    {{ template "emailAlertMessage" . }}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: testdata
+spec:
+  name: testdata
+  type: email
+  instanceSelector:
+    matchLabels:
+      test: ($test.metadata.name)
+  resyncPeriod: 3s
+  settings:
+    addresses: "void@testdata.invalid"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicy
+metadata:
+  name: testdata
+spec:
+  instanceSelector:
+    matchLabels:
+      test: ($test.metadata.name)
+  resyncPeriod: 3s
+  route:
+    receiver: testdata
+    group_by:
+      - grafana_folder
+      - alertname
+    routes:
+      - receiver: grafana-default-email
+        object_matchers:
+          - - team
+            - =
+            - a
+        routeSelector:
+          matchLabels:
+            team-a: "child"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  labels:
+    team-a: "child"
+  name: team-b
+spec:
+  receiver: grafana-default-email
+  object_matchers:
+    - - team
+      - =
+      - b
+  routeSelector:
+    matchLabels:
+      team-b: "child"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  labels:
+    team-b: "child"
+  name: team-c
+spec:
+  receiver: grafana-default-email
+  object_matchers:
+    - - team
+      - =
+      - c
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  labels:
+    team-a: "child"
+  name: team-d
+spec:
+  receiver: grafana-default-email
+  object_matchers:
+    - - team
+      - =
+      - d
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
@@ -43,6 +137,26 @@ spec:
     type: grafana-testdata-datasource
     access: proxy
     basicAuth: false
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaMuteTiming
+metadata:
+  name: testdata
+spec:
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "($test.metadata.name)"
+  name: testdata
+  editable: false
+  time_intervals:
+    - times:
+        - start_time: "20:00"
+          end_time: "23:59"
+        - start_time: "00:00"
+          end_time: "06:00"
+      weekdays: [saturday, sunday]
+      location: Europe/Amsterdam
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaAlertRuleGroup
@@ -349,3 +463,20 @@ spec:
       "version": 0,
       "weekStart": ""
     }
+---
+# Last to be cleaned up first
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: testdata
+  labels:
+    test: ($test.metadata.name)
+spec:
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: ($USER)
+      admin_password: ($PASS)

--- a/tests/example-resources.yaml
+++ b/tests/example-resources.yaml
@@ -65,18 +65,54 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaNotificationPolicy
 metadata:
   name: testdata
-  labels:
-    test: "testdata"
 spec:
   instanceSelector:
     matchLabels:
       test: "testdata"
   resyncPeriod: 3s
   route:
-    receiver: testdata
+    receiver: grafana-default-email
     group_by:
       - grafana_folder
       - alertname
+    routes:
+      - receiver: grafana-default-email
+        object_matchers:
+          - - team
+            - =
+            - a
+        routeSelector:
+          matchLabels:
+            team-a: "child"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  labels:
+    team-a: "child"
+  name: team-b
+spec:
+  receiver: grafana-default-email
+  object_matchers:
+    - - team
+      - =
+      - b
+  routeSelector:
+    matchLabels:
+      team-b: "child"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaNotificationPolicyRoute
+metadata:
+  labels:
+    team-b: "child"
+  name: team-c
+spec:
+  receiver: grafana-default-email
+  object_matchers:
+    - - team
+      - =
+      - c
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
@@ -212,6 +248,26 @@ spec:
       annotations: {}
       labels: {}
       isPaused: false
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaMuteTiming
+metadata:
+  name: testdata
+spec:
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "testdata"
+  name: testdata
+  editable: false
+  time_intervals:
+    - times:
+        - start_time: "20:00"
+          end_time: "23:59"
+        - start_time: "00:00"
+          end_time: "06:00"
+      weekdays: [saturday, sunday]
+      location: Europe/Amsterdam
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard


### PR DESCRIPTION
I forgot that the `buildSynchronizedCondition` function applies either a successful or a failed condition depending on whether errors where present.
This was noticed by @msvechla in #1800

To ensure something like this never happens again, tests have been added to provoke and test every condition currently implemented.

Future PRs will include conditions and tests for `GrafanaDashboards` and potentially `Grafanas`.
Any future CR or condition implementation should probably expand these tests to ensure that the conditions can be provoked appropriately.