### PR TITLE
chore(Internal): Refactor deferred status update to share the same function

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // WARN Run `make` on all file changes
@@ -46,9 +47,11 @@ type GrafanaCommonSpec struct {
 // Common Functions that all CRs should implement, excluding Grafana
 // +kubebuilder:object:generate=false
 type CommonResource interface {
+	client.Object
 	MatchLabels() *metav1.LabelSelector
 	MatchNamespace() string
 	AllowCrossNamespace() bool
+	CommonStatus() *GrafanaCommonStatus
 }
 
 // The most recent observed state of a Grafana resource

--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -144,6 +144,8 @@ type GrafanaAlertRuleGroup struct {
 	Status GrafanaCommonStatus       `json:"status,omitempty"`
 }
 
+var _ CommonResource = (*GrafanaAlertRuleGroup)(nil)
+
 // GroupName returns the name of alert rule group.
 func (in *GrafanaAlertRuleGroup) GroupName() string {
 	groupName := in.Spec.Name
@@ -188,6 +190,10 @@ func (in *GrafanaAlertRuleGroup) MatchNamespace() string {
 
 func (in *GrafanaAlertRuleGroup) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
+}
+
+func (in *GrafanaAlertRuleGroup) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status
 }
 
 var _ operatorapi.FolderReferencer = (*GrafanaAlertRuleGroup)(nil)

--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -66,6 +66,8 @@ type GrafanaContactPoint struct {
 	Status GrafanaCommonStatus     `json:"status,omitempty"`
 }
 
+var _ CommonResource = (*GrafanaContactPoint)(nil)
+
 //+kubebuilder:object:root=true
 
 // GrafanaContactPointList contains a list of GrafanaContactPoint
@@ -102,6 +104,10 @@ func (in *GrafanaContactPoint) MatchNamespace() string {
 
 func (in *GrafanaContactPoint) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
+}
+
+func (in *GrafanaContactPoint) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status
 }
 
 func init() {

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -75,6 +75,8 @@ type GrafanaDashboard struct {
 	Status GrafanaDashboardStatus `json:"status,omitempty"`
 }
 
+var _ CommonResource = (*GrafanaDashboard)(nil)
+
 //+kubebuilder:object:root=true
 
 // GrafanaDashboardList contains a list of GrafanaDashboard
@@ -145,6 +147,10 @@ func (in *GrafanaDashboard) MatchNamespace() string {
 
 func (in *GrafanaDashboard) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
+}
+
+func (in *GrafanaDashboard) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status.GrafanaCommonStatus
 }
 
 func init() {

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -110,6 +110,8 @@ type GrafanaDatasource struct {
 	Status GrafanaDatasourceStatus `json:"status,omitempty"`
 }
 
+var _ CommonResource = (*GrafanaDatasource)(nil)
+
 //+kubebuilder:object:root=true
 
 // GrafanaDatasourceList contains a list of GrafanaDatasource
@@ -169,6 +171,10 @@ func (in *GrafanaDatasource) MatchNamespace() string {
 
 func (in *GrafanaDatasource) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
+}
+
+func (in *GrafanaDatasource) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status.GrafanaCommonStatus
 }
 
 func init() {

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -83,6 +83,8 @@ type GrafanaFolder struct {
 	Status GrafanaFolderStatus `json:"status,omitempty"`
 }
 
+var _ CommonResource = (*GrafanaFolder)(nil)
+
 // Conditions implements FolderReferencer.
 func (in *GrafanaFolder) Conditions() *[]metav1.Condition {
 	return &in.Status.Conditions
@@ -174,4 +176,8 @@ func (in *GrafanaFolder) MatchNamespace() string {
 
 func (in *GrafanaFolder) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
+}
+
+func (in *GrafanaFolder) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status.GrafanaCommonStatus
 }

--- a/api/v1beta1/grafanalibrarypanel_types.go
+++ b/api/v1beta1/grafanalibrarypanel_types.go
@@ -47,6 +47,8 @@ type GrafanaLibraryPanel struct {
 	Status GrafanaLibraryPanelStatus `json:"status,omitempty"`
 }
 
+var _ CommonResource = (*GrafanaLibraryPanel)(nil)
+
 //+kubebuilder:object:root=true
 
 // GrafanaLibraryPanelList contains a list of GrafanaLibraryPanel
@@ -96,6 +98,10 @@ func (in *GrafanaLibraryPanel) MatchNamespace() string {
 
 func (in *GrafanaLibraryPanel) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
+}
+
+func (in *GrafanaLibraryPanel) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status.GrafanaCommonStatus
 }
 
 // GrafanaContentSpec implements GrafanaContentResource

--- a/api/v1beta1/grafanamutetiming_types.go
+++ b/api/v1beta1/grafanamutetiming_types.go
@@ -111,6 +111,10 @@ func (in *GrafanaMuteTiming) NamespacedResource() string {
 	return fmt.Sprintf("%v/%v/%v", in.Namespace, in.Name, in.UID)
 }
 
+func (in *GrafanaMuteTiming) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status
+}
+
 //+kubebuilder:object:root=true
 
 // GrafanaMuteTimingList contains a list of GrafanaMuteTiming

--- a/api/v1beta1/grafananotificationpolicy_types.go
+++ b/api/v1beta1/grafananotificationpolicy_types.go
@@ -190,6 +190,8 @@ type GrafanaNotificationPolicy struct {
 	Status GrafanaNotificationPolicyStatus `json:"status,omitempty"`
 }
 
+var _ CommonResource = (*GrafanaNotificationPolicy)(nil)
+
 func (in *GrafanaNotificationPolicy) NamespacedResource() string {
 	return fmt.Sprintf("%v/%v/%v", in.Namespace, in.Name, in.UID)
 }
@@ -213,6 +215,10 @@ func (in *GrafanaNotificationPolicy) MatchNamespace() string {
 
 func (in *GrafanaNotificationPolicy) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
+}
+
+func (in *GrafanaNotificationPolicy) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status.GrafanaCommonStatus
 }
 
 func init() {

--- a/api/v1beta1/grafananotificationtemplate_types.go
+++ b/api/v1beta1/grafananotificationtemplate_types.go
@@ -72,6 +72,10 @@ func (in *GrafanaNotificationTemplate) NamespacedResource() string {
 	return fmt.Sprintf("%v/%v/%v", in.Namespace, in.Name, in.UID)
 }
 
+func (in *GrafanaNotificationTemplate) CommonStatus() *GrafanaCommonStatus {
+	return &in.Status
+}
+
 //+kubebuilder:object:root=true
 
 // GrafanaNotificationTemplateList contains a list of GrafanaNotificationTemplate

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/grafana/grafana-openapi-client-go/client/library_elements"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -139,21 +137,7 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	defer func() {
-		libraryPanel.Status.LastResync = metav1.Time{Time: time.Now()}
-		if err := r.Client.Status().Update(ctx, libraryPanel); err != nil {
-			log.Error(err, "updating status")
-		}
-		if meta.IsStatusConditionTrue(libraryPanel.Status.Conditions, conditionNoMatchingInstance) {
-			if err := removeFinalizer(ctx, r.Client, libraryPanel); err != nil {
-				log.Error(err, "failed to remove finalizer")
-			}
-		} else {
-			if err := addFinalizer(ctx, r.Client, libraryPanel); err != nil {
-				log.Error(err, "failed to set finalizer")
-			}
-		}
-	}()
+	defer UpdateStatus(ctx, r.Client, libraryPanel)
 
 	// begin validation checks
 


### PR DESCRIPTION
Figured out a way to have all CRs defer the same `UpdateStatus` function.
It did require to extend the `GrafanaCommonResource` interface to ensure all CRs had a way to return the `GrafanaCommonStatus`.