### PR TITLE
Chore(Grafana): Refactor grafana reconciler status

### DIFF
--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -87,7 +87,9 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		grafana.Status.AdminUrl = grafana.Spec.External.URL
 		version, err := r.getVersion(ctx, grafana)
 		if err != nil {
+			grafana.Status.Version = ""
 			grafana.Status.LastMessage = err.Error()
+			grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultFailed
 			return ctrl.Result{}, fmt.Errorf("failed to get version from external instance: %w", err)
 		}
 
@@ -133,12 +135,13 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			return ctrl.Result{}, fmt.Errorf("reconciler error in stage '%s': %w", stage, err)
 		}
-
-		grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultSuccess
 	}
+
+	grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultSuccess
 
 	version, err := r.getVersion(ctx, grafana)
 	if err != nil {
+		grafana.Status.Version = ""
 		grafana.Status.LastMessage = err.Error()
 		return ctrl.Result{}, fmt.Errorf("failed to get version from instance: %w", err)
 	}

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -137,6 +137,10 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	// NOTE When exiting the loop successfully, consider the internal instance reconciled
+	// This is due to the 'E2E conditions test' relying on it having a successful status to even attempt reconciliation.
+	// Unready instances are omitted from synchronization
+	// TODO Implement a solution to mark an instance as failing but also validate `ApplyFailed` conditions for resources
 	grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultSuccess
 
 	version, err := r.getVersion(ctx, grafana)

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -120,7 +120,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			continue
 		}
 
-		status, err := reconciler.Reconcile(ctx, grafana, nextStatus, vars, r.Scheme)
+		status, err := reconciler.Reconcile(ctx, grafana, vars, r.Scheme)
 		if err != nil {
 			log.Error(err, "reconciler error in stage", "stage", stage)
 			nextStatus.LastMessage = err.Error()

--- a/controllers/reconcilers/grafana/admin_secret_reconciler.go
+++ b/controllers/reconcilers/grafana/admin_secret_reconciler.go
@@ -24,7 +24,7 @@ func NewAdminSecretReconciler(client client.Client) reconcilers.OperatorGrafanaR
 	}
 }
 
-func (r *AdminSecretReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *AdminSecretReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	secret := model.GetGrafanaAdminSecret(cr, scheme)
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, secret, func() error {
 		model.SetInheritedLabels(secret, cr.Labels)

--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -15,7 +15,7 @@ func NewCompleteReconciler() reconcilers.OperatorGrafanaReconciler {
 	return &CompleteReconciler{}
 }
 
-func (r *CompleteReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *CompleteReconciler) Reconcile(ctx context.Context, _ *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, _ *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("CompleteReconciler")
 	log.Info("grafana installation complete")
 

--- a/controllers/reconcilers/grafana/config_reconciler.go
+++ b/controllers/reconcilers/grafana/config_reconciler.go
@@ -23,7 +23,7 @@ func NewConfigReconciler(client client.Client) reconcilers.OperatorGrafanaReconc
 	}
 }
 
-func (r *ConfigReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *ConfigReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	_ = logf.FromContext(ctx)
 
 	cfg := config.WriteIni(cr.Spec.Config)

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -45,7 +45,7 @@ func NewDeploymentReconciler(client client.Client, isOpenShift bool) reconcilers
 	}
 }
 
-func (r *DeploymentReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("DeploymentReconciler")
 
 	openshiftPlatform := r.isOpenShift

--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -32,19 +32,19 @@ func NewIngressReconciler(client client.Client, isOpenShift bool) reconcilers.Op
 	}
 }
 
-func (r *IngressReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *IngressReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("IngressReconciler")
 
 	if r.isOpenShift {
 		log.Info("reconciling route", "platform", "openshift")
-		return r.reconcileRoute(ctx, cr, status, vars, scheme)
+		return r.reconcileRoute(ctx, cr, vars, scheme)
 	} else {
 		log.Info("reconciling ingress", "platform", "kubernetes")
-		return r.reconcileIngress(ctx, cr, status, vars, scheme)
+		return r.reconcileIngress(ctx, cr, vars, scheme)
 	}
 }
 
-func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	if cr.Spec.Ingress == nil {
 		return v1beta1.OperatorStageResultSuccess, nil
 	}
@@ -72,13 +72,13 @@ func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Gr
 			return v1beta1.OperatorStageResultFailed, fmt.Errorf("ingress spec is incomplete")
 		}
 
-		status.AdminUrl = adminURL
+		cr.Status.AdminUrl = adminURL
 	}
 
 	return v1beta1.OperatorStageResultSuccess, nil
 }
 
-func (r *IngressReconciler) reconcileRoute(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *IngressReconciler) reconcileRoute(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	if cr.Spec.Route == nil || cr.Spec.Route.Spec == nil {
 		return v1beta1.OperatorStageResultSuccess, nil
 	}
@@ -98,7 +98,7 @@ func (r *IngressReconciler) reconcileRoute(ctx context.Context, cr *v1beta1.Graf
 	// try to assign the admin url
 	if cr.PreferIngress() {
 		if route.Spec.Host != "" {
-			status.AdminUrl = fmt.Sprintf("https://%v", route.Spec.Host)
+			cr.Status.AdminUrl = fmt.Sprintf("https://%v", route.Spec.Host)
 		}
 	}
 

--- a/controllers/reconcilers/grafana/plugins_reconciler.go
+++ b/controllers/reconcilers/grafana/plugins_reconciler.go
@@ -23,7 +23,7 @@ func NewPluginsReconciler(client client.Client) reconcilers.OperatorGrafanaRecon
 	}
 }
 
-func (r *PluginsReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *PluginsReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("PluginsReconciler")
 
 	vars.Plugins = ""

--- a/controllers/reconcilers/grafana/pvc_reconciler.go
+++ b/controllers/reconcilers/grafana/pvc_reconciler.go
@@ -22,7 +22,7 @@ func NewPvcReconciler(client client.Client) reconcilers.OperatorGrafanaReconcile
 	}
 }
 
-func (r *PvcReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *PvcReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("PvcReconciler")
 
 	if cr.Spec.PersistentVolumeClaim == nil {

--- a/controllers/reconcilers/grafana/service_account_reconciler.go
+++ b/controllers/reconcilers/grafana/service_account_reconciler.go
@@ -21,7 +21,7 @@ func NewServiceAccountReconciler(client client.Client) reconcilers.OperatorGrafa
 	}
 }
 
-func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	sa := model.GetGrafanaServiceAccount(cr, scheme)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, sa, func() error {

--- a/controllers/reconcilers/grafana/service_reconciler.go
+++ b/controllers/reconcilers/grafana/service_reconciler.go
@@ -29,7 +29,7 @@ func NewServiceReconciler(client client.Client, clusterDomain string) reconciler
 	}
 }
 
-func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	_ = logf.FromContext(ctx)
 
 	service := model.GetGrafanaService(cr, scheme)
@@ -57,7 +57,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 		if r.clusterDomain != "" {
 			adminHost += "." + r.clusterDomain
 		}
-		status.AdminUrl = fmt.Sprintf("%v://%v:%d", getGrafanaServerProtocol(cr), adminHost, int32(GetGrafanaPort(cr))) // #nosec G115
+		cr.Status.AdminUrl = fmt.Sprintf("%v://%v:%d", getGrafanaServerProtocol(cr), adminHost, int32(GetGrafanaPort(cr))) // #nosec G115
 	}
 
 	// Headless service for grafana unified alerting

--- a/controllers/reconcilers/reconciler.go
+++ b/controllers/reconcilers/reconciler.go
@@ -8,5 +8,5 @@ import (
 )
 
 type OperatorGrafanaReconciler interface {
-	Reconcile(ctx context.Context, cr *v1beta1.Grafana, status *v1beta1.GrafanaStatus, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error)
+	Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error)
 }

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	discovery2 "k8s.io/client-go/discovery"
+
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -254,7 +254,6 @@ func main() { // nolint:gocyclo
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
 		IsOpenShift:   isOpenShift,
-		Discovery:     discovery2.NewDiscoveryClientForConfigOrDie(restConfig),
 		ClusterDomain: clusterDomain,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Grafana")


### PR DESCRIPTION
- Status updates no longer trigger full reconciles of instances.
- All Grafana instance reconciler signatures no longer take a `GrafanaStatus` struct.
  Locally unused args are prefixed with `_` for clarity.
- Status is now updated in a Defer similar to other resources.
- `updateStatus` func has been removed.

I spent a long time to boil this one down, but in the end I had to change the if conditions within the for loop to properly support a deferred status update.
The logic itself should be almost exactly the same with no major changes to the flow unlike in #1880 