### PR TITLE
Chore: Bump k8s versions in E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -56,9 +56,9 @@ jobs:
       matrix:
         version:
           - v1.27.13
-          - v1.28.9
-          - v1.29.4
-          - v1.30.0
+          - v1.30.10
+          - v1.31.6
+          - v1.32.2
     steps:
       - name: Clone repo and checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Found no documentation on the versions we aim to support.
Since [AKS](https://endoflife.date/azure-kubernetes-service) and [EKS](https://endoflife.date/amazon-eks) both support `1.27` I left that in the matrix of supported versions.

The versions were sourced from [kinds latest release](https://github.com/kubernetes-sigs/kind/releases/tag/v0.27.0) except `1.27.14` which was unavailable to pull??