### PR TITLE
ci: decouple ghcr and quay image publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,13 +167,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Quay.io
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: "go.mod"
@@ -188,30 +181,42 @@ jobs:
         with:
           cosign-release: "v2.2.2"
 
-      - name: Prepare
-        run: |
-          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
-          echo "REPOS"="quay.io/grafana-operator/grafana-operator" "ghcr.io/${{ github.repository }}" >> $GITHUB_ENV
-
       - name: Build and push
         env:
           IMAGE_VERSION: ${{ github.ref_name }}
+          KO_DOCKER_REPO: "ghcr.io/${{ github.repository }}"
         run: |
-          for i in ${{ env.REPOS }}
-          do
-            export KO_DOCKER_REPO=${i}
-            ko build --sbom=spdx --image-refs ./image-digest-${i%.*} --bare --platform linux/arm64,linux/arm/v7,linux/amd64,linux/ppc64le -t ${IMAGE_VERSION} \
+          ko build --sbom=spdx --image-refs ./image-digest --bare --platform linux/arm64,linux/arm/v7,linux/amd64,linux/ppc64le -t ${IMAGE_VERSION} \
             --image-label org.opencontainers.image.title=grafana-operator \
             --image-label org.opencontainers.image.description="An operator for Grafana that installs and manages Grafana instances & Dashboards & Datasources through Kubernetes/OpenShift CRs" \
             --image-label org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }} \
             --image-label org.opencontainers.image.revision=${{ github.sha }} \
             --image-label org.opencontainers.image.version=${IMAGE_VERSION} \
-            --image-label org.opencontainers.image.created=${{ env.BUILD_DATE }}
-          done
+            --image-label org.opencontainers.image.created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
       - name: Sign Image
         run: |
-          for i in ${{ env.REPOS }}
-          do
-            cosign sign -d -y $(cat ./image-digest-${i%.*})
-          done
+          cosign sign -d -y $(cat ./image-digest)
+
+  distribute-to-quay:
+    runs-on: ubuntu-latest
+    needs:
+      - image
+    permissions:
+      packages: read
+    steps:
+      - name: Copy image to quay
+        env:
+          IMAGE_VERSION: ${{ github.ref_name }}
+          DOCKER_REPO: "ghcr.io/${{ github.repository }}"
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          docker run -it --rm quay.io/containers/skopeo:v1.18.0 \
+            copy --multi-arch all \
+            --source-creds "$GHCR_USERNAME:$GHCR_PASSWORD" \
+            --dest-creds "$QUAY_USERNAME:$QUAY_PASSWORD" \
+            docker://${DOCKER_REPO}:${IMAGE_VERSION} \
+            docker://quay.io/grafana-operator/grafana-operator:${IMAGE_VERSION}


### PR DESCRIPTION
Decouple the push process per registry to make sure we're not blocked when quay is down