### PR TITLE
chore(docs): add redirect, update slack URL, adjust styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,13 @@ Switching to Grafana Operator from traditional deployments amplifies your effici
 - Providing multi-architecture support, making it versatile across different platforms.
 - Offering one-click installation through Operatorhub/OLM.
 
-## Get In Touch!
+## Get In Touch
 
 Got questions or suggestions? Let us know! The quickest way to reach us is through our [GitHub Issues](https://github.com/grafana/grafana-operator/issues) or by joining our weekly public meeting on Mondays at 11:00 Central European (Summer) Time (09:00/10:00 UTC in Summer/Winter) (link [here](https://meet.google.com/spw-jtbk-mwj)).
 
 Feel free to drop into our Grafana Operator discussions on:
 
-[![Kubernetes Slack](https://img.shields.io/badge/kubernetes%20slack-white?logo=slack&logoColor=black)](https://kubernetes.slack.com/archives/C019A1KTYKC) [![Grafana Slack](https://img.shields.io/badge/grafana%20community%20Slack-4A254A?logo=slack&logoColor=white)](https://join.slack.com/t/grafana/shared_invite/zt-2eqidcplt-QzkxMuhZA4tGQeFQenE_MQ)
-
-
+[![Grafana Slack](https://img.shields.io/badge/grafana%20community%20Slack-4A254A?logo=slack&logoColor=white)](https://join.slack.com/t/grafana/shared_invite/zt-2eqidcplt-QzkxMuhZA4tGQeFQenE_MQ) [![Kubernetes Slack](https://img.shields.io/badge/kubernetes%20slack-white?logo=slack&logoColor=black)](https://kubernetes.slack.com/archives/C019A1KTYKC)
 
 ## Contributing
 
@@ -112,7 +110,6 @@ For more information on how to contribute to the operator look at [CONTRIBUTING.
 > [!CAUTION]
 > v4 will stop receiving bug fixes and security updates as of the 22nd of December 2023.
 > We recommend you migrate to v5 if you haven't yet! Please follow our [v4 -> v5 Migration Guide](https://grafana.github.io/grafana-operator/blog/2023/05/27/v4-to-v5-migration/) to mitigate any potential future risks.
-
 
 V5 is the current, actively developed and maintained version of the operator, which you can find on the
 ***[Master Branch](https://github.com/grafana/grafana-operator/tree/master)***.
@@ -144,15 +141,15 @@ With certain standards and approaches, we can provide a better user experience t
 
 - Better designed Custom Resource Definitions (Upstream Grafana Native fields will be supported without having to
   whitelist them in the operator logic).
-    - Upstream documentation can be followed to define the Grafana Operator Custom Resources.
-    - This also means a change in API versions for the resources, but we see this as a benefit, our previous mantra of
+  - Upstream documentation can be followed to define the Grafana Operator Custom Resources.
+  - This also means a change in API versions for the resources, but we see this as a benefit, our previous mantra of
       maintaining a seamless upgrade from version to version, limited us in the changes we wanted to make for a long
       time.
 - A more streamlined Grafana resource management workflow, one that will be reflected across all controllers.
 - Using an upstream Grafana API client (standardizing our interactions with the Grafana API, moving away from bespoke
   logic).
 - The use of a more up-to-date Operator-SDK version, making use of newer features.
-    - along with all relevant dependencies being kept up-to-date.
+  - along with all relevant dependencies being kept up-to-date.
 - Proper testing.
 - Cleaning and cutting down on code.
 - Multi-instance and Multi-namespace support!

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -24,11 +24,10 @@ We make it possible for you to manage and share Grafana dashboards, datasources 
 
 {{< blocks/section color="white" type="row" >}}
 {{% blocks/feature icon="fab fa-slack" title="Grafana-Operator slack" %}}
-Sign up for the [Kubernetes slack](https://slack.k8s.io/) today
-and join the [grafana-operator channel](https://kubernetes.slack.com/messages/grafana-operator/)
+Sign up for the [Grafana Slack](https://grafana.slack.com/) today
+and join the [grafana-operator channel](https://grafana.slack.com/messages/grafana-operator/)
 to chat with maintainers and users.
 {{% /blocks/feature %}}
-
 
 {{% blocks/feature icon="fab fa-github" title="Contributions welcome" url="https://github.com/grafana/grafana-operator/blob/master/CONTRIBUTING.md" %}}
 Feel free to do a [Pull Request](https://github.com/grafana/grafana-operator/pulls) contributions workflow on **GitHub**. New contributors are always welcome!

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -1,36 +1,3 @@
-+++
-title = "Grafana-Operator"
-linkTitle = "grafana-operator"
-
-+++
-
-{{< blocks/cover title="Welcome to the Grafana Operator documentation" image_anchor="top" height="full" >}}
-<a class="btn btn-lg btn-primary me-3 mb-4" href="docs/">
-  Learn More <i class="fas fa-arrow-alt-circle-right ms-2"></i>
-</a>
-<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/grafana/grafana-operator/releases">
-  Releases <i class="fab fa-github ms-2 "></i>
-</a>
-<p class="lead mt-5">Manage Grafana resources through Kubernetes!</p>
-{{< blocks/link-down color="info" >}}
-{{< /blocks/cover >}}
-
-
-{{% blocks/lead color="primary" %}}
-The grafana-operator is a Kubernetes operator built to help you manage your Grafana instances in and outside of Kubernetes.
-
-We make it possible for you to manage and share Grafana dashboards, datasources etc. through code between multiple instances in an easy and scalable way.
-{{% /blocks/lead %}}
-
-{{< blocks/section color="white" type="row" >}}
-{{% blocks/feature icon="fab fa-slack" title="Grafana-Operator slack" %}}
-Sign up for the [Grafana Slack](https://grafana.slack.com/) today
-and join the [grafana-operator channel](https://grafana.slack.com/messages/grafana-operator/)
-to chat with maintainers and users.
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome" url="https://github.com/grafana/grafana-operator/blob/master/CONTRIBUTING.md" %}}
-Feel free to do a [Pull Request](https://github.com/grafana/grafana-operator/pulls) contributions workflow on **GitHub**. New contributors are always welcome!
-{{% /blocks/feature %}}
-
-{{< /blocks/section >}}
+<head>
+<meta http-equiv="refresh" content="0; url=docs" />
+</head>

--- a/docs/about/_index.html
+++ b/docs/about/_index.html
@@ -3,7 +3,7 @@ title: About Grafana-Operator
 linkTitle: About
 menu:
   main:
-    weight: 10
+    weight: 30
 ---
 
 {{< blocks/section >}}

--- a/docs/blog/_index.md
+++ b/docs/blog/_index.md
@@ -3,7 +3,7 @@ title: "Docsy Blog"
 linkTitle: "Blog"
 menu:
   main:
-    weight: 30
+    weight: 20
 ---
 
 

--- a/docs/blog/v5-getting-started.md
+++ b/docs/blog/v5-getting-started.md
@@ -313,6 +313,6 @@ Learned about the new concepts that we have introduced with the operator and hop
 
 If you find any issues feel free to create one after reading through the existing once in v5 [labels](https://github.com/grafana/grafana-operator/labels/v5) to see all open issues.
 
-To give feedback you can also join us in the [Kubernetes Slack](https://slack.k8s.io/) in the [grafana-operator channel](https://kubernetes.slack.com/messages/grafana-operator/).
+To give feedback you can also join us in the [Grafana Slack](https://grafana.slack.com) in the [grafana-operator channel](https://grafana.slack.com/messages/grafana-operator/).
 
 And of course we are happy to receive PRs.

--- a/docs/docs/_index.md
+++ b/docs/docs/_index.md
@@ -1,13 +1,14 @@
 ---
 title: "Introduction"
 linkTitle: "Documentation"
-weight: 20
+weight: 10
 menu:
   main:
-    weight: 20
+    weight: 10
 ---
 
 The Grafana operator allows you to:
+
 * ⚙️ Deploy & Manage Grafana Instances inside of Kubernetes with ease
 * 🌐 Manage externally hosted instances using Kubernetes resources (for example Grafana Cloud)
 

--- a/hugo/config.yaml
+++ b/hugo/config.yaml
@@ -68,10 +68,6 @@ module:
   mounts:
     - source: ../docs
       target: content
-    - source: ../docs
-      target: content
-    - source: ../examples
-      target: content/docs/examples
     - source: ../examples
       target: content/docs/examples
     - source: ../deploy/helm/grafana-operator/README.md

--- a/hugo/config.yaml
+++ b/hugo/config.yaml
@@ -51,11 +51,9 @@ params:
       - name: GitHub
         url: https://github.com/grafana/grafana-operator
         icon: fab fa-github
-        desc: Development takes place here!
       - name: Slack
-        url: https://kubernetes.slack.com/messages/grafana-operator/
+        url: https://grafana.slack.com/messages/grafana-operator/
         icon: fab fa-slack
-        desc: Chat with other grafana-operator users
 module:
   hugoVersion:
     extended: true


### PR DESCRIPTION
- docs:
  - replaced landing with a redirect to documentation;
  - replaced main Slack URL to point at Grafana Labs Slack workspace (in README.md, only swapped links to the two workspaces);
  - remove duplication hugo mounts;
  - reordered header links ("Documentation -> Blog -> About" instead of "About -> Documentation -> Blog");
  - removed color overrides.
