### PR TITLE
Refactor dashboard reconcile loop

### DIFF
--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -126,10 +126,6 @@ func (in *GrafanaDashboard) GrafanaContentStatus() *GrafanaContentStatus {
 
 var _ GrafanaContentResource = &GrafanaDashboard{}
 
-func (in *GrafanaDashboard) IsAllowCrossNamespaceImport() bool {
-	return in.Spec.AllowCrossNamespaceImport
-}
-
 func (in *GrafanaDashboardList) Find(namespace string, name string) *GrafanaDashboard {
 	for _, dashboard := range in.Items {
 		if dashboard.Namespace == namespace && dashboard.Name == name {
@@ -137,6 +133,18 @@ func (in *GrafanaDashboardList) Find(namespace string, name string) *GrafanaDash
 		}
 	}
 	return nil
+}
+
+func (in *GrafanaDashboard) MatchLabels() *metav1.LabelSelector {
+	return in.Spec.InstanceSelector
+}
+
+func (in *GrafanaDashboard) MatchNamespace() string {
+	return in.ObjectMeta.Namespace
+}
+
+func (in *GrafanaDashboard) AllowCrossNamespace() bool {
+	return in.Spec.AllowCrossNamespaceImport
 }
 
 func init() {

--- a/controllers/content/fetchers/jsonnet_fetcher.go
+++ b/controllers/content/fetchers/jsonnet_fetcher.go
@@ -384,11 +384,6 @@ func unwrapSingleSubdirectory(dirPath string) error {
 	}
 
 	subDirPath := filepath.Join(dirPath, subDirEntry.Name())
-	if err != nil {
-		fmt.Println("Smth goes wrong")
-		return err
-	}
-
 	err = copyDir(subDirPath, dirPath)
 	if err != nil {
 		fmt.Println("Error copying dir", err)

--- a/controllers/content/resolver.go
+++ b/controllers/content/resolver.go
@@ -74,13 +74,7 @@ func WithDisabledSources(disabledSources []ContentSourceType) Option {
 	}
 }
 
-func NewContentResolver(cr v1beta1.GrafanaContentResource, client client.Client, opts ...Option) (*ContentResolver, error) {
-	// Perform these error checks once in initialization; we assume in the function calls
-	// that the spec and status will be non-nil as a result.
-	if cr.GrafanaContentSpec() == nil || cr.GrafanaContentStatus() == nil {
-		return nil, fmt.Errorf("resource does not properly implement content spec or status fields; this indicates a bug in implementation")
-	}
-
+func NewContentResolver(cr v1beta1.GrafanaContentResource, client client.Client, opts ...Option) *ContentResolver {
 	resolver := &ContentResolver{
 		Client:   client,
 		resource: cr,
@@ -90,7 +84,7 @@ func NewContentResolver(cr v1beta1.GrafanaContentResource, client client.Client,
 		opt(resolver)
 	}
 
-	return resolver, nil
+	return resolver
 }
 
 func (h *ContentResolver) Resolve(ctx context.Context) (map[string]interface{}, string, error) {

--- a/controllers/content/resolver_test.go
+++ b/controllers/content/resolver_test.go
@@ -36,6 +36,10 @@ func TestGetDashboardEnvs(t *testing.T) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
 	defer stop()
 
+	var contentResource v1beta1.GrafanaContentResource = &dashboard
+	assert.NotNil(t, contentResource.GrafanaContentSpec(), "resource does not properly implement content spec or status fields; this indicates a bug in implementation")
+	assert.NotNil(t, contentResource.GrafanaContentStatus(), "resource does not properly implement content spec or status fields; this indicates a bug in implementation")
+
 	resolver := NewContentResolver(&dashboard, k8sClient)
 
 	envs, err := resolver.getContentEnvs(ctx)

--- a/controllers/content/resolver_test.go
+++ b/controllers/content/resolver_test.go
@@ -36,8 +36,7 @@ func TestGetDashboardEnvs(t *testing.T) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
 	defer stop()
 
-	resolver, err := NewContentResolver(&dashboard, k8sClient)
-	assert.NoError(t, err)
+	resolver := NewContentResolver(&dashboard, k8sClient)
 
 	envs, err := resolver.getContentEnvs(ctx)
 

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -48,31 +48,6 @@ const (
 
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
-// Gets all instances matching labelSelector
-func GetMatchingInstances(ctx context.Context, k8sClient client.Client, labelSelector *metav1.LabelSelector) (v1beta1.GrafanaList, error) {
-	// Should never happen, sanity check
-	if labelSelector == nil {
-		return v1beta1.GrafanaList{}, nil
-	}
-
-	var list v1beta1.GrafanaList
-	opts := []client.ListOption{
-		client.MatchingLabels(labelSelector.MatchLabels),
-	}
-	err := k8sClient.List(ctx, &list, opts...)
-
-	var selectedList v1beta1.GrafanaList
-
-	for _, instance := range list.Items {
-		selected := labelsSatisfyMatchExpressions(instance.Labels, labelSelector.MatchExpressions)
-		if selected {
-			selectedList.Items = append(selectedList.Items, instance)
-		}
-	}
-
-	return selectedList, err
-}
-
 // Only matching instances in the scope of the resource are returned
 // Resources with allowCrossNamespaceImport expands the scope to the entire cluster
 // Intended to be used in reconciler functions

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -161,6 +161,7 @@ func labelsSatisfyMatchExpressions(labels map[string]string, matchExpressions []
 	return true
 }
 
+// TODO Refactor to use scheme from k8sClient.Scheme() as it's the same anyways
 func ReconcilePlugins(ctx context.Context, k8sClient client.Client, scheme *runtime.Scheme, grafana *v1beta1.Grafana, plugins v1beta1.PluginList, resource string) error {
 	pluginsConfigMap := model.GetPluginsConfigMap(grafana, scheme)
 	selector := client.ObjectKey{

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -56,8 +55,7 @@ const (
 // GrafanaDashboardReconciler reconciles a GrafanaDashboard object
 type GrafanaDashboardReconciler struct {
 	client.Client
-	Scheme    *runtime.Scheme
-	Discovery discovery.DiscoveryInterface
+	Scheme *runtime.Scheme
 }
 
 //+kubebuilder:rbac:groups=grafana.integreatly.org,resources=grafanadashboards,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -264,7 +264,6 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// TODO Add new Condition displaing plugin reconciliation errors
-	// Specific to datasources
 	if len(pluginErrors) > 0 {
 		err := fmt.Errorf("%v", pluginErrors)
 		log.Error(err, "failed to apply plugins to all instances")

--- a/tests/e2e/conditions/01-no-matching-instances-assertions.yaml
+++ b/tests/e2e/conditions/01-no-matching-instances-assertions.yaml
@@ -65,12 +65,11 @@ metadata:
   name: testdata
 status:
   NoMatchingInstances: true
-# TODO Switch dashboard assert to conditions
-# status:
-#   conditions:
-#   - reason: EmptyAPIReply
-#     status: "True"
-#     type: NoMatchingInstance
+status:
+  conditions:
+  - reason: EmptyAPIReply
+    status: "True"
+    type: NoMatchingInstance
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource

--- a/tests/e2e/conditions/02-apply-failed-assertions.yaml
+++ b/tests/e2e/conditions/02-apply-failed-assertions.yaml
@@ -65,11 +65,7 @@ metadata:
   name: testdata
 status:
   conditions:
-# TODO Status is never updated on failed apply
-#   - reason: ApplyFailed
-#     status: "True"
-#     type: DashboardSynchronized
-    - reason: ApplySuccessful
+    - reason: ApplyFailed
       status: "True"
       type: DashboardSynchronized
 ---

--- a/tests/e2e/conditions/03-additional-invalid-spec.yaml
+++ b/tests/e2e/conditions/03-additional-invalid-spec.yaml
@@ -28,3 +28,13 @@ spec:
         routeSelector:
           matchLabels:
             dynamic: "child"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: no-resolvable-model
+spec:
+  resyncPeriod: 3s
+  instanceSelector:
+    matchLabels:
+      test: "($test.metadata.name)"

--- a/tests/e2e/conditions/03-invalid-spec-assertions.yaml
+++ b/tests/e2e/conditions/03-invalid-spec-assertions.yaml
@@ -55,7 +55,16 @@ status:
       status: "True"
       type: InvalidSpec
 ---
-# TODO GrafanaDashboard when InvalidSpec is implemented for dashboards with an invalid model
+# Model is not valid JSON or any other resolution error
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: testdata
+status:
+  conditions:
+    - reason: InvalidModelResolution
+      status: "True"
+      type: InvalidSpec
 ---
 # Reference non-existing secret
 apiVersion: grafana.integreatly.org/v1beta1

--- a/tests/e2e/conditions/03-testdata-invalid-specs.yaml
+++ b/tests/e2e/conditions/03-testdata-invalid-specs.yaml
@@ -32,7 +32,13 @@ spec:
     matchLabels:
       team-b: "child"
 ---
-# TODO GrafanaDashboard when InvalidSpec is triggered on invalid dashboard model
+# Model is not valid JSON
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: testdata
+spec:
+  json: "{"
 ---
 # Reference non-existing secret
 apiVersion: grafana.integreatly.org/v1beta1

--- a/tests/e2e/testdata-resources.yaml
+++ b/tests/e2e/testdata-resources.yaml
@@ -52,7 +52,7 @@ spec:
       test: ($test.metadata.name)
   resyncPeriod: 3s
   route:
-    receiver: testdata
+    receiver: grafana-default-email
     group_by:
       - grafana_folder
       - alertname


### PR DESCRIPTION
Similar to the Datasource reconciler, this was another big refactor.

When I was adding models I had a look over the [NewContentResolver](https://github.com/grafana/grafana-operator/pull/1868/files#diff-5723394742dbfbf05333333388ae1b0de1f9f47650f514bfba6b5d91ace771aa) func.
From what I can tell, the error check and return is unnecessary as [structs don't have a zero value](https://go.dev/ref/spec#The_zero_value) and the `GrafanaContentResource` struct is not embedded as a pointer.

Closes: #1021 #1164 #1679 #1850

PS. @theSuess I did not forget about validating all pre-conditions before updating the status.
But I decided to wait and have a look at that in a different PR.