### PR TITLE
fix(controllers): retry reconciliation for plugins and home dashboards and fix ownerReferences for plugins and Deployment

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -392,3 +392,23 @@ func removeAnnotation(ctx context.Context, cl client.Client, cr client.Object, k
 	// Differs from removeFinalizer where we overwrite an array.
 	return cl.Patch(ctx, cr, client.RawPatch(types.JSONPatchType, patch))
 }
+
+func mergeReconcileErrors(sources ...map[string]string) map[string]string {
+	merged := make(map[string]string)
+
+	for _, source := range sources {
+		if source == nil {
+			source = make(map[string]string)
+		}
+
+		for k, v := range source {
+			if merged[k] == "" {
+				merged[k] = v
+			} else {
+				merged[k] = fmt.Sprintf("%v; %v", merged[k], v)
+			}
+		}
+	}
+
+	return merged
+}

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -185,6 +185,10 @@ func ReconcilePlugins(ctx context.Context, k8sClient client.Client, scheme *runt
 		return err
 	}
 
+	// Even though model.GetPluginsConfigMap already sets an owner reference, it gets overwritten
+	// when we fetch the actual contents of the ConfigMap using k8sClient, so we need to set it here again
+	controllerutil.SetControllerReference(grafana, pluginsConfigMap, scheme) //nolint:errcheck
+
 	val, err := json.Marshal(plugins.Sanitize())
 	if err != nil {
 		return err

--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -233,6 +233,60 @@ func TestLabelsSatisfyMatchExpressions(t *testing.T) {
 	}
 }
 
+func TestMergeReconcileErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []map[string]string
+		want    map[string]string
+	}{
+		{
+			name: "Merge multiple maps",
+			sources: []map[string]string{
+				{
+					"default-grafana": "error1",
+				},
+				{
+					"default-grafana": "error2",
+				},
+				{
+					"default-grafana2": "error3",
+				},
+			},
+			want: map[string]string{
+				"default-grafana":  "error1; error2",
+				"default-grafana2": "error3",
+			},
+		},
+		{
+			name: "Nil maps are properly handled",
+			sources: []map[string]string{
+				nil,
+				{
+					"default-grafana": "error1",
+				},
+			},
+			want: map[string]string{
+				"default-grafana": "error1",
+			},
+		},
+		{
+			name: "Empty maps are properly handled",
+			sources: []map[string]string{
+				{},
+				{},
+			},
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeReconcileErrors(tt.sources...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 var _ = Describe("GetMatchingInstances functions", Ordered, func() {
 	namespace := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -54,6 +54,8 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafan
 	deployment := model.GetGrafanaDeployment(cr, scheme)
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, deployment, func() error {
 		model.SetInheritedLabels(deployment, cr.Labels)
+		// Prevents overwrites for owner references
+		controllerutil.SetControllerReference(cr, deployment, scheme) //nolint:errcheck
 		deployment.Spec = getDeploymentSpec(cr, deployment.Name, scheme, vars, openshiftPlatform)
 		err := v1beta1.Merge(deployment, cr.Spec.Deployment)
 		return err


### PR DESCRIPTION
# Fix 1

During recent refactoring of dashboard and datasource controllers, a small defect was introduced around re-queuing CRs in case plugin or home dashboard reconciliation fails (e.g. when resource version changed) . - Such errors were only logged, whereas the operator should have re-queued CRs.

I think there's probably no need to introduce additional conditions for those errors like it was suggested in "TODOs". Instead, we can simply join strings containing various errors. In the end, those belong to the same dashboards / datasources, so the contents of the respective conditions would not cause any confusion.

# Fix 2

This part is funny. Prior to #1574, we used `controllerutil.SetOwnerReference` for all resources including Deployments and ConfigMaps. This function doesn't set `controller: true`. After #1574 (part of [v5.10.0](https://github.com/grafana/grafana-operator/releases/tag/v5.10.0)), we use `controllerutil.SetControllerReference` for everything except for PVCs, so all those objects should have `controller: true`.

Grafana controller gets notified when Deployment / ConfigMap change only if those objects have the right owner reference. As part of that requirement, by default, `controller-runtime` (library that we use under the hood), expects `controller` to be set to `true`, other owner references are filtered out.

Even though `controllerutil.SetControllerReference` tries to set `controller: true`, unfortunately, the field gets overwritten in our code for many objects. The PR mitigates this behaviour for plugins ConfigMap and Deployment, but, eventually, we need to fix that for all dependent objects (services, service accounts, etc). It'll be part of a separate PR.

Fixes #1917 