### PR TITLE
Chore(Hugo): Remove installation of deprecated dart-sass-embedded in hugo actions

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -30,13 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.134.3
+      DART_SASS_VERSION: 1.86.0
     steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass Embedded
-        run: sudo snap install dart-sass-embedded
+      - name: Install Dart Sass
+        run: |
+          wget -O ${{ runner.temp }}/dart-sass.tar.gz https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64-musl.tar.gz \
+          && tar -xvf ${{ runner.temp }}/dart-sass.tar.gz -C ${{ runner.temp }}/ \
+          && echo "${{ runner.temp }}/dart-sass" >> $GITHUB_PATH
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages

--- a/.github/workflows/pr-hugo.yaml
+++ b/.github/workflows/pr-hugo.yaml
@@ -13,13 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.134.3
+      DART_SASS_VERSION: 1.86.0
     steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass Embedded
-        run: sudo snap install dart-sass-embedded
+      - name: Install Dart Sass
+        run: |
+          wget -O ${{ runner.temp }}/dart-sass.tar.gz https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64-musl.tar.gz \
+          && tar -xvf ${{ runner.temp }}/dart-sass.tar.gz -C ${{ runner.temp }}/ \
+          && echo "${{ runner.temp }}/dart-sass" >> $GITHUB_PATH
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages


### PR DESCRIPTION
[dart-sass-embedded](https://github.com/sass/dart-sass-embedded) The repo has been deprecated as the project was merged into the dart-sass compiler.
Additionally, the step has begun to fail in CI recently due to long snap timeouts.
Hence the installation was changed to install from the Github releases directly.

The initial resolution was to remove the dart-sass installation entirely, but we use a couple of .scss files and likely need it to be available, which did not fail the build?
I checked and `dart-sass` is not available in ubuntu-latest per default, unlike go which is necessary to compile the modules defined in `/hugo/config.yaml`

The output is a bit difficult to compare, but from what I can tell, the only difference is the "last update date" in the HTML tags and other files.
The artifact from [master](https://github.com/grafana/grafana-operator/actions/runs/14403141791) can be compared with the one from this [branch](https://github.com/grafana/grafana-operator/actions/runs/14419404576) where the upload artifact action was added temporarily.