### PR TITLE
feat(Grafana): add an option to disable default admin secret

### DIFF
--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -78,6 +78,8 @@ type GrafanaSpec struct {
 	External *External `json:"external,omitempty"`
 	// Preferences holds the Grafana Preferences settings
 	Preferences *GrafanaPreferences `json:"preferences,omitempty"`
+	// DisableDefaultAdminSecret prevents operator from creating default admin-credentials secret
+	DisableDefaultAdminSecret bool `json:"disableDefaultAdminSecret,omitempty"`
 }
 
 type External struct {

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -8207,6 +8207,10 @@ spec:
                         type: object
                     type: object
                 type: object
+              disableDefaultAdminSecret:
+                description: DisableDefaultAdminSecret prevents operator from creating
+                  default admin-credentials secret
+                type: boolean
               external:
                 description: External enables you to configure external grafana instances
                   that is not managed by the operator.

--- a/controllers/grafana_admin_secret_reconciler_test.go
+++ b/controllers/grafana_admin_secret_reconciler_test.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/grafana/grafana-operator/v5/controllers/reconcilers/grafana"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var _ = Describe("Reconcile AdminSecret", func() {
+	It("runs successfully with disabled default admin secret", func() {
+		r := grafana.NewAdminSecretReconciler(k8sClient)
+		cr := &v1beta1.Grafana{
+			Spec: v1beta1.GrafanaSpec{
+				DisableDefaultAdminSecret: true,
+			},
+		}
+
+		vars := &v1beta1.OperatorReconcileVars{}
+		status, err := r.Reconcile(context.Background(), cr, vars, scheme.Scheme)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status).To(Equal(v1beta1.OperatorStageResultSuccess))
+	})
+})

--- a/controllers/reconcilers/grafana/admin_secret_reconciler.go
+++ b/controllers/reconcilers/grafana/admin_secret_reconciler.go
@@ -25,6 +25,9 @@ func NewAdminSecretReconciler(client client.Client) reconcilers.OperatorGrafanaR
 }
 
 func (r *AdminSecretReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+	if cr.Spec.DisableDefaultAdminSecret {
+		return v1beta1.OperatorStageResultSuccess, nil
+	}
 	secret := model.GetGrafanaAdminSecret(cr, scheme)
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, secret, func() error {
 		model.SetInheritedLabels(secret, cr.Labels)

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
@@ -8207,6 +8207,10 @@ spec:
                         type: object
                     type: object
                 type: object
+              disableDefaultAdminSecret:
+                description: DisableDefaultAdminSecret prevents operator from creating
+                  default admin-credentials secret
+                type: boolean
               external:
                 description: External enables you to configure external grafana instances
                   that is not managed by the operator.

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -11464,6 +11464,10 @@ spec:
                         type: object
                     type: object
                 type: object
+              disableDefaultAdminSecret:
+                description: DisableDefaultAdminSecret prevents operator from creating
+                  default admin-credentials secret
+                type: boolean
               external:
                 description: External enables you to configure external grafana instances
                   that is not managed by the operator.

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -6232,6 +6232,13 @@ GrafanaSpec defines the desired state of Grafana
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>disableDefaultAdminSecret</b></td>
+        <td>boolean</td>
+        <td>
+          DisableDefaultAdminSecret prevents operator from creating default admin-credentials secret<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#grafanaspecexternal">external</a></b></td>
         <td>object</td>
         <td>


### PR DESCRIPTION
When you have a custom secret created for Grafana credentials like this one:
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: credentials
  namespace: grafana
stringData:
  GF_SECURITY_ADMIN_PASSWORD: secret
  GF_SECURITY_ADMIN_USER: root
type: Opaque

```

The default one is misleading.

Here is an option to disable it.

```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
metadata:
  name: grafana
spec:
  disableDefaultAdminSecret: true
      

