### PR TITLE
chore(controllers): log cases when none of available Grafana instances match selector

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -108,7 +108,7 @@ func GetScopedMatchingInstances(ctx context.Context, k8sClient client.Client, cr
 		log.Info("Grafana instances not ready, excluded from matching", "instances", unready_instances)
 	}
 	if len(selectedList) == 0 {
-		log.Info("No instances matched selector, reconciliation will be retried", "AllowCrossNamespaceImport", cr.AllowCrossNamespace())
+		log.Info("None of the available Grafana instances matched the selector, skipping reconciliation", "AllowCrossNamespaceImport", cr.AllowCrossNamespace())
 	}
 
 	return selectedList, nil
@@ -210,7 +210,7 @@ func setNoMatchingInstancesCondition(conditions *[]metav1.Condition, generation 
 		message = fmt.Sprintf("error occurred during fetching of instances: %s", err.Error())
 	} else {
 		reason = "EmptyAPIReply"
-		message = "Instances could not be fetched, reconciliation will be retried"
+		message = "None of the available Grafana instances matched the selector, skipping reconciliation"
 	}
 	meta.SetStatusCondition(conditions, metav1.Condition{
 		Type:               conditionNoMatchingInstance,

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -107,6 +107,9 @@ func GetScopedMatchingInstances(ctx context.Context, k8sClient client.Client, cr
 	if len(unready_instances) > 0 {
 		log.Info("Grafana instances not ready, excluded from matching", "instances", unready_instances)
 	}
+	if len(selectedList) == 0 {
+		log.Info("No instances matched selector, reconciliation will be retried", "AllowCrossNamespaceImport", cr.AllowCrossNamespace())
+	}
 
 	return selectedList, nil
 }


### PR DESCRIPTION
Currently we only display the result as a status condition, we do not log that no instances matched during the current reconciliation.
To partially accomodate #1570 `"AllowCrossNamespaceImport": true/false` has been added to the log line.

Example log line:
```log
2025-03-29T11:36:11.216Z        info    GrafanaDashboardReconciler      No instances matched selector, reconciliation will be retried   {"controller": "grafanadashboard", "controllerGroup": "grafana.integreatly.org", "controllerKind": "GrafanaDashboard", "GrafanaDashboard": {"name":"external-grafanadashboard-sample","namespace":"default"}, "namespace": "default", "name": "external-grafanadashboard-sample", "reconcileID": "5cd532f1-9bd2-4d7e-a722-ce42d5b0f595", "AllowCrossNamespaceImport": false}
```