### PR TITLE
chore: Remove enum validation of contactpoint type

### DIFF
--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -47,8 +47,8 @@ type GrafanaContactPointSpec struct {
 	// +kubebuilder:validation:MaxItems=99
 	ValuesFrom []ValueFrom `json:"valuesFrom,omitempty"`
 
-	// +kubebuilder:validation:Enum=alertmanager;prometheus-alertmanager;dingding;discord;email;googlechat;kafka;line;opsgenie;pagerduty;pushover;sensugo;sensu;slack;sns;teams;telegram;threema;victorops;webex;webhook;wecom;hipchat;oncall
-	Type string `json:"type,omitempty"`
+	// +kubebuilder:validation:MinLength=1
+	Type string `json:"type"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -118,31 +118,7 @@ spec:
               settings:
                 x-kubernetes-preserve-unknown-fields: true
               type:
-                enum:
-                - alertmanager
-                - prometheus-alertmanager
-                - dingding
-                - discord
-                - email
-                - googlechat
-                - kafka
-                - line
-                - opsgenie
-                - pagerduty
-                - pushover
-                - sensugo
-                - sensu
-                - slack
-                - sns
-                - teams
-                - telegram
-                - threema
-                - victorops
-                - webex
-                - webhook
-                - wecom
-                - hipchat
-                - oncall
+                minLength: 1
                 type: string
               uid:
                 description: Manually specify the UID the Contact Point is created
@@ -223,6 +199,7 @@ spec:
             - instanceSelector
             - name
             - settings
+            - type
             type: object
             x-kubernetes-validations:
             - message: spec.uid is immutable

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -118,31 +118,7 @@ spec:
               settings:
                 x-kubernetes-preserve-unknown-fields: true
               type:
-                enum:
-                - alertmanager
-                - prometheus-alertmanager
-                - dingding
-                - discord
-                - email
-                - googlechat
-                - kafka
-                - line
-                - opsgenie
-                - pagerduty
-                - pushover
-                - sensugo
-                - sensu
-                - slack
-                - sns
-                - teams
-                - telegram
-                - threema
-                - victorops
-                - webex
-                - webhook
-                - wecom
-                - hipchat
-                - oncall
+                minLength: 1
                 type: string
               uid:
                 description: Manually specify the UID the Contact Point is created
@@ -223,6 +199,7 @@ spec:
             - instanceSelector
             - name
             - settings
+            - type
             type: object
             x-kubernetes-validations:
             - message: spec.uid is immutable

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -465,31 +465,7 @@ spec:
               settings:
                 x-kubernetes-preserve-unknown-fields: true
               type:
-                enum:
-                - alertmanager
-                - prometheus-alertmanager
-                - dingding
-                - discord
-                - email
-                - googlechat
-                - kafka
-                - line
-                - opsgenie
-                - pagerduty
-                - pushover
-                - sensugo
-                - sensu
-                - slack
-                - sns
-                - teams
-                - telegram
-                - threema
-                - victorops
-                - webex
-                - webhook
-                - wecom
-                - hipchat
-                - oncall
+                minLength: 1
                 type: string
               uid:
                 description: Manually specify the UID the Contact Point is created
@@ -570,6 +546,7 @@ spec:
             - instanceSelector
             - name
             - settings
+            - type
             type: object
             x-kubernetes-validations:
             - message: spec.uid is immutable

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -777,6 +777,13 @@ GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>type</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>allowCrossNamespaceImport</b></td>
         <td>boolean</td>
         <td>
@@ -800,15 +807,6 @@ GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
           <br/>
             <i>Format</i>: duration<br/>
             <i>Default</i>: 10m0s<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>type</b></td>
-        <td>enum</td>
-        <td>
-          <br/>
-          <br/>
-            <i>Enum</i>: alertmanager, prometheus-alertmanager, dingding, discord, email, googlechat, kafka, line, opsgenie, pagerduty, pushover, sensugo, sensu, slack, sns, teams, telegram, threema, victorops, webex, webhook, wecom, hipchat, oncall<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
As we agreed on in the last weekly meeting.
The list of valid `contactpoint.type` inputs is a moving target which inhibits users unnecessarily.

The field is required according to the [HTTP API DOCS](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/#span-idembedded-contact-pointspan-embeddedcontactpoint) hence I opted to add a `MinLength=1` validation and remove `omitEmpty`