### PR TITLE
chore(labeler): Remove `refactor` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,10 +10,7 @@ bugfix:
  - head-branch: ['^fix', 'fix', '^bugfix']
 
 chore:
- - head-branch: ['^chore', '^ci']
-
-refactor:
- - head-branch: ['^refactor']
+ - head-branch: ['^chore', '^ci', ^refactor]
 
 test:
  - head-branch: ['^test']


### PR DESCRIPTION
As discussed in the weekly, we do not use the refactor label.
When this is merged we can [remove/replace the refactor label](https://github.com/grafana/grafana-operator/issues?q=label%3Arefactor%20state%3Aclosed)