### PR TITLE
ci: Stabilize E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,10 +5,6 @@ on:
     branches: [master]
   merge_group:
 
-env:
-  NAME: grafana-operator
-  NAMESPACE: grafana-operator-system
-
 permissions:
   contents: read
 
@@ -101,11 +97,13 @@ jobs:
 
       - name: Debug failure
         if: failure()
+        env:
+          NAMESPACE: default
         run: |
           set -e
           kubectl version
-          kubectl -n $NAMESPACE get all
-          kubectl -n $NAMESPACE get grafana
+          kubectl get all -A
+          kubectl get grafanas -A
           kubectl get crd
           POD=$(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/name=grafana-operator --output='jsonpath={.items[].metadata.name}')
           echo "pod logs"

--- a/tests/e2e/example-test/08-alert-folder.yaml
+++ b/tests/e2e/example-test/08-alert-folder.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     folder: "test-folder"
 spec:
+  resyncPeriod: 30s
   instanceSelector:
     matchLabels:
       dashboards: "grafana"

--- a/tests/e2e/example-test/08-alert-folder.yaml
+++ b/tests/e2e/example-test/08-alert-folder.yaml
@@ -1,0 +1,10 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: test-folder-from-operator
+  labels:
+    folder: "test-folder"
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"

--- a/tests/e2e/example-test/08-alert-rule-group.yaml
+++ b/tests/e2e/example-test/08-alert-rule-group.yaml
@@ -1,13 +1,3 @@
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaFolder
-metadata:
-  name: test-folder-from-operator
-  labels:
-    folder: "test-folder"
-spec:
-  instanceSelector:
-    matchLabels:
-      dashboards: "grafana"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaAlertRuleGroup

--- a/tests/e2e/example-test/08-folder-assert.yaml
+++ b/tests/e2e/example-test/08-folder-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: test-folder-from-operator
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: FolderSynchronized

--- a/tests/e2e/example-test/10-assert-contact-points.yaml
+++ b/tests/e2e/example-test/10-assert-contact-points.yaml
@@ -1,0 +1,19 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: first-test
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: ContactPointSynchronized
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: second-test
+status:
+  conditions:
+  - reason: ApplySuccessful
+    status: "True"
+    type: ContactPointSynchronized

--- a/tests/e2e/example-test/10-contact-points.yaml
+++ b/tests/e2e/example-test/10-contact-points.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   name: first-test
   type: "email"
+  resyncPeriod: 30s
   instanceSelector:
     matchLabels:
       dashboards: "grafana"
@@ -18,6 +19,7 @@ metadata:
 spec:
   name: second-test
   type: "email"
+  resyncPeriod: 30s
   instanceSelector:
     matchLabels:
       dashboards: "grafana"

--- a/tests/e2e/example-test/10-contact-points.yaml
+++ b/tests/e2e/example-test/10-contact-points.yaml
@@ -1,0 +1,25 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: first-test
+spec:
+  name: first-test
+  type: "email"
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  settings:
+    addresses: "email@email.com"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaContactPoint
+metadata:
+  name: second-test
+spec:
+  name: second-test
+  type: "email"
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  settings:
+    addresses: "email@email.com"

--- a/tests/e2e/example-test/10-notification-policy.yaml
+++ b/tests/e2e/example-test/10-notification-policy.yaml
@@ -1,28 +1,3 @@
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaContactPoint
-metadata:
-  name: first-test
-spec:
-  name: first-test
-  type: "email"
-  instanceSelector:
-    matchLabels:
-      dashboards: "grafana"
-  settings:
-    addresses: "email@email.com"
----
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaContactPoint
-metadata:
-  name: second-test
-spec:
-  name: second-test
-  type: "email"
-  instanceSelector:
-    matchLabels:
-      dashboards: "grafana"
-  settings:
-    addresses: "email@email.com"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaNotificationPolicy

--- a/tests/e2e/example-test/chainsaw-test.yaml
+++ b/tests/e2e/example-test/chainsaw-test.yaml
@@ -75,6 +75,10 @@ spec:
   - name: step-10
     try:
     - apply:
+        file: 10-contact-points.yaml
+    - assert:
+        file: 10-assert-contact-points.yaml
+    - apply:
         file: 10-notification-policy.yaml
     - assert:
         file: 10-assert.yaml

--- a/tests/e2e/example-test/chainsaw-test.yaml
+++ b/tests/e2e/example-test/chainsaw-test.yaml
@@ -59,6 +59,10 @@ spec:
   - name: step-08
     try:
     - apply:
+        file: 08-alert-folder.yaml
+    - assert:
+        file: 08-folder-assert.yaml
+    - apply:
         file: 08-alert-rule-group.yaml
     - assert:
         file: 08-assert.yaml


### PR DESCRIPTION
I noticed that it is largely the same two E2E `example-test`s  that are unstable.
Isolating requisite resources and lowering their `resyncPeriod` should allow more reconcile attempts which seems to have lowered CI failures in my testing.