### PR TITLE
chore(AdminSecret): Remove unnecessary env variables

### DIFF
--- a/controllers/reconcilers/grafana/admin_secret_reconciler.go
+++ b/controllers/reconcilers/grafana/admin_secret_reconciler.go
@@ -2,7 +2,6 @@ package grafana
 
 import (
 	"context"
-	"os"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers/config"
@@ -79,11 +78,6 @@ func getData(cr *v1beta1.Grafana, current *v1.Secret) map[string][]byte {
 		config.GrafanaAdminUserEnvVar:     getAdminUser(cr, current),
 		config.GrafanaAdminPasswordEnvVar: getAdminPassword(cr, current),
 	}
-
-	// Make the credentials available to the environment when running the operator
-	// outside of the cluster
-	os.Setenv(config.GrafanaAdminUserEnvVar, string(credentials[config.GrafanaAdminUserEnvVar]))
-	os.Setenv(config.GrafanaAdminPasswordEnvVar, string(credentials[config.GrafanaAdminPasswordEnvVar]))
 
 	return credentials
 }


### PR DESCRIPTION
Was looking at some lints and I discovered these two lines.

I simply could not figure out where and how they were used.
Nowhere else are we reading the variables and removing them still allows the operator to function when using `make run`
Apparently they were introduced back at the beginning of V5 8bed473923b59388228d19dc2836a5f7e25b9344