### PR TITLE
fix(examples): use Recreate strategy to fit PVC with ReadWriteOnce access mode

### DIFF
--- a/examples/persistent_volume/resources.yaml
+++ b/examples/persistent_volume/resources.yaml
@@ -34,3 +34,5 @@ spec:
             - name: grafana-data
               persistentVolumeClaim:
                 claimName: grafana-pvc
+      strategy:
+        type: Recreate


### PR DESCRIPTION
The default strategy `RollingUpdate` conflicts with the `ReadWriteOnce` accessMode. Changing the default strategy to `Recreate` on the "Persistent Volume" example seems like a sensible way to workaround this.