### PR TITLE
fix(Makefile): properly set new image in deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd deploy/kustomize/overlays/cluster_scoped && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd deploy/kustomize/overlays/cluster_scoped && $(KUSTOMIZE) edit set image ghcr.io/grafana/grafana-operator=${IMG}
 	$(KUSTOMIZE) build deploy/kustomize/overlays/cluster_scoped | kubectl apply --server-side --force-conflicts -f -
 
 .PHONY: deploy-chainsaw


### PR DESCRIPTION
In #1949, we switched from `config/manager` to `deploy/kustomize/overlays/cluster_scoped`, but did not update `kustomize edit set image` step. As a result, no overrides were happening meaning `make deploy` would always deploy the version that is set in `base/deployment.yaml`.

The PR fixes the behavior.