### PR TITLE
fix(controllers): set Status in synchronized condition to False when hitting apply errors

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -274,7 +274,7 @@ func buildSynchronizedCondition(resource string, syncType string, generation int
 		condition.Reason = conditionApplySuccessful
 		condition.Message = fmt.Sprintf("%s was successfully applied to %d instances", resource, total)
 	} else {
-		condition.Status = metav1.ConditionTrue
+		condition.Status = metav1.ConditionFalse
 		condition.Reason = conditionApplyFailed
 
 		var sb strings.Builder

--- a/tests/e2e/conditions/02-apply-failed-assertions.yaml
+++ b/tests/e2e/conditions/02-apply-failed-assertions.yaml
@@ -6,7 +6,7 @@ metadata:
 status:
   conditions:
   - reason: ApplyFailed
-    status: "True"
+    status: "False"
     type: NotificationTemplateSynchronized
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -16,7 +16,7 @@ metadata:
 status:
   conditions:
   - reason: ApplyFailed
-    status: "True"
+    status: "False"
     type: ContactPointSynchronized
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -26,7 +26,7 @@ metadata:
 status:
   conditions:
   - reason: ApplyFailed
-    status: "True"
+    status: "False"
     type: NotificationPolicySynchronized
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -36,7 +36,7 @@ metadata:
 status:
   conditions:
   - reason: ApplyFailed
-    status: "True"
+    status: "False"
     type: FolderSynchronized
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -46,7 +46,7 @@ metadata:
 status:
   conditions:
   - reason: ApplyFailed
-    status: "True"
+    status: "False"
     type: AlertGroupSynchronized
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -56,7 +56,7 @@ metadata:
 status:
   conditions:
   - reason: ApplyFailed
-    status: "True"
+    status: "False"
     type: MuteTimingSynchronized
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -66,7 +66,7 @@ metadata:
 status:
   conditions:
     - reason: ApplyFailed
-      status: "True"
+      status: "False"
       type: DashboardSynchronized
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -78,5 +78,5 @@ status:
 status:
   conditions:
   - reason: ApplyFailed
-    status: "True"
+    status: "False"
     type: DatasourceSynchronized


### PR DESCRIPTION
At the moment, CR's condition `Status` is always set to `True` meaning it does not reflect some of the apply errors (e.g. when a resource cannot be accepted by Grafana instance, because a feature toggle is not enabled).

Instead, we should set `Status` to `False` when `applyErrors > 0`. Thus, the PR.