### PR TITLE
fix(controllers): prevent label and controller reference overrides

### DIFF
--- a/controllers/model/dashboard_resources.go
+++ b/controllers/model/dashboard_resources.go
@@ -15,7 +15,7 @@ func GetPluginsConfigMap(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-plugins", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	controllerutil.SetControllerReference(cr, config, scheme) //nolint:errcheck

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -13,8 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var CommonLabels = map[string]string{
-	"app.kubernetes.io/managed-by": "grafana-operator",
+func GetCommonLabels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by": "grafana-operator",
+	}
 }
 
 func GetGrafanaConfigMap(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v1.ConfigMap {
@@ -22,7 +24,7 @@ func GetGrafanaConfigMap(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-ini", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	controllerutil.SetControllerReference(cr, config, scheme) //nolint:errcheck
@@ -34,7 +36,7 @@ func GetGrafanaAdminSecret(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-admin-credentials", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 
@@ -49,7 +51,7 @@ func GetGrafanaDataPVC(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v1.P
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-pvc", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	// using OwnerReference specifically here to allow admins to change storage variables without the operator complaining
@@ -62,7 +64,7 @@ func GetGrafanaServiceAccount(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-sa", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	controllerutil.SetControllerReference(cr, sa, scheme) //nolint:errcheck
@@ -74,7 +76,7 @@ func GetGrafanaService(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v1.S
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-service", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	controllerutil.SetControllerReference(cr, service, scheme) //nolint:errcheck
@@ -86,7 +88,7 @@ func GetGrafanaHeadlessService(cr *grafanav1beta1.Grafana, scheme *runtime.Schem
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-alerting", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	controllerutil.SetControllerReference(cr, service, scheme) //nolint:errcheck
@@ -98,7 +100,7 @@ func GetGrafanaIngress(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v12.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-ingress", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	controllerutil.SetControllerReference(cr, ingress, scheme) //nolint:errcheck
@@ -110,7 +112,7 @@ func GetGrafanaRoute(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *routev
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-route", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	controllerutil.SetControllerReference(cr, route, scheme) //nolint:errcheck
@@ -122,7 +124,7 @@ func GetGrafanaDeployment(cr *grafanav1beta1.Grafana, scheme *runtime.Scheme) *v
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-deployment", cr.Name),
 			Namespace: cr.Namespace,
-			Labels:    CommonLabels,
+			Labels:    GetCommonLabels(),
 		},
 	}
 	if scheme != nil {

--- a/controllers/model/utils.go
+++ b/controllers/model/utils.go
@@ -47,7 +47,7 @@ func SetInheritedLabels(obj metav1.ObjectMetaAccessor, extraLabels map[string]st
 		labels[k] = v
 	}
 	// Ensure default CommonLabels for child resources
-	for k, v := range CommonLabels {
+	for k, v := range GetCommonLabels() {
 		labels[k] = v
 	}
 	meta.SetLabels(labels)

--- a/controllers/reconcilers/grafana/plugins_reconciler.go
+++ b/controllers/reconcilers/grafana/plugins_reconciler.go
@@ -30,7 +30,15 @@ func (r *PluginsReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 
 	plugins := model.GetPluginsConfigMap(cr, scheme)
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, plugins, func() error {
+		if scheme != nil {
+			err := controllerutil.SetOwnerReference(cr, plugins, scheme)
+			if err != nil {
+				return err
+			}
+		}
+
 		model.SetInheritedLabels(plugins, cr.Labels)
+
 		return nil
 	})
 	if err != nil {

--- a/controllers/reconcilers/grafana/service_account_reconciler.go
+++ b/controllers/reconcilers/grafana/service_account_reconciler.go
@@ -25,8 +25,21 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, cr *v1beta1.Gr
 	sa := model.GetGrafanaServiceAccount(cr, scheme)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, sa, func() error {
+		err := v1beta1.Merge(sa, cr.Spec.ServiceAccount)
+		if err != nil {
+			return err
+		}
+
+		if scheme != nil {
+			err = controllerutil.SetControllerReference(cr, sa, scheme)
+			if err != nil {
+				return err
+			}
+		}
+
 		model.SetInheritedLabels(sa, cr.Labels)
-		return v1beta1.Merge(sa, cr.Spec.ServiceAccount)
+
+		return nil
 	})
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err

--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func main() { // nolint:gocyclo
 			setupLog.Info(fmt.Sprintf("sharding is enabled via %s=%s. Beware: Always label Grafana CRs before enabling to ensure labels are inherited. Existing Secrets/ConfigMaps referenced in CRs also need to be labeled to continue working.", watchLabelSelectorsEnvVar, watchLabelSelectors))
 		} else {
 			// Otherwise limit it to managed-by label
-			cacheLabelConfig = cache.ByObject{Label: labels.SelectorFromSet(model.CommonLabels)}
+			cacheLabelConfig = cache.ByObject{Label: labels.SelectorFromSet(model.GetCommonLabels())}
 		}
 
 		// ConfigMaps and secrets stay fully cached until we implement support for bypassing the cache for referenced objects
@@ -412,7 +412,7 @@ func getLabelSelectors(watchLabelSelectors string) (labels.Selector, error) {
 	} else {
 		labelSelectors = labels.Everything() // Match any labels
 	}
-	managedByLabelSelector, _ := labels.SelectorFromSet(model.CommonLabels).Requirements()
+	managedByLabelSelector, _ := labels.SelectorFromSet(model.GetCommonLabels()).Requirements()
 	labelSelectors.Add(managedByLabelSelector...)
 	return labelSelectors, nil
 }


### PR DESCRIPTION
As it was described in #1959, it's currently possible to override the label that we use for cache tuning. Bitnami's chart (not supported by us) has the bug, which breaks visibility of PVCs.

It would make sense to prohibit such overrides, thus the PR.

Extra changes:
- switch from `var CommonLabels` to `GetCommonLabels()` to make code more idiomatic (`CommonLabels` was meant to behave like a `const`);
- prevent controller overrides for other child resources, similar to #1932.

Fixes: #1959