### PR TITLE
chore(Makefile): add hugo

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -27,7 +27,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.134.3
       DART_SASS_VERSION: 1.86.0
     steps:
       - name: Install Hugo CLI
@@ -51,16 +50,8 @@ jobs:
           cd hugo
           [[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true
       - name: Build with Hugo # zizmor: ignore[template-injection] configure-pages considered safe
-        env:
-          # For maximum backward compatibility with Hugo modules
-          HUGO_ENVIRONMENT: production
-          HUGO_ENV: production
         run: |
-          cd hugo
-          hugo \
-            --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+          make hugo
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -29,10 +29,6 @@ jobs:
     env:
       DART_SASS_VERSION: 1.86.0
     steps:
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass
         run: |
           wget -O ${{ runner.temp }}/dart-sass.tar.gz https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64-musl.tar.gz \

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -26,14 +26,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    env:
-      DART_SASS_VERSION: 1.86.0
     steps:
-      - name: Install Dart Sass
-        run: |
-          wget -O ${{ runner.temp }}/dart-sass.tar.gz https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64-musl.tar.gz \
-          && tar -xvf ${{ runner.temp }}/dart-sass.tar.gz -C ${{ runner.temp }}/ \
-          && echo "${{ runner.temp }}/dart-sass" >> $GITHUB_PATH
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/pr-hugo.yaml
+++ b/.github/workflows/pr-hugo.yaml
@@ -39,13 +39,5 @@ jobs:
           cd hugo
           [[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true
       - name: Build with Hugo # zizmor: ignore[template-injection] configure-pages considered safe
-        env:
-          # For maximum backward compatibility with Hugo modules
-          HUGO_ENVIRONMENT: production
-          HUGO_ENV: production
         run: |
-          cd hugo
-          hugo \
-            --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+          make hugo

--- a/.github/workflows/pr-hugo.yaml
+++ b/.github/workflows/pr-hugo.yaml
@@ -15,13 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.134.3
       DART_SASS_VERSION: 1.86.0
     steps:
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass
         run: |
           wget -O ${{ runner.temp }}/dart-sass.tar.gz https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64-musl.tar.gz \

--- a/.github/workflows/pr-hugo.yaml
+++ b/.github/workflows/pr-hugo.yaml
@@ -14,14 +14,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    env:
-      DART_SASS_VERSION: 1.86.0
     steps:
-      - name: Install Dart Sass
-        run: |
-          wget -O ${{ runner.temp }}/dart-sass.tar.gz https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64-musl.tar.gz \
-          && tar -xvf ${{ runner.temp }}/dart-sass.tar.gz -C ${{ runner.temp }}/ \
-          && echo "${{ runner.temp }}/dart-sass" >> $GITHUB_PATH
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -107,18 +107,20 @@ helm-lint: $(HELM) ## Validate helm chart.
 	$(HELM) lint deploy/helm/grafana-operator/
 
 .PHONY: hugo
-hugo: $(HUGO) ## Prepare production build for hugo docs.
+hugo: $(DART_SASS) $(HUGO) ## Prepare production build for hugo docs.
 	$(info $(M) running $@)
-	cd hugo && \
-	HUGO_ENVIRONMENT=production HUGO_ENV=production $(HUGO) --gc --minify && \
-	cd -
+	@echo -- Checking presence of dart-sass
+	@cd hugo && $(HUGO) env | grep dart-sass
+	@echo -- Building artifacts
+	@cd hugo && HUGO_ENVIRONMENT=production HUGO_ENV=production $(HUGO) --gc --minify
 
 .PHONY: hugo-dev
-hugo-dev: $(HUGO) ## Start development server for hugo.
+hugo-dev: $(DART_SASS) $(HUGO) ## Start development server for hugo.
 	$(info $(M) running $@)
-	cd hugo && \
-	$(HUGO) server --baseURL http://127.0.0.1/ && \
-	cd -
+	@echo -- Checking presence of dart-sass
+	@cd hugo && $(HUGO) env | grep dart-sass
+	@echo -- Starting dev server
+	@cd hugo && $(HUGO) env && $(HUGO) server --baseURL http://127.0.0.1/
 
 .PHONY: kustomize-lint
 kustomize-lint: $(KUSTOMIZE) ## Lint kustomize overlays.

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,13 @@ hugo: $(HUGO) ## Prepare production build for hugo docs.
 	HUGO_ENVIRONMENT=production HUGO_ENV=production $(HUGO) --gc --minify && \
 	cd -
 
+.PHONY: hugo-dev
+hugo-dev: $(HUGO) ## Start development server for hugo.
+	$(info $(M) running $@)
+	cd hugo && \
+	$(HUGO) server --baseURL http://127.0.0.1/ && \
+	cd -
+
 .PHONY: kustomize-lint
 kustomize-lint: $(KUSTOMIZE) ## Lint kustomize overlays.
 	$(info $(M) running $@)

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,13 @@ helm-lint: $(HELM) ## Validate helm chart.
 	$(HELM) template deploy/helm/grafana-operator/ > /dev/null
 	$(HELM) lint deploy/helm/grafana-operator/
 
+.PHONY: hugo
+hugo: $(HUGO) ## Prepare production build for hugo docs.
+	$(info $(M) running $@)
+	cd hugo && \
+	HUGO_ENVIRONMENT=production HUGO_ENV=production $(HUGO) --gc --minify && \
+	cd -
+
 .PHONY: kustomize-lint
 kustomize-lint: $(KUSTOMIZE) ## Lint kustomize overlays.
 	$(info $(M) running $@)

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -2,13 +2,12 @@ BIN = $(CURDIR)/bin
 $(BIN):
 	mkdir -p $(BIN)
 
-PATH := $(BIN):$(PATH)
-
 M = $(shell printf "\033[34;1m▶\033[0m")
 
 CHAINSAW_VERSION = v0.2.12
 CONTROLLER_GEN_VERSION = v0.17.3
 CRDOC_VERSION = v0.6.4
+DART_SASS_VERSION = 1.86.0
 ENVTEST_VERSION = v0.21.0
 GOLANGCI_LINT_VERSION = v2.1.6
 HELM_DOCS_VERSION = v1.14.2
@@ -51,6 +50,20 @@ $(CRDOC): | $(BIN)
 	set -e ;\
 	GOBIN=$(BIN) go install fybrik.io/crdoc@$(CRDOC_VERSION) ;\
 	mv $(BIN)/crdoc $(CRDOC) ;\
+	}
+
+DART_SASS := $(BIN)/dart-sass-$(DART_SASS_VERSION)
+$(DART_SASS): | $(BIN)
+	$(info $(M) installing dart-sass)
+	@{ \
+	set -e ;\
+	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
+	if [ "`uname`" = "Darwin" ]; then OSTYPE="macos"; fi && \
+	if [ "`go env GOARCH`" = "amd64" ]; then ARCH="x64"; fi && \
+	curl -sSLo $(DART_SASS).tar.gz https://github.com/sass/dart-sass/releases/download/$(DART_SASS_VERSION)/dart-sass-$(DART_SASS_VERSION)-$${OSTYPE}-$${ARCH}.tar.gz && \
+	mkdir -p $(DART_SASS) && \
+	tar -zxvf $(DART_SASS).tar.gz -C $(DART_SASS) --strip-components=1 && \
+	rm $(DART_SASS).tar.gz ;\
 	}
 
 ENVTEST := $(BIN)/setup-envtest-$(ENVTEST_VERSION)
@@ -161,3 +174,5 @@ $(YQ): | $(BIN)
 	curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$${OSTYPE}_$${ARCH} ;\
 	chmod +x $(YQ) ;\
 	}
+
+PATH := $(DART_SASS):$(BIN):$(PATH)

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -13,6 +13,7 @@ ENVTEST_VERSION = v0.21.0
 GOLANGCI_LINT_VERSION = v2.1.6
 HELM_DOCS_VERSION = v1.14.2
 HELM_VERSION = v3.17.3
+HUGO_VERSION = 0.134.3
 KIND_VERSION = v0.29.0
 KO_VERSION = v0.18.0
 KUSTOMIZE_VERSION = v5.6.0
@@ -87,6 +88,20 @@ $(HELM_DOCS): | $(BIN)
 	set -e ;\
 	GOBIN=$(BIN) go install github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION) ;\
 	mv $(BIN)/helm-docs $(HELM_DOCS) ;\
+	}
+
+HUGO := $(BIN)/hugo-$(HUGO_VERSION)
+$(HUGO): | $(BIN)
+	$(info $(M) installing hugo)
+	@{ \
+	set -e ;\
+	OSTYPE=$(shell uname | awk '{print tolower($$0)}') && ARCH=$(shell go env GOARCH) && \
+	if [ "`uname`" = "Darwin" ]; then ARCH="universal"; fi && \
+	curl -sSLo $(HUGO).tar.gz https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_extended_$(HUGO_VERSION)_$${OSTYPE}-$${ARCH}.tar.gz && \
+	tar -zxvf $(HUGO).tar.gz -C $(BIN) hugo && \
+	mv $(BIN)/hugo $(HUGO) && \
+	chmod +x $(HUGO) && \
+	rm $(HUGO).tar.gz ;\
 	}
 
 KIND := $(BIN)/kind-$(KIND_VERSION)

--- a/hugo/config.yaml
+++ b/hugo/config.yaml
@@ -1,4 +1,4 @@
-baseURL: /
+baseURL: https://grafana.github.io/grafana-operator/
 title: grafana-operator
 contentDir: content
 enableRobotsTXT: true


### PR DESCRIPTION
- Makefile:
  - add `hugo` and `dart-sass` to toolchain;
  - add `hugo` and `hugo-dev` targets;
- Workflows:
  - switch to Makefile for hugo;
- hugo:
  - hardcode baseURL (to simplify workflows).
