### PR TITLE
fix(Grafana): do not skip reconciliation if generation is the same as before

### DIFF
--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -205,7 +205,6 @@ func (r *GrafanaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&grafanav1beta1.Grafana{}).
 		Owns(&v1.Deployment{}).
 		Owns(&v12.ConfigMap{}).
-		WithEventFilter(ignoreStatusUpdates()).
 		Complete(r)
 }
 


### PR DESCRIPTION
In #1901, we added an instruction to skip reconciliation in case generation is the same as before. The issue with that approach is that it leads to skipped reconciles triggered by owned Deployment / ConfigMap (holds a list of plugins) updates, so, e.g., the Deployment is not updated when a new plugin is added.
The PR rolls back the change (until we have a better filtering logic should the need for that be).