### PR TITLE
don't treat missing datasource as an error when deleting datasource

### DIFF
--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -114,7 +114,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 			instanceDatasource, err := grafanaClient.Datasources.GetDataSourceByUID(uid)
 			if err != nil {
 				var notFound *datasources.GetDataSourceByUIDNotFound
-				if errors.As(err, &notFound) {
+				if !errors.As(err, &notFound) {
 					return ctrl.Result{}, err
 				}
 				log.Info("datasource no longer exists", "namespace", namespace, "name", name)
@@ -122,7 +122,7 @@ func (r *GrafanaDatasourceReconciler) syncDatasources(ctx context.Context) (ctrl
 				_, err = grafanaClient.Datasources.DeleteDataSourceByUID(instanceDatasource.Payload.UID) //nolint
 				if err != nil {
 					var notFound *datasources.DeleteDataSourceByUIDNotFound
-					if errors.As(err, &notFound) {
+					if !errors.As(err, &notFound) {
 						return ctrl.Result{}, err
 					}
 				}

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -101,7 +101,7 @@ func (r *GrafanaFolderReconciler) syncFolders(ctx context.Context) (ctrl.Result,
 		for _, folder := range existingFolders {
 			// avoid bombarding the grafana instance with a large number of requests at once, limit
 			// the sync to a certain number of folders per cycle. This means that it will take longer to sync
-			// a large number of deleted dashboard crs, but that should be an edge case.
+			// a large number of deleted folders crs, but that should be an edge case.
 			if foldersSynced >= syncBatchSize {
 				return ctrl.Result{Requeue: true}, nil
 			}


### PR DESCRIPTION
A similar PR as for the issue regarding `grafanafolder` controller #1516 but for the `grafanadatasource` controller.

## This solves two problems
### Datasource removed from Grafana instance but not yet from Grafana CRD
Looks like when we retrieve the ID or try to the delete the resource and we receive an error we only return the exception on `NotFound`. While we should proceed on `NotFound` (to delete the resource from the Grafana CRD) and return on any other exception.

This will happen when a datasource is for example manually deleted using the the UI. And will loop forever. `Reconciler error`

### Datasource removed from Grafana CRD when client throws an error
The other side of this is that when an error occurs that is anything _but_ `NotFound`: `if errors.As(err, &notFound) > False > remove datasource` the datasource is removed from the Grafana CRD status anyway. 

## Code
### Bug
```go
... 
if errors.As(err, &notFound) {
	return ctrl.Result{}, err
}
...
grafana.Status.Dashboards = grafana.Status.Dashboards.Remove(namespace, name)

// won't remove datasource from Grafana CRD when already removed, e.g. through UI
// will remove datasource from Grafana CRD status list when different error occurs (e.g. Grafana unavailable)
```

### Feature
```go
...
if !errors.As(err, &notFound) {
	return ctrl.Result{}, err
}
...
grafana.Status.Dashboards = grafana.Status.Dashboards.Remove(namespace, name)

// will remove datasource from Grafana CRD when already removed, e.g. through UI
// won't remove datasource from Grafana CRD status list when different error occurs (e.g. Grafana unavailable)
```