### PR TITLE
chore(api): switch to native error wrapping

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.32.1
 	k8s.io/apiextensions-apiserver v0.32.1
@@ -49,6 +48,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/api/v1beta1/typeoverrides.go
+++ b/api/v1beta1/typeoverrides.go
@@ -2,11 +2,11 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -530,26 +530,26 @@ func Merge(base, overrides interface{}) error {
 
 	baseBytes, err := json.Marshal(base)
 	if err != nil {
-		return errors.Wrap(err, "failed to convert current object to byte sequence")
+		return fmt.Errorf("failed to convert current object to byte sequence: %w", err)
 	}
 
 	overrideBytes, err := json.Marshal(overrides)
 	if err != nil {
-		return errors.Wrap(err, "failed to convert current object to byte sequence")
+		return fmt.Errorf("failed to convert current object to byte sequence: %w", err)
 	}
 
 	patchMeta, err := strategicpatch.NewPatchMetaFromStruct(base)
 	if err != nil {
-		return errors.Wrap(err, "failed to produce patch meta from struct")
+		return fmt.Errorf("failed to produce patch meta from struct: %w", err)
 	}
 	patch, err := strategicpatch.CreateThreeWayMergePatch(overrideBytes, overrideBytes, baseBytes, patchMeta, true)
 	if err != nil {
-		return errors.Wrap(err, "failed to create three way merge patch")
+		return fmt.Errorf("failed to create three way merge patch: %w", err)
 	}
 
 	merged, err := strategicpatch.StrategicMergePatchUsingLookupPatchMeta(baseBytes, patch, patchMeta)
 	if err != nil {
-		return errors.Wrap(err, "failed to apply patch")
+		return fmt.Errorf("failed to apply patch: %w", err)
 	}
 
 	valueOfBase := reflect.Indirect(reflect.ValueOf(base))
@@ -558,7 +558,7 @@ func Merge(base, overrides interface{}) error {
 		return err
 	}
 	if !valueOfBase.CanSet() {
-		return errors.New("unable to set unmarshalled value into base object")
+		return fmt.Errorf("unable to set unmarshalled value into base object")
 	}
 	valueOfBase.Set(reflect.Indirect(into))
 	return nil


### PR DESCRIPTION
api module wraps errors using package `github.com/pkg/errors` that is no longer maintained and is not needed anyway as we can replace it with `fmt`. Thus, the PR.