### PR TITLE
chore(grafana): Slow down exponential backoff retries on errors

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -52,7 +52,7 @@ const (
 // Allow slower initial retry on any failure
 // Significantly slower compared to the default exponential backoff
 func defaultRateLimiter() workqueue.TypedRateLimiter[reconcile.Request] {
-	return workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](RequeueDelay, 12*RequeueDelay)
+	return workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](RequeueDelay, 120*time.Second)
 }
 
 // Only matching instances in the scope of the resource are returned

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -18,11 +18,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -46,6 +48,12 @@ const (
 )
 
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
+
+// Allow slower initial retry on any failure
+// Significantly slower compared to the default exponential backoff
+func defaultRateLimiter() workqueue.TypedRateLimiter[reconcile.Request] {
+	return workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](RequeueDelay, 12*RequeueDelay)
+}
 
 // Only matching instances in the scope of the resource are returned
 // Resources with allowCrossNamespaceImport expands the scope to the entire cluster

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	grafanav1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -91,10 +92,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			grafana.Status.LastMessage = err.Error()
 			grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultFailed
 
-			// requeueDelay is returned instead of an error to prevent bombarding a
-			// single instance with reconciliation retries in quick succession
-			log.Error(err, "failed to get version from external instance")
-			return ctrl.Result{RequeueAfter: RequeueDelay}, nil
+			return ctrl.Result{}, fmt.Errorf("failed to get version from external instance: %w", err)
 		}
 
 		grafana.Status.Version = version
@@ -147,9 +145,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		grafana.Status.LastMessage = err.Error()
 		grafana.Status.StageStatus = grafanav1beta1.OperatorStageResultFailed
 
-		// The same as the external instances above, avoids overloading a single instance
-		log.Error(err, "failed to get version from instance")
-		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
+		return ctrl.Result{}, fmt.Errorf("failed to get version from instance: %w", err)
 	}
 
 	grafana.Status.Version = version
@@ -205,6 +201,7 @@ func (r *GrafanaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&grafanav1beta1.Grafana{}).
 		Owns(&v1.Deployment{}).
 		Owns(&v12.ConfigMap{}).
+		WithOptions(controller.Options{RateLimiter: defaultRateLimiter()}).
 		Complete(r)
 }
 


### PR DESCRIPTION
Tested with an external Grafana with an invalid url.
This extends the base timeout when an error or requeue: true is returned from a reconcile.
```
2025-04-12T13:01:59.167+0200    error   Reconciler error        {"controller": "grafana", "controllerGroup": "grafana.integreatly.org", "controllerKind": "Grafana", "Grafana": {"name":"external-grafana","namespace":"default"}, "namespace": "default", "name": "external-grafana", "reconcileID": "2f962a5a-0278-4382-8175-9f7f425a512d", "error": "failed to get version from external instance: parsing health endpoint data: invalid character '<' looking for beginning of value"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
        /home/ste/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
        /home/ste/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
        /home/ste/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
2025-04-12T13:02:06.729+0200    error   Reconciler error ...
2025-04-12T13:02:44.261+0200    error   Reconciler error ...
2025-04-12T13:03:59.303+0200    error   Reconciler error ...
2025-04-12T13:05:49.373+0200    error   Reconciler error ...
```
This *might* mess with CI timings and may need to be configurable.