### PR TITLE
feat: add headlessService for grafana high availability

### DIFF
--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -22,6 +22,8 @@ const (
 	GrafanaHttpPort       int = 3000
 	GrafanaHttpPortName       = "grafana"
 	GrafanaServerProtocol     = "http"
+	GrafanaAlertPort      int = 9094
+	GrafanaAlertPortName      = "grafana-alert"
 
 	// Data storage
 	GrafanaProvisionPluginVolumeName    = "grafana-provision-plugins"

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -81,6 +81,18 @@ func GetGrafanaService(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v1.S
 	return service
 }
 
+func GetGrafanaHeadlessService(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v1.Service {
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-alerting", cr.Name),
+			Namespace: cr.Namespace,
+			Labels:    CommonLabels,
+		},
+	}
+	controllerutil.SetControllerReference(cr, service, scheme) //nolint:errcheck
+	return service
+}
+
 func GetGrafanaIngress(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v12.Ingress {
 	ingress := &v12.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -54,6 +54,24 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 			int32(GetGrafanaPort(cr))) // #nosec G115
 	}
 
+	// Headless service for grafana unified alerting
+	headlessService := model.GetGrafanaHeadlessService(cr, scheme)
+	_, err = controllerutil.CreateOrUpdate(ctx, r.client, headlessService, func() error {
+		model.SetCommonLabels(service)
+		service.Spec = v1.ServiceSpec{
+			ClusterIP: "None",
+			Ports:     getHeadlessServicePorts(cr),
+			Selector: map[string]string{
+				"app": cr.Name,
+			},
+			Type: v1.ServiceTypeClusterIP,
+		}
+		return nil
+	})
+	if err != nil {
+		return v1beta1.OperatorStageResultFailed, err
+	}
+
 	return v1beta1.OperatorStageResultSuccess, nil
 }
 
@@ -90,6 +108,21 @@ func getServicePorts(cr *v1beta1.Grafana) []v1.ServicePort {
 			Protocol:   "TCP",
 			Port:       intPort,
 			TargetPort: intstr.FromString("grafana-http"),
+		},
+	}
+
+	return defaultPorts
+}
+
+func getHeadlessServicePorts(_ *v1beta1.Grafana) []v1.ServicePort {
+	intPort := int32(config.GrafanaAlertPort)
+
+	defaultPorts := []v1.ServicePort{
+		{
+			Name:       config.GrafanaAlertPortName,
+			Protocol:   "TCP",
+			Port:       intPort,
+			TargetPort: intstr.FromInt32(intPort),
 		},
 	}
 

--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -57,8 +57,8 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 	// Headless service for grafana unified alerting
 	headlessService := model.GetGrafanaHeadlessService(cr, scheme)
 	_, err = controllerutil.CreateOrUpdate(ctx, r.client, headlessService, func() error {
-		model.SetCommonLabels(service)
-		service.Spec = v1.ServiceSpec{
+		model.SetCommonLabels(headlessService)
+		headlessService.Spec = v1.ServiceSpec{
 			ClusterIP: "None",
 			Ports:     getHeadlessServicePorts(cr),
 			Selector: map[string]string{

--- a/examples/multiple_replicas/resources.yaml
+++ b/examples/multiple_replicas/resources.yaml
@@ -85,3 +85,12 @@ spec:
       name: "grafana"
       user: "grafana"
       password: "grafana"
+    # Configure HA for Grafana alerting
+    # https://grafana.com/docs/grafana/latest/alerting/set-up/configure-high-availability/
+    unified_alerting:
+      enabled: true
+      ha_listen_address: "${POD_IP}:9094"
+      ha_peers: "grafana-alerting:9094"
+      ha_advertise_address: "${POD_IP}:9094"
+      ha_peer_timeout: 15s
+      ha_reconnect_timeout: 2m

--- a/tests/e2e/examples/basic/assertions.yaml
+++ b/tests/e2e/examples/basic/assertions.yaml
@@ -19,6 +19,16 @@ metadata:
 spec: {}
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-alerting
+  ownerReferences:
+  - apiVersion: grafana.integreatly.org/v1beta1
+    kind: Grafana
+    name: grafana
+spec: {}
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-ini

--- a/tests/e2e/examples/crossnamespace/assertions.yaml
+++ b/tests/e2e/examples/crossnamespace/assertions.yaml
@@ -19,6 +19,16 @@ metadata:
 spec: {}
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-alerting
+  ownerReferences:
+  - apiVersion: grafana.integreatly.org/v1beta1
+    kind: Grafana
+    name: grafana
+spec: {}
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-ini


### PR DESCRIPTION
This PR implements the steps described in the [Grafana documentation](https://grafana.com/docs/grafana/latest/alerting/set-up/configure-high-availability/) to configure a HA grafana:
- Headless Service
- Expose port 9094 on the deployment
- `POD_IP` environment variable from downward API

While most of it can already be added manually with overrides in the CR, the headless service has to be manually created. I think that providing all the key components to run a HA Grafana makes sense.

The "Multiple replicas" doc example has also been updated to include a config snippet for HA setup.