### PR TITLE
Chore(Grafana): Reduce differences between Internal and External Grafana instance reconciliation.

### DIFF
--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -2,22 +2,81 @@ package grafana
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	client2 "github.com/grafana/grafana-operator/v5/controllers/client"
 	"github.com/grafana/grafana-operator/v5/controllers/reconcilers"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-type CompleteReconciler struct{}
-
-func NewCompleteReconciler() reconcilers.OperatorGrafanaReconciler {
-	return &CompleteReconciler{}
+type CompleteReconciler struct {
+	client client.Client
 }
 
-func (r *CompleteReconciler) Reconcile(ctx context.Context, _ *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, _ *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func NewCompleteReconciler(client client.Client) reconcilers.OperatorGrafanaReconciler {
+	return &CompleteReconciler{
+		client: client,
+	}
+}
+
+func (r *CompleteReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, _ *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("CompleteReconciler")
-	log.Info("grafana installation complete")
+
+	log.Info("fetching Grafana version from instance")
+	version, err := r.getVersion(ctx, cr)
+	if err != nil {
+		cr.Status.Version = ""
+		return v1beta1.OperatorStageResultFailed, fmt.Errorf("failed to get version from instance: %w", err)
+	}
+
+	cr.Status.Version = version
+	log.Info("reconciliation completed")
 
 	return v1beta1.OperatorStageResultSuccess, nil
+}
+
+func (r *CompleteReconciler) getVersion(ctx context.Context, cr *v1beta1.Grafana) (string, error) {
+	cl, err := client2.NewHTTPClient(ctx, r.client, cr)
+	if err != nil {
+		return "", fmt.Errorf("setup of the http client: %w", err)
+	}
+
+	instanceURL := cr.Status.AdminURL
+	if instanceURL == "" && cr.Spec.External != nil {
+		instanceURL = cr.Spec.External.URL
+	}
+
+	req, err := http.NewRequest("GET", instanceURL+"/api/frontend/settings", nil)
+	if err != nil {
+		return "", fmt.Errorf("building request to fetch version: %w", err)
+	}
+
+	err = client2.InjectAuthHeaders(context.Background(), r.client, cr, req)
+	if err != nil {
+		return "", fmt.Errorf("fetching authentication information for version detection: %w", err)
+	}
+
+	resp, err := cl.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching version: %w", err)
+	}
+
+	data := struct {
+		BuildInfo struct {
+			Version string `json:"version"`
+		} `json:"buildInfo"`
+	}{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", fmt.Errorf("parsing health endpoint data: %w", err)
+	}
+	if data.BuildInfo.Version == "" {
+		return "", fmt.Errorf("empty version received from server")
+	}
+
+	return data.BuildInfo.Version, nil
 }

--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -27,7 +27,7 @@ func NewCompleteReconciler(client client.Client) reconcilers.OperatorGrafanaReco
 func (r *CompleteReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, _ *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("CompleteReconciler")
 
-	log.Info("fetching Grafana version from instance")
+	log.V(1).Info("fetching Grafana version from instance")
 	version, err := r.getVersion(ctx, cr)
 	if err != nil {
 		cr.Status.Version = ""
@@ -35,7 +35,7 @@ func (r *CompleteReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana,
 	}
 
 	cr.Status.Version = version
-	log.Info("reconciliation completed")
+	log.V(1).Info("reconciliation completed")
 
 	return v1beta1.OperatorStageResultSuccess, nil
 }

--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -31,7 +31,7 @@ func (r *CompleteReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana,
 	version, err := r.getVersion(ctx, cr)
 	if err != nil {
 		cr.Status.Version = ""
-		return v1beta1.OperatorStageResultFailed, fmt.Errorf("failed to get version from instance: %w", err)
+		return v1beta1.OperatorStageResultFailed, fmt.Errorf("failed fetching version from instance: %w", err)
 	}
 
 	cr.Status.Version = version
@@ -58,12 +58,12 @@ func (r *CompleteReconciler) getVersion(ctx context.Context, cr *v1beta1.Grafana
 
 	err = client2.InjectAuthHeaders(context.Background(), r.client, cr, req)
 	if err != nil {
-		return "", fmt.Errorf("fetching authentication information for version detection: %w", err)
+		return "", fmt.Errorf("fetching credentials for version detection: %w", err)
 	}
 
 	resp, err := cl.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("fetching version: %w", err)
+		return "", err
 	}
 
 	data := struct {


### PR DESCRIPTION
- Moved `r.getVersion` from `GrafanaReconciler` to `CompleteReconciler`
- External and internal instances now use the same reconciliation logic.