### PR TITLE
fix(GrafanaAlertRuleGroup): apply mute_time_intervals

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -202,11 +202,12 @@ func (r *GrafanaAlertRuleGroupReconciler) reconcileWithInstance(ctx context.Cont
 		}
 		if rule.NotificationSettings != nil {
 			apiRule.NotificationSettings = &models.AlertRuleNotificationSettings{
-				Receiver:       &rule.NotificationSettings.Receiver,
-				GroupBy:        rule.NotificationSettings.GroupBy,
-				GroupWait:      rule.NotificationSettings.GroupWait,
-				GroupInterval:  rule.NotificationSettings.GroupInterval,
-				RepeatInterval: rule.NotificationSettings.RepeatInterval,
+				Receiver:          &rule.NotificationSettings.Receiver,
+				GroupBy:           rule.NotificationSettings.GroupBy,
+				GroupWait:         rule.NotificationSettings.GroupWait,
+				MuteTimeIntervals: rule.NotificationSettings.MuteTimeIntervals,
+				GroupInterval:     rule.NotificationSettings.GroupInterval,
+				RepeatInterval:    rule.NotificationSettings.RepeatInterval,
 			}
 		}
 		if rule.Record != nil {


### PR DESCRIPTION
Currently, the operator is updating/persisting the mute timing configuration within the notification settings.

```yaml
...
notificationSettings:
  receiver: my-receiver-1
  mute_time_intervals:
      - mute-pods-weekend
```   
This Pull Request (PR) adds the MuteTimeInterval field to the Alert Group Rule update to support the configuration of mute time intervals.