### PR TITLE
chore(Makefile): further improvements

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -21,28 +21,6 @@ jobs:
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
-  go-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
-      - name: Setup go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
-        with:
-          go-version-file: "go.mod"
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.1.6
-
-      - name: Verify golangci-lint config
-        run: |
-          golangci-lint config verify
-
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -68,31 +68,6 @@ jobs:
             exit 1
           fi
 
-  helm:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
-      - name: Setup go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
-        with:
-          go-version-file: "go.mod"
-
-      - name: Run helm-docs
-        run: |
-          make helm-docs
-
-      - name: Check if working tree is dirty
-        run: |
-          if [[ $(git status --porcelain) ]]; then
-            git diff
-            echo '::error::run make helm-docs and commit changes'
-            exit 1
-          fi
-
   trivy:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,6 @@ Before pushing any code we recommend that you run the following make commands:
 
 ```shell
 make test
-make code/golangci-lint
 ```
 
 Also, to make sure `pre-commit` runs automatically on `git commit`, its hooks need to be installed first (installation of `pre-commit` itself is described [here](https://pre-commit.com/#installation)):

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,7 @@ e2e: $(CHAINSAW) install deploy-chainsaw ## Run e2e tests using chainsaw.
 .PHONY: code/golangci-lint
 ifndef GITHUB_ACTIONS # Inside GitHub Actions, we run golangci-lint in a separate step
 code/golangci-lint: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) config verify
 	$(GOLANGCI_LINT) fmt ./...
 	$(GOLANGCI_LINT) run --allow-parallel-runners ./...
 endif

--- a/Makefile
+++ b/Makefile
@@ -110,22 +110,22 @@ helm-lint: $(HELM) ## Validate helm chart.
 kustomize-lint: $(KUSTOMIZE) ## Lint kustomize overlays.
 	$(info $(M) running $@)
 	@for d in deploy/kustomize/overlays/*/ ; do \
-		kustomize build "$${d}" --load-restrictor LoadRestrictionsNone > /dev/null ;\
+		$(KUSTOMIZE) build "$${d}" --load-restrictor LoadRestrictionsNone > /dev/null ;\
 	done
 
 .PHONY: kustomize-set-image
 kustomize-set-image: $(KUSTOMIZE) ## Sets release image.
 	$(info $(M) running $@)
-	cd deploy/kustomize/base && kustomize edit set image ghcr.io/${GITHUB_REPOSITORY}=${GHCR_REPO}:${RELEASE_NAME} && cd -
+	cd deploy/kustomize/base && $(KUSTOMIZE) edit set image ghcr.io/${GITHUB_REPOSITORY}=${GHCR_REPO}:${RELEASE_NAME} && cd -
 
 .PHONY: kustomize-github-assets
 kustomize-github-assets: $(KUSTOMIZE) ## Generates GitHub assets.
 	$(info $(M) running $@)
 	@for d in deploy/kustomize/overlays/*/ ; do \
 		echo "$${d}" ;\
-		kustomize build "$${d}" --load-restrictor LoadRestrictionsNone > kustomize-$$(basename "$${d}").yaml ;\
+		$(KUSTOMIZE) build "$${d}" --load-restrictor LoadRestrictionsNone > kustomize-$$(basename "$${d}").yaml ;\
 	done
-	kustomize build config/crd > crds.yaml
+	$(KUSTOMIZE) build config/crd > crds.yaml
 
 .PHONY: test
 test: $(ENVTEST) manifests generate vet golangci-lint api-docs kustomize-lint helm-docs helm-lint ## Run tests.

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,11 @@ manifests: $(CONTROLLER_GEN) $(KUSTOMIZE) $(YQ) ## Generate WebhookConfiguration
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=deploy/helm/grafana-operator/crds
 	$(YQ) -i '(select(.kind == "Deployment") | .spec.template.spec.containers[0].env[] | select (.name == "RELATED_IMAGE_GRAFANA")).value="$(GRAFANA_IMAGE):$(GRAFANA_VERSION)"' config/manager/manager.yaml
 
-	# NOTE: As we publish the whole kustomize folder structure (deploy/kustomize) as an OCI arfifact via flux, in kustomization.yaml, we cannot reference files that reside outside of deploy/kustomize. Thus, we need to maintain an additional copy of CRDs and the ClusterRole
+	@# NOTE: As we publish the whole kustomize folder structure (deploy/kustomize) as an OCI arfifact via flux, in kustomization.yaml, we cannot reference files that reside outside of deploy/kustomize. Thus, we need to maintain an additional copy of CRDs and the ClusterRole
 	$(KUSTOMIZE) build config/crd -o deploy/kustomize/base/crds.yaml
 	cp config/rbac/role.yaml deploy/kustomize/base/role.yaml
 
-	# Sync role definitions to helm chart
+	@# Sync role definitions to helm chart
 	mkdir -p deploy/helm/grafana-operator/files
 	cat config/rbac/role.yaml | $(YQ) -r 'del(.rules[] | select (.apiGroups | contains(["route.openshift.io"])))' > deploy/helm/grafana-operator/files/rbac.yaml
 	cat config/rbac/role.yaml | $(YQ) -r 'del(.rules[] | select (.apiGroups | contains(["route.openshift.io"]) | not))'  > deploy/helm/grafana-operator/files/rbac-openshift.yaml

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ vet: ## Run go vet against code.
 	$(info $(M) running $@)
 	go vet ./...
 
-.PHONY:
-helm-docs: $(HELM_DOCS) ## Generate helm docs
+.PHONY: helm-docs
+helm-docs: $(HELM_DOCS) ## Generate helm docs.
 	$(info $(M) running $@)
 	$(HELM_DOCS) deploy/helm
 

--- a/Makefile
+++ b/Makefile
@@ -230,13 +230,11 @@ e2e: $(CHAINSAW) install deploy-chainsaw ## Run e2e tests using chainsaw.
 	$(CHAINSAW) test --test-dir ./tests/e2e/$(TESTS)
 
 .PHONY: code/golangci-lint
-ifndef GITHUB_ACTIONS # Inside GitHub Actions, we run golangci-lint in a separate step
 code/golangci-lint: $(GOLANGCI_LINT)
 	$(info $(M) running $@)
 	$(GOLANGCI_LINT) config verify
 	$(GOLANGCI_LINT) fmt ./...
 	$(GOLANGCI_LINT) run --allow-parallel-runners ./...
-endif
 
 export KO_DOCKER_REPO ?= ko.local/grafana/grafana-operator
 export KIND_CLUSTER_NAME ?= kind-grafana

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ kustomize-github-assets: $(KUSTOMIZE) ## Generates GitHub assets.
 	kustomize build config/crd > crds.yaml
 
 .PHONY: test
-test: $(ENVTEST) manifests generate code/golangci-lint api-docs vet kustomize-lint helm-lint ## Run tests.
+test: $(ENVTEST) manifests generate code/golangci-lint api-docs vet kustomize-lint helm-docs helm-lint ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ kustomize-github-assets: $(KUSTOMIZE) ## Generates GitHub assets.
 	kustomize build config/crd > crds.yaml
 
 .PHONY: test
-test: $(ENVTEST) manifests generate code/golangci-lint api-docs vet kustomize-lint helm-docs helm-lint ## Run tests.
+test: $(ENVTEST) manifests generate golangci-lint api-docs vet kustomize-lint helm-docs helm-lint ## Run tests.
 	$(info $(M) running $@)
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN) -p path)" go test ./... -coverprofile cover.out
 
@@ -229,8 +229,8 @@ e2e: $(CHAINSAW) install deploy-chainsaw ## Run e2e tests using chainsaw.
 	$(info $(M) running $@)
 	$(CHAINSAW) test --test-dir ./tests/e2e/$(TESTS)
 
-.PHONY: code/golangci-lint
-code/golangci-lint: $(GOLANGCI_LINT)
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Run golangci-lint checks.
 	$(info $(M) running $@)
 	$(GOLANGCI_LINT) config verify
 	$(GOLANGCI_LINT) fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ vet: ## Run go vet against code.
 
 .PHONY:
 helm-docs: $(HELM_DOCS) ## Generate helm docs
-	$(HELM_DOCS)
+	$(HELM_DOCS) deploy/helm
 
 .PHONY: helm-lint
 helm-lint: $(HELM) ## Validate helm chart.

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ kustomize-github-assets: $(KUSTOMIZE) ## Generates GitHub assets.
 	kustomize build config/crd > crds.yaml
 
 .PHONY: test
-test: $(ENVTEST) manifests generate golangci-lint api-docs vet kustomize-lint helm-docs helm-lint ## Run tests.
+test: $(ENVTEST) manifests generate vet golangci-lint api-docs kustomize-lint helm-docs helm-lint ## Run tests.
 	$(info $(M) running $@)
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN) -p path)" go test ./... -coverprofile cover.out
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: $(CONTROLLER_GEN) $(KUSTOMIZE) $(YQ) ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+	$(info $(M) running $@)
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=config/crd/bases
 	$(CONTROLLER_GEN) rbac:roleName=manager-role webhook paths="./..." crd output:crd:artifacts:config=deploy/helm/grafana-operator/crds
 	$(YQ) -i '(select(.kind == "Deployment") | .spec.template.spec.containers[0].env[] | select (.name == "RELATED_IMAGE_GRAFANA")).value="$(GRAFANA_IMAGE):$(GRAFANA_VERSION)"' config/manager/manager.yaml
@@ -79,37 +80,45 @@ manifests: $(CONTROLLER_GEN) $(KUSTOMIZE) $(YQ) ## Generate WebhookConfiguration
 # Generate API reference documentation
 .PHONY: api-docs
 api-docs: $(CRDOC) manifests
+	$(info $(M) running $@)
 	$(CRDOC) --resources config/crd/bases --output docs/docs/api.md --template hugo/templates/frontmatter-grafana-operator.tmpl
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+	$(info $(M) running $@)
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: vet
 vet: ## Run go vet against code.
+	$(info $(M) running $@)
 	go vet ./...
 
 .PHONY:
 helm-docs: $(HELM_DOCS) ## Generate helm docs
+	$(info $(M) running $@)
 	$(HELM_DOCS) deploy/helm
 
 .PHONY: helm-lint
 helm-lint: $(HELM) ## Validate helm chart.
+	$(info $(M) running $@)
 	$(HELM) template deploy/helm/grafana-operator/ > /dev/null
 	$(HELM) lint deploy/helm/grafana-operator/
 
 .PHONY: kustomize-lint
 kustomize-lint: $(KUSTOMIZE) ## Lint kustomize overlays.
+	$(info $(M) running $@)
 	@for d in deploy/kustomize/overlays/*/ ; do \
 		kustomize build "$${d}" --load-restrictor LoadRestrictionsNone > /dev/null ;\
 	done
 
 .PHONY: kustomize-set-image
 kustomize-set-image: $(KUSTOMIZE) ## Sets release image.
+	$(info $(M) running $@)
 	cd deploy/kustomize/base && kustomize edit set image ghcr.io/${GITHUB_REPOSITORY}=${GHCR_REPO}:${RELEASE_NAME} && cd -
 
 .PHONY: kustomize-github-assets
 kustomize-github-assets: $(KUSTOMIZE) ## Generates GitHub assets.
+	$(info $(M) running $@)
 	@for d in deploy/kustomize/overlays/*/ ; do \
 		echo "$${d}" ;\
 		kustomize build "$${d}" --load-restrictor LoadRestrictionsNone > kustomize-$$(basename "$${d}").yaml ;\
@@ -118,17 +127,20 @@ kustomize-github-assets: $(KUSTOMIZE) ## Generates GitHub assets.
 
 .PHONY: test
 test: $(ENVTEST) manifests generate code/golangci-lint api-docs vet kustomize-lint helm-docs helm-lint ## Run tests.
+	$(info $(M) running $@)
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(BIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 
 .PHONY: build
 build: $(GOLANGCI_LINT) generate vet ## Build manager binary.
+	$(info $(M) running $@)
 	$(GOLANGCI_LINT) fmt ./...
 	go build -o bin/manager main.go
 
 .PHONY: run
 run: $(GOLANGCI_LINT) manifests generate vet ## Run a controller from your host.
+	$(info $(M) running $@)
 	$(GOLANGCI_LINT) fmt ./...
 	go run ./main.go --zap-devel=true
 
@@ -140,27 +152,33 @@ endif
 
 .PHONY: install
 install: $(KUSTOMIZE) manifests ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+	$(info $(M) running $@)
 	$(KUSTOMIZE) build config/crd | kubectl replace --force=true -f -
 
 .PHONY: uninstall
 uninstall: $(KUSTOMIZE) manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(info $(M) running $@)
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: $(KUSTOMIZE) manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	$(info $(M) running $@)
 	cd deploy/kustomize/overlays/cluster_scoped && $(KUSTOMIZE) edit set image ghcr.io/grafana/grafana-operator=${IMG}
 	$(KUSTOMIZE) build deploy/kustomize/overlays/cluster_scoped | kubectl apply --server-side --force-conflicts -f -
 
 .PHONY: deploy-chainsaw
 deploy-chainsaw: $(KUSTOMIZE) manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	$(info $(M) running $@)
 	$(KUSTOMIZE) build deploy/kustomize/overlays/chainsaw | kubectl apply --server-side --force-conflicts -f -
 
 .PHONY: undeploy
 undeploy: $(KUSTOMIZE) ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(info $(M) running $@)
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: start-kind
 start-kind: $(KIND) ## Start kind cluster locally
+	$(info $(M) running $@)
 	@KIND=$(KIND) hack/kind/start-kind.sh
 	@KIND=$(KIND) hack/kind/populate-kind-cluster.sh
 
@@ -187,6 +205,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 .PHONY: bundle
 bundle: $(KUSTOMIZE) $(OPERATOR_SDK) manifests ## Generate bundle manifests and metadata, then validate generated files.
+	$(info $(M) running $@)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	./hack/add-openshift-annotations.sh
@@ -199,6 +218,7 @@ bundle/redhat: bundle
 # e2e
 .PHONY: e2e-kind
 e2e-kind: $(KIND)
+	$(info $(M) running $@)
 	KIND=$(KIND) hack/kind/start-kind.sh
 
 .PHONY: e2e-local-gh-actions
@@ -206,11 +226,13 @@ e2e-local-gh-actions: e2e-kind ko-build-kind e2e
 
 .PHONY: e2e
 e2e: $(CHAINSAW) install deploy-chainsaw ## Run e2e tests using chainsaw.
+	$(info $(M) running $@)
 	$(CHAINSAW) test --test-dir ./tests/e2e/$(TESTS)
 
 .PHONY: code/golangci-lint
 ifndef GITHUB_ACTIONS # Inside GitHub Actions, we run golangci-lint in a separate step
 code/golangci-lint: $(GOLANGCI_LINT)
+	$(info $(M) running $@)
 	$(GOLANGCI_LINT) config verify
 	$(GOLANGCI_LINT) fmt ./...
 	$(GOLANGCI_LINT) run --allow-parallel-runners ./...
@@ -222,20 +244,24 @@ export KUBECONFIG        ?= ${HOME}/.kube/kind-grafana-operator
 
 .PHONY: ko-build-local
 ko-build-local: $(KO) ## Build Docker image with KO
+	$(info $(M) running $@)
 	$(KO) build --sbom=none --bare
 
 .PHONY: ko-build-kind
 ko-build-kind: $(KIND) ko-build-local ## Build and Load Docker image into kind cluster
+	$(info $(M) running $@)
 	$(KIND) load docker-image $(KO_DOCKER_REPO) --name $(KIND_CLUSTER_NAME)
 
 BUNDLE_IMG ?= $(REGISTRY)/$(ORG)/grafana-operator-bundle:v$(VERSION)
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
+	$(info $(M) running $@)
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
+	$(info $(M) running $@)
 	docker push $(BUNDLE_IMG)
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
@@ -255,15 +281,18 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: $(OPM) ## Build a catalog image.
+	$(info $(M) running $@)
 	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
+	$(info $(M) running $@)
 	docker push $(CATALOG_IMG)
 
 .PHONY: prep-release
 prep-release: $(YQ)
+	$(info $(M) running $@)
 	$(YQ) -i '.version="v$(VERSION)"' deploy/helm/grafana-operator/Chart.yaml
 	$(YQ) -i '.appVersion="v$(VERSION)"' deploy/helm/grafana-operator/Chart.yaml
 	$(YQ) -i '.params.version="v$(VERSION)"' hugo/config.yaml


### PR DESCRIPTION
- Makefile & workflows (where applicable):
  - logging:
    - added log messages to highlight which target is being run (helpful for complex targets like `test`);
    - suppressed logging of comments in `manifests` target to declutter outputs;
  - golangci-lint:
    - added config verify step;
    - renamed `code/golangci-lint` target to `golangci-lint` and added comments to make the target appear in `help` target;
    - deprecated `go-lint` job in favour of running `golangci-lint` only through Makefile, it should help to avoid behaviour and version inconsistency in workflows;
    - moved the target to Development section of Makefile;
  - helm-docs:
    - added `helm-docs` to `test` target;
    - passed path to the helm chart to prevent scanning of the whole repository tree;
    - added `.PHONY` statement;
  - vet:
    - moved `vet` inside `test` target to make it fail early;
    - moved `vet` target inside Development section of the Makefile to improve `help` outputs;
  - kustomize:
    - fixed some of the kustomize calls to make them use the pinned binary;
- docs:
  - removed references to golangci-lint step from CONTRIBUTING.md as the linter runs under `test` target anyway.

**NOTE:** If the PR is accepted, we'll need to remove `helm` and `test` jobs from the list of required checks.
