### PR TITLE
fix: folder title had to be unique

### DIFF
--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -420,6 +420,11 @@ func (r *GrafanaFolderReconciler) Exists(client *genapi.GrafanaHTTPAPI, cr *graf
 		return true, uidResp.Payload.UID, uidResp.Payload.ParentUID, nil
 	}
 
+	// If we could not find the UID in the Grafana but a CustomUID is set in the CR we must assume the folder does not exist.
+	if cr.Spec.CustomUID != "" {
+		return false, uid, "", nil
+	}
+
 	page := int64(1)
 	limit := int64(10000)
 	for {


### PR DESCRIPTION
Grafana folders with the same name caused conflicts. This fix allows multiple folders with the same name to exist in a filetree. 

Fixes:  #1847 