### PR TITLE
chore(Grafana): mark internal Grafana as failed if version cannot be fetched

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -91,7 +91,7 @@ func GetScopedMatchingInstances(ctx context.Context, k8sClient client.Client, cr
 		// Readiness checks omits instances that have not completed a full reconciliation successfully.
 		// This allows speeding up reconciliations and reduces the amount of noisy errors.
 		// A toggle to skip the readiness check allows additional testing of reconcilers, like provoking the ApplyFailed synchronization condition.
-		doReadinessCheck := instance.Annotations["grafana/skip-readiness-check"] != "true"
+		doReadinessCheck := instance.Annotations["grafana-operator/skip-readiness-check"] != "true"
 
 		// admin url is required to interact with Grafana
 		// the instance or route might not yet be ready

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -91,7 +91,10 @@ func GetScopedMatchingInstances(ctx context.Context, k8sClient client.Client, cr
 		// Readiness checks omits instances that have not completed a full reconciliation successfully.
 		// This allows speeding up reconciliations and reduces the amount of noisy errors.
 		// A toggle to skip the readiness check allows additional testing of reconcilers, like provoking the ApplyFailed synchronization condition.
-		doReadinessCheck := instance.Annotations["grafana-operator/skip-readiness-check"] != "true"
+		doReadinessCheck := true
+		if instance.Annotations["grafana-operator/skip-readiness-check"] == "true" {
+			doReadinessCheck = false
+		}
 
 		// admin url is required to interact with Grafana
 		// the instance or route might not yet be ready

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -87,9 +87,15 @@ func GetScopedMatchingInstances(ctx context.Context, k8sClient client.Client, cr
 		if !selected {
 			continue
 		}
+
+		// Readiness checks omits instances that have not completed a full reconciliation successfully.
+		// This allows speeding up reconciliations and reduces the amount of noisy errors.
+		// A toggle to skip the readiness check allows additional testing of reconcilers, like provoking the ApplyFailed synchronization condition.
+		doReadinessCheck := instance.Annotations["grafana/skip-readiness-check"] != "true"
+
 		// admin url is required to interact with Grafana
 		// the instance or route might not yet be ready
-		if instance.Status.Stage != v1beta1.OperatorStageComplete || instance.Status.StageStatus != v1beta1.OperatorStageResultSuccess {
+		if doReadinessCheck && (instance.Status.Stage != v1beta1.OperatorStageComplete || instance.Status.StageStatus != v1beta1.OperatorStageResultSuccess) {
 			unready_instances = append(unready_instances, instance.Name)
 			continue
 		}

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -141,16 +141,11 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	// NOTE When exiting the loop successfully, consider the internal instance reconciled
-	// This is due to the 'E2E conditions test' relying on it having a successful status to even attempt reconciliation.
-	// Unready instances are omitted from synchronization
-	// TODO Implement a solution to mark an instance as failing but also validate `ApplyFailed` conditions for resources
-	grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultSuccess
-
 	version, err := r.getVersion(ctx, grafana)
 	if err != nil {
 		grafana.Status.Version = ""
 		grafana.Status.LastMessage = err.Error()
+		grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultFailed
 
 		// The same as the external instances above, avoids overloading a single instance
 		log.Error(err, "failed to get version from instance")
@@ -158,6 +153,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	grafana.Status.Version = version
+	grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultSuccess
 	grafana.Status.LastMessage = ""
 	return ctrl.Result{}, nil
 }

--- a/tests/e2e/conditions/02-apply-failed-assertions.yaml
+++ b/tests/e2e/conditions/02-apply-failed-assertions.yaml
@@ -1,5 +1,13 @@
 ---
 apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: testdata
+status:
+  stage: complete
+  stageStatus: failed
+---
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaNotificationTemplate
 metadata:
   name: testdata

--- a/tests/e2e/conditions/chainsaw-test.yaml
+++ b/tests/e2e/conditions/chainsaw-test.yaml
@@ -69,7 +69,7 @@ spec:
             file: "../testdata-assertions.yaml"
 
     # reason: ApplyFailed
-    - name: Scale Grafana deployment to zero
+    - name: Scale Grafana deployment to zero and skip ready check
       try:
         - patch:
             resource:
@@ -77,6 +77,10 @@ spec:
               kind: Grafana
               metadata:
                 name: testdata
+                annotations:
+                  # Disables the check that would otherwise omit the instance from reconciliation.
+                  # Without this a NoMatchingInstances condition would be added to the status instead.
+                  grafana/skip-readiness-check: "true"
               spec:
                 deployment:
                   spec:
@@ -91,6 +95,8 @@ spec:
               kind: Grafana
               metadata:
                 name: testdata
+                annotations:
+                  grafana/skip-readiness-check: ""
               spec:
                 deployment:
                   spec:

--- a/tests/e2e/conditions/chainsaw-test.yaml
+++ b/tests/e2e/conditions/chainsaw-test.yaml
@@ -69,7 +69,7 @@ spec:
             file: "../testdata-assertions.yaml"
 
     # reason: ApplyFailed
-    - name: Scale Grafana deployment to zero and skip ready check
+    - name: Scale Grafana deployment to zero and skip readiness check
       try:
         - patch:
             resource:
@@ -80,7 +80,7 @@ spec:
                 annotations:
                   # Disables the check that would otherwise omit the instance from reconciliation.
                   # Without this a NoMatchingInstances condition would be added to the status instead.
-                  grafana/skip-readiness-check: "true"
+                  grafana-operator/skip-readiness-check: "true"
               spec:
                 deployment:
                   spec:
@@ -96,7 +96,7 @@ spec:
               metadata:
                 name: testdata
                 annotations:
-                  grafana/skip-readiness-check: ""
+                  grafana-operator/skip-readiness-check: "false"
               spec:
                 deployment:
                   spec:


### PR DESCRIPTION
Marks internal instances where Version is empty as failed and omits them when reconciling resources.
A special annotation has been added to ensure that it's possible to provoke the `ApplyFailed` condition in the E2E tests.
`grafana/skip-readiness-check: "true"`
