### PR TITLE
fix(Grafana): avoid grafana-ini's configmap mount masking the existing files/directories

### DIFF
--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -119,7 +119,8 @@ func getVolumeMounts(cr *v1beta1.Grafana, scheme *runtime.Scheme) []v1.VolumeMou
 
 	mounts = append(mounts, v1.VolumeMount{
 		Name:      config.Name,
-		MountPath: "/etc/grafana/",
+		MountPath: "/etc/grafana/grafana.ini",
+		SubPath:   "grafana.ini",
 	})
 
 	mounts = append(mounts, v1.VolumeMount{


### PR DESCRIPTION
The previous way of mounting the `configmap` was masking the default content of `/etc/grafana`. This could be troublesome especially if one wants to mount something in the container under `/etc/grafana/provisioning/*` on its own/without relying on the operator to do so.

```shell
docker run -it --entrypoint /bin/bash grafana/grafana
24832c31ab77:/usr/share/grafana$ tree /etc/grafana/
/etc/grafana/
├── grafana.ini
├── ldap.toml
└── provisioning
    ├── access-control
    ├── alerting
    ├── dashboards
    ├── datasources
    ├── notifiers
    └── plugins

7 directories, 2 files
```

The following patch mounts only `grafana.ini` under `/etc/grafana/grafana.ini`.