### PR TITLE
chore: modernize some code using gopls

### DIFF
--- a/api/v1beta1/typeoverrides.go
+++ b/api/v1beta1/typeoverrides.go
@@ -520,7 +520,7 @@ type ServiceAccountV1 struct {
 // Merge merges `overrides` into `base` using the SMP (structural merge patch) approach.
 // - It intentionally does not remove fields present in base but missing from overrides
 // - It merges slices only if the `patchStrategy:"merge"` tag is present and the `patchMergeKey` identifies the unique field
-func Merge(base, overrides interface{}) error {
+func Merge(base, overrides any) error {
 	if overrides == nil {
 		return nil
 	}

--- a/api/v1beta1/typeoverrides.go
+++ b/api/v1beta1/typeoverrides.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -31,17 +32,13 @@ func (override *ObjectMeta) Merge(meta metav1.ObjectMeta) metav1.ObjectMeta {
 		if meta.Annotations == nil {
 			meta.Annotations = make(map[string]string)
 		}
-		for key, val := range override.Annotations {
-			meta.Annotations[key] = val
-		}
+		maps.Copy(meta.Annotations, override.Annotations)
 	}
 	if len(override.Labels) > 0 {
 		if meta.Labels == nil {
 			meta.Labels = make(map[string]string)
 		}
-		for key, val := range override.Labels {
-			meta.Labels[key] = val
-		}
+		maps.Copy(meta.Labels, override.Labels)
 	}
 	return meta
 }

--- a/controllers/autodetect/main.go
+++ b/controllers/autodetect/main.go
@@ -40,7 +40,7 @@ func (a *autoDetect) IsOpenshift() (bool, error) {
 	}
 
 	apiGroups := apiList.Groups
-	for i := 0; i < len(apiGroups); i++ {
+	for i := range apiGroups {
 		if apiGroups[i].Name == "route.openshift.io" {
 			return true, nil
 		}

--- a/controllers/client/grafana_client.go
+++ b/controllers/client/grafana_client.go
@@ -132,10 +132,7 @@ func ParseAdminURL(adminURL string) (*url.URL, error) {
 func NewGeneratedGrafanaClient(ctx context.Context, c client.Client, grafana *v1beta1.Grafana) (*genapi.GrafanaHTTPAPI, error) {
 	var timeout time.Duration
 	if grafana.Spec.Client != nil && grafana.Spec.Client.TimeoutSeconds != nil {
-		timeout = time.Duration(*grafana.Spec.Client.TimeoutSeconds)
-		if timeout < 0 {
-			timeout = 0
-		}
+		timeout = max(time.Duration(*grafana.Spec.Client.TimeoutSeconds), 0)
 	} else {
 		timeout = 10
 	}

--- a/controllers/client/http_client.go
+++ b/controllers/client/http_client.go
@@ -14,10 +14,7 @@ import (
 func NewHTTPClient(ctx context.Context, c client.Client, grafana *v1beta1.Grafana) (*http.Client, error) {
 	var timeout time.Duration
 	if grafana.Spec.Client != nil && grafana.Spec.Client.TimeoutSeconds != nil {
-		timeout = time.Duration(*grafana.Spec.Client.TimeoutSeconds)
-		if timeout < 0 {
-			timeout = 0
-		}
+		timeout = max(time.Duration(*grafana.Spec.Client.TimeoutSeconds), 0)
 	} else {
 		timeout = 10
 	}

--- a/controllers/client/round_tripper.go
+++ b/controllers/client/round_tripper.go
@@ -3,6 +3,7 @@ package client
 import (
 	"crypto/tls"
 	"log/slog"
+	"maps"
 	"net/http"
 	"strconv"
 
@@ -75,7 +76,5 @@ func (in *instrumentedRoundTripper) addHeaders(headers map[string]string) {
 		in.headers = make(map[string]string)
 	}
 
-	for k, v := range headers {
-		in.headers[k] = v
-	}
+	maps.Copy(in.headers, headers)
 }

--- a/controllers/content/fetchers/jsonnet_fetcher_test.go
+++ b/controllers/content/fetchers/jsonnet_fetcher_test.go
@@ -29,7 +29,7 @@ func teardown(t *testing.T) {
 }
 
 func normalizeAndCompareJSON(json1, json2 []byte) bool {
-	var data1, data2 map[string]interface{}
+	var data1, data2 map[string]any
 
 	if err := json.Unmarshal(json1, &data1); err != nil {
 		return false

--- a/controllers/content/resolver.go
+++ b/controllers/content/resolver.go
@@ -87,7 +87,7 @@ func NewContentResolver(cr v1beta1.GrafanaContentResource, client client.Client,
 	return resolver
 }
 
-func (h *ContentResolver) Resolve(ctx context.Context) (map[string]interface{}, string, error) {
+func (h *ContentResolver) Resolve(ctx context.Context) (map[string]any, string, error) {
 	json, err := h.fetchContentJSON(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to fetch contents: %w", err)
@@ -225,19 +225,19 @@ func (h *ContentResolver) getReferencedValue(ctx context.Context, cr v1beta1.Gra
 }
 
 // getContentModel resolves datasources, updates uid (if needed) and converts raw json to type grafana client accepts
-func (h *ContentResolver) getContentModel(contentJSON []byte) (map[string]interface{}, string, error) {
+func (h *ContentResolver) getContentModel(contentJSON []byte) (map[string]any, string, error) {
 	contentJSON, err := h.resolveDatasources(contentJSON)
 	if err != nil {
-		return map[string]interface{}{}, "", err
+		return map[string]any{}, "", err
 	}
 
 	hash := sha256.New()
 	hash.Write(contentJSON)
 
-	var contentModel map[string]interface{}
+	var contentModel map[string]any
 	err = json.Unmarshal(contentJSON, &contentModel)
 	if err != nil {
-		return map[string]interface{}{}, "", err
+		return map[string]any{}, "", err
 	}
 
 	// NOTE: id should never be hardcoded in a model, otherwise grafana will try to update a model by id instead of uid.

--- a/controllers/content/resolver_test.go
+++ b/controllers/content/resolver_test.go
@@ -194,7 +194,7 @@ func TestContentIsUpdatedUID(t *testing.T) {
 
 func getCR(t *testing.T, crUID string, statusUID string, specUID string, dashUID string) *NopContentResource {
 	t.Helper()
-	dashboardModel := make(map[string]interface{})
+	dashboardModel := make(map[string]any)
 	dashboardModel["uid"] = dashUID
 	dashboard, _ := json.Marshal(dashboardModel) //nolint:errcheck
 

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -362,7 +362,7 @@ func patchFinalizers(ctx context.Context, cl client.Client, cr client.Object) er
 	crFinalizers := cr.GetFinalizers()
 
 	// Create patch using slice
-	patch, err := json.Marshal(map[string]interface{}{"metadata": map[string]interface{}{"finalizers": crFinalizers}})
+	patch, err := json.Marshal(map[string]any{"metadata": map[string]any{"finalizers": crFinalizers}})
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func addAnnotation(ctx context.Context, cl client.Client, cr client.Object, key 
 
 	// Add key to map and create patch
 	crAnnotations[key] = value
-	patch, err := json.Marshal(map[string]interface{}{"metadata": map[string]interface{}{"annotations": crAnnotations}})
+	patch, err := json.Marshal(map[string]any{"metadata": map[string]any{"annotations": crAnnotations}})
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func removeAnnotation(ctx context.Context, cl client.Client, cr client.Object, k
 	// Escape slash '/' according to RFC6901
 	// We could also escape tilde '~', but that is not a valid character in annotation keys.
 	key = strings.ReplaceAll(key, "/", "~1")
-	patch, err := json.Marshal([]interface{}{map[string]interface{}{"op": "remove", "path": "/metadata/annotations/" + key}})
+	patch, err := json.Marshal([]any{map[string]any{"op": "remove", "path": "/metadata/annotations/" + key}})
 	if err != nil {
 		return err
 	}

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -322,7 +322,7 @@ func (r *GrafanaDashboardReconciler) finalize(ctx context.Context, cr *v1beta1.G
 	return nil
 }
 
-func (r *GrafanaDashboardReconciler) onDashboardCreated(ctx context.Context, grafana *v1beta1.Grafana, cr *v1beta1.GrafanaDashboard, dashboardModel map[string]interface{}, hash string) error {
+func (r *GrafanaDashboardReconciler) onDashboardCreated(ctx context.Context, grafana *v1beta1.Grafana, cr *v1beta1.GrafanaDashboard, dashboardModel map[string]any, hash string) error {
 	log := logf.FromContext(ctx)
 	if grafana.IsExternal() && cr.Spec.Plugins != nil {
 		return fmt.Errorf("external grafana instances don't support plugins, please remove spec.plugins from your dashboard cr")
@@ -436,13 +436,13 @@ func (r *GrafanaDashboardReconciler) Exists(client *genapi.GrafanaHTTPAPI, uid s
 }
 
 // HasRemoteChange checks if a dashboard in Grafana is different to the model defined in the custom resources
-func (r *GrafanaDashboardReconciler) hasRemoteChange(exists bool, model map[string]interface{}, remoteDashboard *dashboards.GetDashboardByUIDOK) (bool, error) {
+func (r *GrafanaDashboardReconciler) hasRemoteChange(exists bool, model map[string]any, remoteDashboard *dashboards.GetDashboardByUIDOK) (bool, error) {
 	if !exists {
 		// if the dashboard doesn't exist, don't even request
 		return true, nil
 	}
 
-	remoteModel, ok := (remoteDashboard.GetPayload().Dashboard).(map[string]interface{})
+	remoteModel, ok := (remoteDashboard.GetPayload().Dashboard).(map[string]any)
 	if !ok {
 		return true, fmt.Errorf("remote dashboard is not a valid object")
 	}

--- a/controllers/model/utils.go
+++ b/controllers/model/utils.go
@@ -3,6 +3,7 @@ package model
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -26,9 +27,7 @@ func MergeAnnotations(requested map[string]string, existing map[string]string) m
 		return requested
 	}
 
-	for k, v := range requested {
-		existing[k] = v
-	}
+	maps.Copy(existing, requested)
 	return existing
 }
 
@@ -43,12 +42,8 @@ func SetInheritedLabels(obj metav1.ObjectMetaAccessor, extraLabels map[string]st
 		labels = make(map[string]string)
 	}
 	// Inherit labels from the parent grafana instance if any
-	for k, v := range extraLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, extraLabels)
 	// Ensure default CommonLabels for child resources
-	for k, v := range GetCommonLabels() {
-		labels[k] = v
-	}
+	maps.Copy(labels, GetCommonLabels())
 	meta.SetLabels(labels)
 }

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -238,7 +238,7 @@ func getContainers(cr *v1beta1.Grafana, scheme *runtime.Scheme, vars *v1beta1.Op
 	// Use auto generated admin account?
 	secret := model.GetGrafanaAdminSecret(cr, scheme)
 
-	for i := 0; i < len(containers); i++ {
+	for i := range containers {
 		containers[i].Env = append(containers[i].Env, v1.EnvVar{
 			Name: config.GrafanaAdminUserEnvVar,
 			ValueFrom: &v1.EnvVarSource{

--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers/model"
@@ -150,11 +151,8 @@ func (r *IngressReconciler) getIngressAdminURL(ingress *v1.Ingress) string {
 
 	// If we can find the target host in any of the IngressTLS, then we should use https protocol
 	for _, tls := range ingress.Spec.TLS {
-		for _, h := range tls.Hosts {
-			if h == hostname {
-				protocol = "https"
-				break
-			}
+		if slices.Contains(tls.Hosts, hostname) {
+			protocol = "https"
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -359,7 +359,7 @@ func main() { // nolint:gocyclo
 
 func getNamespaceConfig(namespaces string, labelSelectors labels.Selector) map[string]cache.Config {
 	defaultNamespaces := map[string]cache.Config{}
-	for _, v := range strings.Split(namespaces, ",") {
+	for v := range strings.SplitSeq(namespaces, ",") {
 		// Generate a mapping of namespaces to label/field selectors, set to Everything() to enable matching all
 		// instances in all namespaces from watchNamespace to be controlled by the operator
 		// this is the default behavior of the operator on v5, if you require finer grained control over this


### PR DESCRIPTION
- modernized some using gopls (`go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix ./...`):
  - interface type (interface{} -> any);
  - maps calls (copying using special functions);
  - range by index loops (no need to play with i++);
  - range over split string (`strings.SplitSeq` is more effective);
  - search in slices (better to use `slices.Contains`);
  - timeout calculation (if condition can be folder using `max`).

**NOTE**: gopls also suggests some changes around removal of omitempty tag for structs, but it should be better looked at separately.