### PR TITLE
patch: add support for amazon sns contactpoint

### DIFF
--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -47,7 +47,7 @@ type GrafanaContactPointSpec struct {
 	// +kubebuilder:validation:MaxItems=99
 	ValuesFrom []ValueFrom `json:"valuesFrom,omitempty"`
 
-	// +kubebuilder:validation:Enum=alertmanager;prometheus-alertmanager;dingding;discord;email;googlechat;kafka;line;opsgenie;pagerduty;pushover;sensugo;sensu;slack;teams;telegram;threema;victorops;webex;webhook;wecom;hipchat;oncall
+	// +kubebuilder:validation:Enum=alertmanager;prometheus-alertmanager;dingding;discord;email;googlechat;kafka;line;opsgenie;pagerduty;pushover;sensugo;sensu;slack;sns;teams;telegram;threema;victorops;webex;webhook;wecom;hipchat;oncall
 	Type string `json:"type,omitempty"`
 }
 

--- a/bundle/manifests/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -118,6 +118,7 @@ spec:
                 - sensugo
                 - sensu
                 - slack
+                - sns
                 - teams
                 - telegram
                 - threema

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -133,6 +133,7 @@ spec:
                 - sensugo
                 - sensu
                 - slack
+                - sns
                 - teams
                 - telegram
                 - threema

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -133,6 +133,7 @@ spec:
                 - sensugo
                 - sensu
                 - slack
+                - sns
                 - teams
                 - telegram
                 - threema

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -468,6 +468,7 @@ spec:
                 - sensugo
                 - sensu
                 - slack
+                - sns
                 - teams
                 - telegram
                 - threema

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -765,7 +765,7 @@ GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
         <td>
           <br/>
           <br/>
-            <i>Enum</i>: alertmanager, prometheus-alertmanager, dingding, discord, email, googlechat, kafka, line, opsgenie, pagerduty, pushover, sensugo, sensu, slack, teams, telegram, threema, victorops, webex, webhook, wecom, hipchat, oncall<br/>
+            <i>Enum</i>: alertmanager, prometheus-alertmanager, dingding, discord, email, googlechat, kafka, line, opsgenie, pagerduty, pushover, sensugo, sensu, slack, sns, teams, telegram, threema, victorops, webex, webhook, wecom, hipchat, oncall<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
### Expected behavior
Currently there's no support for Amazon SNS contactpoint even tough it's available on grafana:
https://grafana.com/docs/grafana/v11.3/alerting/configure-notifications/manage-contact-points/integrations/configure-amazon-sns/
If you try to configure it, you get the following error:
```
GrafanaContactPoint.grafana.integreatly.org "sns" is invalid: [spec.type: Unsupported value: "sns": supported values: "alertmanager", "prometheus-alertmanager", "dingding", "discord", "email", "googlechat", "kafka", "line", "opsgenie", "pagerduty", "pushover", "sensugo", "sensu", "slack", "teams", "telegram", "threema", "victorops", "webex", "webhook", "wecom", "hipchat", "oncall",
```

### Changes
Modified enums adding sns as an option
