### PR TITLE
Unit test for syncDatasources

### DIFF
--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -150,9 +150,9 @@ func (in *GrafanaDatasource) CustomUIDOrUID() string {
 	return string(in.UID)
 }
 
-func (in *GrafanaDatasourceList) Find(namespace string, name string) *GrafanaDatasource {
+func (in *GrafanaDatasourceList) Find(namespace string, name string, id string) *GrafanaDatasource {
 	for _, datasource := range in.Items {
-		if datasource.Namespace == namespace && datasource.Name == name {
+		if datasource.Namespace == namespace && datasource.Name == name && datasource.Status.UID == id {
 			return &datasource
 		}
 	}

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -150,9 +150,9 @@ func (in *GrafanaDatasource) CustomUIDOrUID() string {
 	return string(in.UID)
 }
 
-func (in *GrafanaDatasourceList) Find(namespace string, name string, id string) *GrafanaDatasource {
+func (in *GrafanaDatasourceList) Find(namespace string, name string) *GrafanaDatasource {
 	for _, datasource := range in.Items {
-		if datasource.Namespace == namespace && datasource.Name == name && datasource.Status.UID == id {
+		if datasource.Namespace == namespace && datasource.Name == name {
 			return &datasource
 		}
 	}

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -141,7 +141,7 @@ func getDatasourcesToDelete(allDatasources *v1beta1.GrafanaDatasourceList, grafa
 	datasourcesToDelete := map[*v1beta1.Grafana][]v1beta1.NamespacedResource{}
 	for _, grafana := range grafanas {
 		for _, datasource := range grafana.Status.Datasources {
-			if allDatasources.Find(datasource.Namespace(), datasource.Name(), datasource.UID()) == nil {
+			if allDatasources.Find(datasource.Namespace(), datasource.Name()) == nil {
 				datasourcesToDelete[&grafana] = append(datasourcesToDelete[&grafana], datasource)
 			}
 		}

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -54,16 +54,6 @@ func TestGetDatasourcesToDelete(t *testing.T) {
 					UID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 				},
 			},
-			{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "datasource-b",
-					Namespace: "namespace",
-				},
-				Status: v1beta1.GrafanaDatasourceStatus{
-					UID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-				},
-			},
 		},
 	}
 	grafanaList := []v1beta1.Grafana{
@@ -76,7 +66,6 @@ func TestGetDatasourcesToDelete(t *testing.T) {
 			Status: v1beta1.GrafanaStatus{
 				Datasources: v1beta1.NamespacedResourceList{
 					"namespace/datasource-a/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-					"namespace/datasource-a/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 					"namespace/datasource-c/cccccccc-cccc-cccc-cccc-cccccccccccc",
 				},
 			},
@@ -87,7 +76,6 @@ func TestGetDatasourcesToDelete(t *testing.T) {
 	for grafana := range datasourcesToDelete {
 		if grafana.Name == "grafana-1" {
 			assert.Equal(t, []v1beta1.NamespacedResource([]v1beta1.NamespacedResource{
-				"namespace/datasource-a/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				"namespace/datasource-c/cccccccc-cccc-cccc-cccc-cccccccccccc",
 			}), datasourcesToDelete[grafana])
 		}

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -40,24 +40,43 @@ func TestGetDatasourceContent(t *testing.T) {
 }
 
 func TestGetDatasourcesToDelete(t *testing.T) {
-	dashboardList := v1beta1.GrafanaDatasourceList{
-		TypeMeta: metav1.TypeMeta{},
-		ListMeta: metav1.ListMeta{},
-		Items: []v1beta1.GrafanaDatasource{
-			{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "datasource-a",
-					Namespace: "namespace",
-				},
-				Status: v1beta1.GrafanaDatasourceStatus{
-					UID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+	f := func(ds []v1beta1.GrafanaDatasource, grafana v1beta1.Grafana, expected []v1beta1.NamespacedResource) {
+		t.Helper()
+		dashboardList := v1beta1.GrafanaDatasourceList{
+			TypeMeta: metav1.TypeMeta{},
+			ListMeta: metav1.ListMeta{},
+			Items: []v1beta1.GrafanaDatasource{
+				{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "datasource-a",
+						Namespace: "namespace",
+					},
+					Status: v1beta1.GrafanaDatasourceStatus{
+						UID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					},
 				},
 			},
-		},
+		}
+		datasourcesToDelete := getDatasourcesToDelete(&dashboardList, []v1beta1.Grafana{grafana})
+		for _, out := range datasourcesToDelete {
+			assert.Equal(t, out, expected)
+		}
 	}
-	grafanaList := []v1beta1.Grafana{
+
+	f([]v1beta1.GrafanaDatasource{
 		{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "datasource-a",
+				Namespace: "namespace",
+			},
+			Status: v1beta1.GrafanaDatasourceStatus{
+				UID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+			},
+		},
+	},
+		v1beta1.Grafana{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "grafana-1",
@@ -70,14 +89,8 @@ func TestGetDatasourcesToDelete(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	datasourcesToDelete := getDatasourcesToDelete(&dashboardList, grafanaList)
-	for grafana := range datasourcesToDelete {
-		if grafana.Name == "grafana-1" {
-			assert.Equal(t, []v1beta1.NamespacedResource([]v1beta1.NamespacedResource{
-				"namespace/datasource-c/cccccccc-cccc-cccc-cccc-cccccccccccc",
-			}), datasourcesToDelete[grafana])
-		}
-	}
+		[]v1beta1.NamespacedResource{
+			"namespace/datasource-c/cccccccc-cccc-cccc-cccc-cccccccccccc",
+		},
+	)
 }


### PR DESCRIPTION
## Updated to only keep the unit test
- Break datasources to delete logic in a separate function (similar as for the dashboards [here](https://github.com/grafana/grafana-operator/blob/0dda0c7fc9f23364b8b4928ce0be7ef54a2682b0/controllers/dashboard_controller.go#L134))
- Add a unit test for above function

## OLD: Problem
A `Grafana` resource with multiple datasources with the _same_ name but _different_ ID will not have the duplicate datasources removed.

```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
...
status:
  datasources:
  - test-datasource/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAA
  - test-datasource/BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBB < should be deleted if there is not datasource with BB..BB ID
```

If the `kubectl get grafanadatasources` returns
```
NAME                                                     UID
test-datasource                                     AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAA
```
## Resolution
- Break datasources to delete logic in a separate function (similar as for the dashboards [here](https://github.com/grafana/grafana-operator/blob/0dda0c7fc9f23364b8b4928ce0be7ef54a2682b0/controllers/dashboard_controller.go#L134))
- Match grafana status datasource with CR datasources only when ID also match
- Add a unit test for above