### PR TITLE
Chore: Address more Gopls lints

### DIFF
--- a/api/v1beta1/suite_test.go
+++ b/api/v1beta1/suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,7 +38,6 @@ const (
 )
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
 )

--- a/controllers/content/fetchers/grafana_com_fetcher.go
+++ b/controllers/content/fetchers/grafana_com_fetcher.go
@@ -68,7 +68,7 @@ func getLatestGrafanaComRevision(cr v1beta1.GrafanaContentResource, tlsConfig *t
 	if err != nil {
 		return -1, err
 	}
-	defer response.Body.Close()
+	defer response.Body.Close() //nolint:errcheck
 
 	if response.StatusCode != http.StatusOK {
 		return -1, fmt.Errorf("unexpected status code when requesting revisions, got %v for dashboard %v", response.StatusCode, cr.GetName())

--- a/controllers/content/fetchers/jsonnet_fetcher.go
+++ b/controllers/content/fetchers/jsonnet_fetcher.go
@@ -334,7 +334,7 @@ func untarGzip(archivePath, extractPath string) error {
 			if err != nil {
 				return err
 			}
-			defer fileToWrite.Close()
+			defer fileToWrite.Close() //nolint:errcheck
 
 			for {
 				_, err := io.CopyN(fileToWrite, tr, 4096)
@@ -439,13 +439,13 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer srcFile.Close()
+	defer srcFile.Close() //nolint:errcheck
 
 	dstFile, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
-	defer dstFile.Close()
+	defer dstFile.Close() //nolint:errcheck
 
 	_, err = io.Copy(dstFile, srcFile)
 	if err != nil {

--- a/controllers/content/fetchers/suite_test.go
+++ b/controllers/content/fetchers/suite_test.go
@@ -6,7 +6,6 @@ import (
 	grafanav1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -17,7 +16,6 @@ import (
 )
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
 )

--- a/controllers/content/fetchers/url_fetcher.go
+++ b/controllers/content/fetchers/url_fetcher.go
@@ -79,7 +79,7 @@ func FetchFromURL(ctx context.Context, cr v1beta1.GrafanaContentResource, c clie
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer response.Body.Close() //nolint:errcheck
 
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code from dashboard url request, get %v for dashboard %v", response.StatusCode, cr.GetName())

--- a/controllers/reconcilers/grafana/suite_test.go
+++ b/controllers/reconcilers/grafana/suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,7 +36,6 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
 )

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,7 +36,6 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
 )


### PR DESCRIPTION
Similar to #2024 this addresses additional gopls lints/hints.
- Removes `cfg *rest.Config` from the suite_test.go files as it is never used in our K8S_ENV_TEST.
- Adds `// nolint:errcheck` to multiple deferred function calls.
  This is where I noticed and fixed #2022 

I would have liked to address the `Omitempty has no effect on nested struct fields` in all our _types.go files.
But it changes the output of `make manifests`
```go
type Grafana struct {
    metav1.TypeMeta   `json:",inline"`
    metav1.ObjectMeta `json:"metadata,omitempty"`  Omitempty has no effect on nested struct fields
    Spec              GrafanaSpec   `json:"spec"`
    Status            GrafanaStatus `json:"status,omitempty"`  Omitempty has no effect on nested struct fields
}
```
It can be fixed either by making the embeds pointers or adding the `// +optional` comment, neither of which I really liked.