### PR TITLE
chore(grafana controller): Ignore status updates on Grafanas and Deployments

### DIFF
--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -26,12 +26,13 @@ import (
 	"github.com/grafana/grafana-operator/v5/controllers/metrics"
 	"github.com/grafana/grafana-operator/v5/controllers/reconcilers"
 	"github.com/grafana/grafana-operator/v5/controllers/reconcilers/grafana"
-	v1 "k8s.io/api/apps/v1"
-	v12 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -136,9 +137,9 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *GrafanaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&grafanav1beta1.Grafana{}).
-		Owns(&v1.Deployment{}).
-		Owns(&v12.ConfigMap{}).
+		For(&grafanav1beta1.Grafana{}, builder.WithPredicates(ignoreStatusUpdates())).
+		Owns(&appsv1.Deployment{}, builder.WithPredicates(ignoreStatusUpdates())).
+		Owns(&corev1.ConfigMap{}).
 		WithOptions(controller.Options{RateLimiter: defaultRateLimiter()}).
 		Complete(r)
 }


### PR DESCRIPTION
Should be the last controller that needs the `ignoreStatusUpdates` filter to finally close #1220 

It has previously been attempted to ignore status updates in #1901.
But using the `WithEventFilter` options filters events for Owned resources as well, even if they do not have the `.metadata.generation` field.
See #1931

Using the examples: grafana_deployment and plugins.
Any change to either of:
- `grafanadashboard/keycloak-dashboard#spec.plugins`
- `grafanadatasource/example-grafanadatasource#spec.plugins`

Is reflected in the `cm/grafana-plugins` and triggers an update to `deploy/grafana-deployment`
Unlike the previous attempt.