### PR TITLE
feat: enable setting labels just for pods

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -84,6 +84,7 @@ It's easier to just manage this configuration outside of the operator.
 | namespaceScope | bool | `false` | If the operator should run in namespace-scope or not, if true the operator will only be able to manage instances in the same namespace |
 | nodeSelector | object | `{}` | pod node selector |
 | podAnnotations | object | `{}` | pod annotations |
+| podLabels | object | `{}` | pod labels |
 | podSecurityContext | object | `{}` | pod security context |
 | priorityClassName | string | `""` | pod priority class name |
 | rbac.create | bool | `true` | Specifies whether to create the ClusterRole and ClusterRoleBinding. If "namespaceScope" is true or "watchNamespaces" is set, this will create Role and RoleBinding instead. |

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       labels:
         {{- include "grafana-operator.labels" . | nindent 8 }}
         app.kubernetes.io/component: operator
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -88,6 +88,9 @@ metricsService:
 # -- additional labels to add to all resources
 additionalLabels: {}
 
+# -- pod labels
+podLabels: {}
+
 # -- pod annotations
 podAnnotations: {}
 


### PR DESCRIPTION
the 'additionalLabels' setting is a bit too coarse-grained especially if you want to utilize e.g. istio sidecar injection, which is only valid for pods.