### PR TITLE
Chore(GrafanaLibraryPanel): Implement startup sync and simplify finalize stage

### DIFF
--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -87,6 +87,7 @@ func init() {
 	metrics.Registry.MustRegister(DashboardURLRequests)
 	metrics.Registry.MustRegister(ContentURLRequests)
 	metrics.Registry.MustRegister(InitialDashboardSyncDuration)
+	metrics.Registry.MustRegister(InitialLibraryPanelSyncDuration)
 	metrics.Registry.MustRegister(InitialDatasourceSyncDuration)
 	metrics.Registry.MustRegister(InitialFoldersSyncDuration)
 }

--- a/main.go
+++ b/main.go
@@ -290,7 +290,7 @@ func main() { // nolint:gocyclo
 	if err = (&controllers.GrafanaLibraryPanelReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrafanaLibraryPanel")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Similar to #1897 and #1896, this simplifies the finalize stage by removing the initial GET request to the instances.

This also implements the startup synchronisation for cleaning up Grafana statuses in cases where the library panel CR has been removed.

Unlike other resources, the sync does not attempt to remove the panel from the instance and is not part of the standard reconcile loop.
Due to this, the protection against bombarding a single instance have been removed.

With less logic in the sync function, it was possible to reduce the amount of loops compared to other sync functions.