### PR TITLE
Fix: Finalize only deletes datasource from the first instance

### DIFF
--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -319,7 +319,10 @@ func (r *GrafanaDatasourceReconciler) deleteOldDatasource(ctx context.Context, c
 		}
 
 		grafana.Status.Datasources = grafana.Status.Datasources.Remove(cr.Namespace, cr.Name)
-		return r.Client.Status().Update(ctx, &grafana)
+		err = r.Client.Status().Update(ctx, &grafana)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -357,12 +360,15 @@ func (r *GrafanaDatasourceReconciler) finalize(ctx context.Context, cr *v1beta1.
 		if grafana.IsInternal() {
 			err = ReconcilePlugins(ctx, r.Client, r.Scheme, &grafana, nil, fmt.Sprintf("%v-datasource", cr.Name))
 			if err != nil {
-				return err
+				return fmt.Errorf("reconciling plugins: %w", err)
 			}
 		}
 
 		grafana.Status.Datasources = grafana.Status.Datasources.Remove(cr.Namespace, cr.Name)
-		return r.Client.Status().Update(ctx, &grafana)
+		err = r.Client.Status().Update(ctx, &grafana)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I noticed that the datasource `onDatasourceDelete` function, that I recently split into a finalize, had an unconditional return at the end of the delete loop.

This means that on the first successful delete of a datasource, the for loop would [return](https://github.com/grafana/grafana-operator/blob/ff3fb07b25ca8ddd171e7a9af297891613c1cdad/controllers/datasource_controller.go#L310) and no other data source would be removed from other instances.

Luckily, this means that no other `Grafana` CRs status was updated.
All other `Grafanas` still have it listed in the status, a restart of the operator will force a datasource sync and delete them from the instances.

This seems to be a two year old bug 😅 

Try applying the below resources to replicate that bug, then delete the datasource and see that it's still present on one of the instances.

```yaml
# Two grafana instances both getting the same datasource
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
metadata:
  name: grafana-testdata
  labels:
    test: "testdata"
spec:
  config:
    log:
      mode: "console"
    auth:
      disable_login_form: "false"
    security:
      admin_user: root
      admin_password: secret
---
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
metadata:
  name: grafana-testdata2
  labels:
    test: "testdata"
spec:
  config:
    log:
      mode: "console"
    auth:
      disable_login_form: "false"
    security:
      admin_user: root
      admin_password: secret
---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaDatasource
metadata:
  name: testdata
spec:
  resyncPeriod: 3s
  instanceSelector:
    matchLabels:
      test: "testdata"
  uid: testdata-datasource
  datasource:
    orgId: 1
    isDefault: true
    name: grafana-testdata-datasource
    type: grafana-testdata-datasource
    access: proxy
    basicAuth: false
```