### PR TITLE
fix: correctly set encoder

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,9 @@ func main() {
 	logCfg := uberzap.NewProductionEncoderConfig()
 	logCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 	opts := zap.Options{
-		Encoder: zapcore.NewConsoleEncoder(logCfg),
+		NewEncoder: func(eco ...zap.EncoderConfigOption) zapcore.Encoder {
+			return zapcore.NewConsoleEncoder(logCfg)
+		},
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Use `NewEncoder` instead of `Encoder` as only `NewEncoder` is overriden when using flags.

Fixes: #1878