### PR TITLE
chore(Makefile): pin dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: yq controller-gen kustomize ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: $(KUSTOMIZE) yq controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=config/crd/bases
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=deploy/helm/grafana-operator/crds
 	$(YQ) -i '(select(.kind == "Deployment") | .spec.template.spec.containers[0].env[] | select (.name == "RELATED_IMAGE_GRAFANA")).value="$(GRAFANA_IMAGE):$(GRAFANA_VERSION)"' config/manager/manager.yaml
@@ -109,24 +109,24 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+install: $(KUSTOMIZE) manifests ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl replace --force=true -f -
 
 .PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+uninstall: $(KUSTOMIZE) manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: $(KUSTOMIZE) manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd deploy/kustomize/overlays/cluster_scoped && $(KUSTOMIZE) edit set image ghcr.io/grafana/grafana-operator=${IMG}
 	$(KUSTOMIZE) build deploy/kustomize/overlays/cluster_scoped | kubectl apply --server-side --force-conflicts -f -
 
 .PHONY: deploy-chainsaw
-deploy-chainsaw: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy-chainsaw: $(KUSTOMIZE) manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build deploy/kustomize/overlays/chainsaw | kubectl apply --server-side --force-conflicts -f -
 
 .PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+undeploy: $(KUSTOMIZE) ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: start-kind
@@ -143,7 +143,6 @@ $(LOCALBIN):
 
 ## Tool Binaries
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 YQ = $(LOCALBIN)/yq
@@ -153,19 +152,12 @@ KIND = $(LOCALBIN)/kind
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.32.0
-KUSTOMIZE_VERSION ?= v5.1.1
 CONTROLLER_TOOLS_VERSION ?= v0.16.3
 OPM_VERSION ?= v1.23.2
 YQ_VERSION ?= v4.35.2
 KO_VERSION ?= v0.16.0
 KIND_VERSION ?= v0.27.0
 CHAINSAW_VERSION ?= v0.2.10
-
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -247,7 +239,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 .PHONY: bundle
-bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+bundle: $(KUSTOMIZE) manifests operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	./hack/add-openshift-annotations.sh

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ manifests: $(CONTROLLER_GEN) $(KUSTOMIZE) $(YQ) ## Generate WebhookConfiguration
 	cat config/rbac/role.yaml | $(YQ) -r 'del(.rules[] | select (.apiGroups | contains(["route.openshift.io"]) | not))'  > deploy/helm/grafana-operator/files/rbac-openshift.yaml
 
 # Generate API reference documentation
-api-docs: manifests gen-crd-api-reference-docs
-	$(API_REF_GEN) crdoc --resources config/crd/bases --output docs/docs/api.md --template hugo/templates/frontmatter-grafana-operator.tmpl
+api-docs: $(CRDOC) manifests
+	$(CRDOC) crdoc --resources config/crd/bases --output docs/docs/api.md --template hugo/templates/frontmatter-grafana-operator.tmpl
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -295,22 +295,6 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	docker push $(CATALOG_IMG)
-
-# Find or download gen-crd-api-reference-docs
-gen-crd-api-reference-docs:
-ifeq (, $(shell which crdoc))
-	@{ \
-	set -e ;\
-	API_REF_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$API_REF_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go install fybrik.io/crdoc@ad5ba1e62f8db46cb5a9282dfedfc3d8f3d45065 ;\
-	rm -rf $$API_REF_GEN_TMP_DIR ;\
-	}
-API_REF_GEN=$(GOBIN)/crdoc
-else
-API_REF_GEN=$(shell which crdoc)
-endif
 
 .PHONY: prep-release
 prep-release: $(YQ)

--- a/Makefile
+++ b/Makefile
@@ -134,13 +134,6 @@ start-kind: $(KIND) ## Start kind cluster locally
 	KIND=$(KIND) @hack/kind/start-kind.sh
 	KIND=$(KIND) @hack/kind/populate-kind-cluster.sh
 
-##@ Build Dependencies
-
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
-
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,6 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPM_VERSION ?= v1.23.2
-CHAINSAW_VERSION ?= v0.2.10
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
@@ -196,20 +195,8 @@ e2e-kind: $(KIND)
 e2e-local-gh-actions: e2e-kind ko-build-kind e2e
 
 .PHONY: e2e
-e2e: chainsaw install deploy-chainsaw ## Run e2e tests using chainsaw.
+e2e: $(CHAINSAW) install deploy-chainsaw ## Run e2e tests using chainsaw.
 	$(CHAINSAW) test --test-dir ./tests/e2e/$(TESTS)
-
-# Find or download chainsaw
-chainsaw:
-ifeq (, $(shell which chainsaw))
-	@{ \
-	set -e ;\
-	go install github.com/kyverno/chainsaw@$(CHAINSAW_VERSION) ;\
-	}
-CHAINSAW=$(GOBIN)/chainsaw
-else
-CHAINSAW=$(shell which chainsaw)
-endif
 
 .PHONY: code/golangci-lint
 ifndef GITHUB_ACTIONS # Inside GitHub Actions, we run golangci-lint in a separate step

--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,6 @@ $(LOCALBIN):
 ## Tool Binaries
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
-## Tool Versions
-# Set the Operator SDK version to use. By default, what is installed on the system is used.
-# This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPM_VERSION ?= v1.23.2
-
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
@@ -231,23 +226,6 @@ bundle-build: ## Build the bundle image.
 bundle-push: ## Push the bundle image.
 	docker push $(BUNDLE_IMG)
 
-.PHONY: opm
-OPM = ./bin/opm
-opm: ## Download opm locally if necessary.
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
-	chmod +x $(OPM) ;\
-	}
-else
-OPM = $(shell which opm)
-endif
-endif
-
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
@@ -264,7 +242,7 @@ endif
 # This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
+catalog-build: $(OPM) ## Build a catalog image.
 	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ YQ = $(LOCALBIN)/yq
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPM_VERSION ?= v1.23.2
 YQ_VERSION ?= v4.35.2
-KO_VERSION ?= v0.16.0
 CHAINSAW_VERSION ?= v0.2.10
 
 .PHONY: envtest
@@ -237,23 +236,12 @@ code/golangci-lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run --allow-parallel-runners ./...
 endif
 
-ko:
-ifeq (, $(shell which ko))
-	@{ \
-	set -e ;\
-	go install github.com/google/ko@${KO_VERSION} ;\
-	}
-KO=$(GOBIN)/ko
-else
-KO=$(shell which ko)
-endif
-
 export KO_DOCKER_REPO ?= ko.local/grafana/grafana-operator
 export KIND_CLUSTER_NAME ?= kind-grafana
 export KUBECONFIG        ?= ${HOME}/.kube/kind-grafana-operator
 
 .PHONY: ko-build-local
-ko-build-local: ko ## Build Docker image with KO
+ko-build-local: $(KO) ## Build Docker image with KO
 	$(KO) build --sbom=none --bare
 
 .PHONY: ko-build-kind

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate code/golangci-lint api-docs vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+test: $(ENVTEST) manifests generate code/golangci-lint api-docs vet ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 
@@ -140,14 +140,6 @@ start-kind: $(KIND) ## Start kind cluster locally
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
-
-## Tool Binaries
-ENVTEST ?= $(LOCALBIN)/setup-envtest
-
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
-$(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -217,19 +217,8 @@ ko-build-local: $(KO) ## Build Docker image with KO
 ko-build-kind: $(KIND) ko-build-local ## Build and Load Docker image into kind cluster
 	$(KIND) load docker-image $(KO_DOCKER_REPO) --name $(KIND_CLUSTER_NAME)
 
-helm-docs:
-ifeq (, $(shell which helm-docs))
-	@{ \
-	set -e ;\
-	go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0 ;\
-	}
-HELM_DOCS=$(GOBIN)/helm-docs
-else
-HELM_DOCS=$(shell which helm-docs)
-endif
-
 .PHONY: helm/docs
-helm/docs: helm-docs
+helm/docs: $(HELM_DOCS)
 	$(HELM_DOCS)
 
 BUNDLE_IMG ?= $(REGISTRY)/$(ORG)/grafana-operator-bundle:v$(VERSION)

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -1,0 +1,17 @@
+BIN = $(CURDIR)/bin
+$(BIN):
+	mkdir -p $(BIN)
+
+PATH := $(BIN):$(PATH)
+
+GOLANGCI_LINT_VERSION = v2.1.6
+
+GOLANGCI_LINT := $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+$(GOLANGCI_LINT):
+ifeq (, $(shell which $(GOLANGCI_LINT)))
+	@{ \
+	set -e ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s $(GOLANGCI_LINT_VERSION) ;\
+	mv $(BIN)/golangci-lint $(GOLANGCI_LINT) ;\
+	}
+endif

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -7,6 +7,7 @@ PATH := $(BIN):$(PATH)
 CONTROLLER_GEN_VERSION = v0.16.3
 GOLANGCI_LINT_VERSION = v2.1.6
 KIND_VERSION = v0.27.0
+KO_VERSION = v0.16.0
 KUSTOMIZE_VERSION = v5.1.1
 OPERATOR_SDK_VERSION = v1.32.0
 
@@ -57,5 +58,14 @@ ifeq (, $(shell which $(CONTROLLER_GEN)))
 	@{ \
 	GOBIN=$(BIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION) ;\
 	mv $(BIN)/controller-gen $(CONTROLLER_GEN) ;\
+	}
+endif
+
+KO := $(BIN)/ko-$(KO_VERSION)
+$(KO): $(BIN)
+ifeq (, $(shell which $(KO)))
+	@{ \
+	GOBIN=$(BIN) go install github.com/google/ko@$(KO_VERSION) ;\
+	mv $(BIN)/ko $(KO) ;\
 	}
 endif

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -17,59 +17,6 @@ OPERATOR_SDK_VERSION = v1.32.0
 OPM_VERSION = v1.23.2
 YQ_VERSION = v4.35.2
 
-GOLANGCI_LINT := $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
-$(GOLANGCI_LINT): $(BIN)
-ifeq (, $(shell which $(GOLANGCI_LINT)))
-	@{ \
-	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s $(GOLANGCI_LINT_VERSION) ;\
-	mv $(BIN)/golangci-lint $(GOLANGCI_LINT) ;\
-	}
-endif
-
-KUSTOMIZE := $(BIN)/kustomize-$(KUSTOMIZE_VERSION)
-$(KUSTOMIZE): $(BIN)
-ifeq (, $(shell which $(KUSTOMIZE)))
-	@{ \
-	set -e ;\
-	curl -sSfL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(BIN) ;\
-	mv $(BIN)/kustomize $(KUSTOMIZE) ;\
-	}
-endif
-
-OPERATOR_SDK := $(BIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
-$(OPERATOR_SDK): $(BIN)
-ifeq (, $(shell which $(OPERATOR_SDK)))
-	@{ \
-	set -e ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
-	chmod +x $(OPERATOR_SDK);\
-	}
-endif
-
-OPM := $(BIN)/opm-$(OPM_VERSION)
-$(OPM): $(BIN)
-ifeq (, $(shell which $(OPM)))
-	@{ \
-	set -e ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
-	chmod +x $(OPM) ;\
-	}
-endif
-
-KIND := $(BIN)/kind-$(KIND_VERSION)
-$(KIND): $(BIN)
-ifeq (, $(shell which $(KIND)))
-	@{ \
-	set -e ;\
-	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$${OSTYPE}-$${ARCH} ;\
-	chmod +x $(KIND) ;\
-	}
-endif
-
 CHAINSAW := $(BIN)/chainsaw-$(CHAINSAW_VERSION)
 $(CHAINSAW): $(BIN)
 ifeq (, $(shell which $(CHAINSAW)))
@@ -110,6 +57,16 @@ ifeq (, $(shell which $(ENVTEST)))
 	}
 endif
 
+GOLANGCI_LINT := $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+$(GOLANGCI_LINT): $(BIN)
+ifeq (, $(shell which $(GOLANGCI_LINT)))
+	@{ \
+	set -e ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s $(GOLANGCI_LINT_VERSION) ;\
+	mv $(BIN)/golangci-lint $(GOLANGCI_LINT) ;\
+	}
+endif
+
 HELM_DOCS := $(BIN)/helm-docs-$(HELM_DOCS_VERSION)
 $(HELM_DOCS): $(BIN)
 ifeq (, $(shell which $(HELM_DOCS)))
@@ -120,6 +77,17 @@ ifeq (, $(shell which $(HELM_DOCS)))
 	}
 endif
 
+KIND := $(BIN)/kind-$(KIND_VERSION)
+$(KIND): $(BIN)
+ifeq (, $(shell which $(KIND)))
+	@{ \
+	set -e ;\
+	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$${OSTYPE}-$${ARCH} ;\
+	chmod +x $(KIND) ;\
+	}
+endif
+
 KO := $(BIN)/ko-$(KO_VERSION)
 $(KO): $(BIN)
 ifeq (, $(shell which $(KO)))
@@ -127,6 +95,38 @@ ifeq (, $(shell which $(KO)))
 	set -e ;\
 	GOBIN=$(BIN) go install github.com/google/ko@$(KO_VERSION) ;\
 	mv $(BIN)/ko $(KO) ;\
+	}
+endif
+
+KUSTOMIZE := $(BIN)/kustomize-$(KUSTOMIZE_VERSION)
+$(KUSTOMIZE): $(BIN)
+ifeq (, $(shell which $(KUSTOMIZE)))
+	@{ \
+	set -e ;\
+	curl -sSfL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(BIN) ;\
+	mv $(BIN)/kustomize $(KUSTOMIZE) ;\
+	}
+endif
+
+OPERATOR_SDK := $(BIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
+$(OPERATOR_SDK): $(BIN)
+ifeq (, $(shell which $(OPERATOR_SDK)))
+	@{ \
+	set -e ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+	chmod +x $(OPERATOR_SDK);\
+	}
+endif
+
+OPM := $(BIN)/opm-$(OPM_VERSION)
+$(OPM): $(BIN)
+ifeq (, $(shell which $(OPM)))
+	@{ \
+	set -e ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
+	chmod +x $(OPM) ;\
 	}
 endif
 

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -4,6 +4,7 @@ $(BIN):
 
 PATH := $(BIN):$(PATH)
 
+CHAINSAW_VERSION = v0.2.10
 CONTROLLER_GEN_VERSION = v0.16.3
 CRDOC_VERSION = v0.6.4
 GOLANGCI_LINT_VERSION = v2.1.6
@@ -51,6 +52,15 @@ ifeq (, $(shell which $(KIND)))
 	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$${OSTYPE}-$${ARCH} ;\
 	chmod +x $(KIND) ;\
+	}
+endif
+
+CHAINSAW := $(BIN)/chainsaw-$(CHAINSAW_VERSION)
+$(CHAINSAW): $(BIN)
+ifeq (, $(shell which $(CHAINSAW)))
+	@{ \
+	GOBIN=$(BIN) go install github.com/kyverno/chainsaw@$(CHAINSAW_VERSION) ;\
+	mv $(BIN)/chainsaw $(CHAINSAW) ;\
 	}
 endif
 

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -4,6 +4,7 @@ $(BIN):
 
 PATH := $(BIN):$(PATH)
 
+CONTROLLER_GEN_VERSION = v0.16.3
 GOLANGCI_LINT_VERSION = v2.1.6
 KIND_VERSION = v0.27.0
 KUSTOMIZE_VERSION = v5.1.1
@@ -47,5 +48,14 @@ ifeq (, $(shell which $(KIND)))
 	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$${OSTYPE}-$${ARCH} ;\
 	chmod +x $(KIND) ;\
+	}
+endif
+
+CONTROLLER_GEN := $(BIN)/controller-gen-$(CONTROLLER_GEN_VERSION)
+$(CONTROLLER_GEN): $(BIN)
+ifeq (, $(shell which $(CONTROLLER_GEN)))
+	@{ \
+	GOBIN=$(BIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION) ;\
+	mv $(BIN)/controller-gen $(CONTROLLER_GEN) ;\
 	}
 endif

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -5,6 +5,7 @@ $(BIN):
 PATH := $(BIN):$(PATH)
 
 GOLANGCI_LINT_VERSION = v2.1.6
+KIND_VERSION = v0.27.0
 KUSTOMIZE_VERSION = v5.1.1
 OPERATOR_SDK_VERSION = v1.32.0
 
@@ -36,5 +37,15 @@ ifeq (, $(shell which $(OPERATOR_SDK)))
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK);\
+	}
+endif
+
+KIND := $(BIN)/kind-$(KIND_VERSION)
+$(KIND): $(BIN)
+ifeq (, $(shell which $(KIND)))
+	@{ \
+	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$${OSTYPE}-$${ARCH} ;\
+	chmod +x $(KIND) ;\
 	}
 endif

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -6,9 +6,10 @@ PATH := $(BIN):$(PATH)
 
 GOLANGCI_LINT_VERSION = v2.1.6
 KUSTOMIZE_VERSION = v5.1.1
+OPERATOR_SDK_VERSION = v1.32.0
 
 GOLANGCI_LINT := $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
-$(GOLANGCI_LINT):
+$(GOLANGCI_LINT): $(BIN)
 ifeq (, $(shell which $(GOLANGCI_LINT)))
 	@{ \
 	set -e ;\
@@ -18,11 +19,22 @@ ifeq (, $(shell which $(GOLANGCI_LINT)))
 endif
 
 KUSTOMIZE := $(BIN)/kustomize-$(KUSTOMIZE_VERSION)
-$(KUSTOMIZE):
+$(KUSTOMIZE): $(BIN)
 ifeq (, $(shell which $(KUSTOMIZE)))
 	@{ \
 	set -e ;\
 	curl -sSfL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(BIN) ;\
 	mv $(BIN)/kustomize $(KUSTOMIZE) ;\
+	}
+endif
+
+OPERATOR_SDK := $(BIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
+$(OPERATOR_SDK): $(BIN)
+ifeq (, $(shell which $(OPERATOR_SDK)))
+	@{ \
+	set -e ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+	chmod +x $(OPERATOR_SDK);\
 	}
 endif

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -52,6 +52,7 @@ OPM := $(BIN)/opm-$(OPM_VERSION)
 $(OPM): $(BIN)
 ifeq (, $(shell which $(OPM)))
 	@{ \
+	set -e ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
@@ -62,6 +63,7 @@ KIND := $(BIN)/kind-$(KIND_VERSION)
 $(KIND): $(BIN)
 ifeq (, $(shell which $(KIND)))
 	@{ \
+	set -e ;\
 	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(KIND) https://github.com/kubernetes-sigs/kind/releases/download/$(KIND_VERSION)/kind-$${OSTYPE}-$${ARCH} ;\
 	chmod +x $(KIND) ;\
@@ -72,6 +74,7 @@ CHAINSAW := $(BIN)/chainsaw-$(CHAINSAW_VERSION)
 $(CHAINSAW): $(BIN)
 ifeq (, $(shell which $(CHAINSAW)))
 	@{ \
+	set -e ;\
 	GOBIN=$(BIN) go install github.com/kyverno/chainsaw@$(CHAINSAW_VERSION) ;\
 	mv $(BIN)/chainsaw $(CHAINSAW) ;\
 	}
@@ -81,6 +84,7 @@ CONTROLLER_GEN := $(BIN)/controller-gen-$(CONTROLLER_GEN_VERSION)
 $(CONTROLLER_GEN): $(BIN)
 ifeq (, $(shell which $(CONTROLLER_GEN)))
 	@{ \
+	set -e ;\
 	GOBIN=$(BIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION) ;\
 	mv $(BIN)/controller-gen $(CONTROLLER_GEN) ;\
 	}
@@ -90,6 +94,7 @@ CRDOC := $(BIN)/crdoc-$(CRDOC_VERSION)
 $(CRDOC): $(BIN)
 ifeq (, $(shell which $(CRDOC)))
 	@{ \
+	set -e ;\
 	GOBIN=$(BIN) go install fybrik.io/crdoc@$(CRDOC_VERSION) ;\
 	mv $(BIN)/crdoc $(CRDOC) ;\
 	}
@@ -109,6 +114,7 @@ HELM_DOCS := $(BIN)/helm-docs-$(HELM_DOCS_VERSION)
 $(HELM_DOCS): $(BIN)
 ifeq (, $(shell which $(HELM_DOCS)))
 	@{ \
+	set -e ;\
 	GOBIN=$(BIN) go install github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION) ;\
 	mv $(BIN)/helm-docs $(HELM_DOCS) ;\
 	}
@@ -118,6 +124,7 @@ KO := $(BIN)/ko-$(KO_VERSION)
 $(KO): $(BIN)
 ifeq (, $(shell which $(KO)))
 	@{ \
+	set -e ;\
 	GOBIN=$(BIN) go install github.com/google/ko@$(KO_VERSION) ;\
 	mv $(BIN)/ko $(KO) ;\
 	}

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -8,6 +8,7 @@ CHAINSAW_VERSION = v0.2.10
 CONTROLLER_GEN_VERSION = v0.16.3
 CRDOC_VERSION = v0.6.4
 GOLANGCI_LINT_VERSION = v2.1.6
+HELM_DOCS_VERSION = v1.11.0
 KIND_VERSION = v0.27.0
 KO_VERSION = v0.16.0
 KUSTOMIZE_VERSION = v5.1.1
@@ -79,6 +80,15 @@ ifeq (, $(shell which $(CRDOC)))
 	@{ \
 	GOBIN=$(BIN) go install fybrik.io/crdoc@$(CRDOC_VERSION) ;\
 	mv $(BIN)/crdoc $(CRDOC) ;\
+	}
+endif
+
+HELM_DOCS := $(BIN)/helm-docs-$(HELM_DOCS_VERSION)
+$(HELM_DOCS): $(BIN)
+ifeq (, $(shell which $(HELM_DOCS)))
+	@{ \
+	GOBIN=$(BIN) go install github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION) ;\
+	mv $(BIN)/helm-docs $(HELM_DOCS) ;\
 	}
 endif
 

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -7,6 +7,7 @@ PATH := $(BIN):$(PATH)
 CHAINSAW_VERSION = v0.2.10
 CONTROLLER_GEN_VERSION = v0.16.3
 CRDOC_VERSION = v0.6.4
+ENVTEST_VERSION = latest
 GOLANGCI_LINT_VERSION = v2.1.6
 HELM_DOCS_VERSION = v1.11.0
 KIND_VERSION = v0.27.0
@@ -91,6 +92,16 @@ ifeq (, $(shell which $(CRDOC)))
 	@{ \
 	GOBIN=$(BIN) go install fybrik.io/crdoc@$(CRDOC_VERSION) ;\
 	mv $(BIN)/crdoc $(CRDOC) ;\
+	}
+endif
+
+ENVTEST := $(BIN)/setup-envtest-$(ENVTEST_VERSION)
+$(ENVTEST): $(BIN)
+ifeq (, $(shell which $(ENVTEST)))
+	@{ \
+	set -e ;\
+	GOBIN=$(BIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION) ;\
+	mv $(BIN)/setup-envtest $(ENVTEST) ;\
 	}
 endif
 

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -5,6 +5,7 @@ $(BIN):
 PATH := $(BIN):$(PATH)
 
 CONTROLLER_GEN_VERSION = v0.16.3
+CRDOC_VERSION = v0.6.4
 GOLANGCI_LINT_VERSION = v2.1.6
 KIND_VERSION = v0.27.0
 KO_VERSION = v0.16.0
@@ -59,6 +60,15 @@ ifeq (, $(shell which $(CONTROLLER_GEN)))
 	@{ \
 	GOBIN=$(BIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION) ;\
 	mv $(BIN)/controller-gen $(CONTROLLER_GEN) ;\
+	}
+endif
+
+CRDOC := $(BIN)/crdoc-$(CRDOC_VERSION)
+$(CRDOC): $(BIN)
+ifeq (, $(shell which $(CRDOC)))
+	@{ \
+	GOBIN=$(BIN) go install fybrik.io/crdoc@$(CRDOC_VERSION) ;\
+	mv $(BIN)/crdoc $(CRDOC) ;\
 	}
 endif
 

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -13,6 +13,7 @@ KIND_VERSION = v0.27.0
 KO_VERSION = v0.16.0
 KUSTOMIZE_VERSION = v5.1.1
 OPERATOR_SDK_VERSION = v1.32.0
+OPM_VERSION = v1.23.2
 YQ_VERSION = v4.35.2
 
 GOLANGCI_LINT := $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
@@ -43,6 +44,16 @@ ifeq (, $(shell which $(OPERATOR_SDK)))
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK);\
+	}
+endif
+
+OPM := $(BIN)/opm-$(OPM_VERSION)
+$(OPM): $(BIN)
+ifeq (, $(shell which $(OPM)))
+	@{ \
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
+	chmod +x $(OPM) ;\
 	}
 endif
 

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -10,6 +10,7 @@ KIND_VERSION = v0.27.0
 KO_VERSION = v0.16.0
 KUSTOMIZE_VERSION = v5.1.1
 OPERATOR_SDK_VERSION = v1.32.0
+YQ_VERSION = v4.35.2
 
 GOLANGCI_LINT := $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT): $(BIN)
@@ -67,5 +68,16 @@ ifeq (, $(shell which $(KO)))
 	@{ \
 	GOBIN=$(BIN) go install github.com/google/ko@$(KO_VERSION) ;\
 	mv $(BIN)/ko $(KO) ;\
+	}
+endif
+
+YQ := $(BIN)/yq-$(YQ_VERSION)
+$(YQ): $(BIN)
+ifeq (, $(shell which $(YQ)))
+	@{ \
+	set -e ;\
+	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$${OSTYPE}_$${ARCH} ;\
+	chmod +x $(YQ) ;\
 	}
 endif

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -5,6 +5,7 @@ $(BIN):
 PATH := $(BIN):$(PATH)
 
 GOLANGCI_LINT_VERSION = v2.1.6
+KUSTOMIZE_VERSION = v5.1.1
 
 GOLANGCI_LINT := $(BIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):
@@ -13,5 +14,15 @@ ifeq (, $(shell which $(GOLANGCI_LINT)))
 	set -e ;\
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s $(GOLANGCI_LINT_VERSION) ;\
 	mv $(BIN)/golangci-lint $(GOLANGCI_LINT) ;\
+	}
+endif
+
+KUSTOMIZE := $(BIN)/kustomize-$(KUSTOMIZE_VERSION)
+$(KUSTOMIZE):
+ifeq (, $(shell which $(KUSTOMIZE)))
+	@{ \
+	set -e ;\
+	curl -sSfL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(BIN) ;\
+	mv $(BIN)/kustomize $(KUSTOMIZE) ;\
 	}
 endif


### PR DESCRIPTION
- Makefile:
  - moved toolchain installation to `Toolchain.mk` to declutter `Makefile`;
  - pinned the existing versions except for:
    - `setup-envtest`:
      - they don't provide a sane way to pin at a patch version, so we're still using "latest";
    - `crdoc`:
      - bumped version from a commit hash to a tag to make binary name more predictable.

There are plenty of things that can be further improved in Makefile, it should just be a good start.
