### PR TITLE
chore: add catalog info for the grafana developer catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,21 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana-operator
+  title: grafana-operator
+  description: |
+    An operator for Grafana that installs and manages Grafana instances, Dashboards and Datasources through Kubernetes/OpenShift CRs
+  links:
+    - title: Internal Slack Channel
+      url: https://raintank-corp.slack.com/archives/C06K5TJ469W
+    - title: Community Slack Channel
+      url: https://grafana.slack.com/archives/C0692KN29K3
+    - title: Kubernetes Slack Channel
+      url: https://kubernetes.slack.com/archives/C019A1KTYKC
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: grafana/grafana-operator
+spec:
+  type: tool
+  owner: group:default/devex
+  lifecycle: production


### PR DESCRIPTION
Required for our internal developer catalog at Grafana Labs.