### PR TITLE
chore(controllers): Use `req.NamespacedName` directly

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -61,10 +61,7 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 	ctx = logf.IntoContext(ctx, log)
 
 	group := &grafanav1beta1.GrafanaAlertRuleGroup{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, group)
+	err := r.Get(ctx, req.NamespacedName, group)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/contactpoint_controller.go
+++ b/controllers/contactpoint_controller.go
@@ -108,10 +108,7 @@ func (r *GrafanaContactPointReconciler) Reconcile(ctx context.Context, req ctrl.
 	ctx = logf.IntoContext(ctx, log)
 
 	contactPoint := &grafanav1beta1.GrafanaContactPoint{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, contactPoint)
+	err := r.Get(ctx, req.NamespacedName, contactPoint)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -119,10 +119,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	ctx = logf.IntoContext(ctx, log)
 
 	cr := &v1beta1.GrafanaDashboard{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, cr)
+	err := r.Get(ctx, req.NamespacedName, cr)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -112,10 +112,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	ctx = logf.IntoContext(ctx, log)
 
 	cr := &v1beta1.GrafanaDatasource{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, cr)
+	err := r.Get(ctx, req.NamespacedName, cr)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -109,10 +109,7 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	ctx = logf.IntoContext(ctx, log)
 
 	folder := &grafanav1beta1.GrafanaFolder{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, folder)
+	err := r.Get(ctx, req.NamespacedName, folder)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -118,10 +118,7 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 	ctx = logf.IntoContext(ctx, log)
 
 	libraryPanel := &v1beta1.GrafanaLibraryPanel{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, libraryPanel)
+	err := r.Get(ctx, req.NamespacedName, libraryPanel)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/mutetiming_controller.go
+++ b/controllers/mutetiming_controller.go
@@ -54,10 +54,7 @@ func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	ctx = logf.IntoContext(ctx, log)
 
 	muteTiming := &grafanav1beta1.GrafanaMuteTiming{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, muteTiming)
+	err := r.Get(ctx, req.NamespacedName, muteTiming)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -68,10 +68,7 @@ func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req
 	ctx = logf.IntoContext(ctx, log)
 
 	notificationPolicy := &v1beta1.GrafanaNotificationPolicy{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, notificationPolicy)
+	err := r.Get(ctx, req.NamespacedName, notificationPolicy)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/controllers/notificationtemplate_controller.go
+++ b/controllers/notificationtemplate_controller.go
@@ -53,10 +53,7 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 	ctx = logf.IntoContext(ctx, log)
 
 	notificationTemplate := &grafanav1beta1.GrafanaNotificationTemplate{}
-	err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      req.Name,
-	}, notificationTemplate)
+	err := r.Get(ctx, req.NamespacedName, notificationTemplate)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil


### PR DESCRIPTION
This removes all the places we store a pointer to the scheme unnecessarily and refactors the controllers to use the `req.NamespacedName` when fetching the resource in the beginning of all Reconcile functions.
