### PR TITLE
feat(Controllers): Suspend reconciliation with `.spec.suspend=true`

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -42,6 +42,10 @@ type GrafanaCommonSpec struct {
 	// +optional
 	// +kubebuilder:default=false
 	AllowCrossNamespaceImport bool `json:"allowCrossNamespaceImport,omitempty"`
+
+	// Suspend pauses synchronizing attempts and tells the operator to ignore changes
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 // Common Functions that all CRs should implement, excluding Grafana

--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -86,6 +86,9 @@ type GrafanaSpec struct {
 	Preferences *GrafanaPreferences `json:"preferences,omitempty"`
 	// DisableDefaultAdminSecret prevents operator from creating default admin-credentials secret
 	DisableDefaultAdminSecret bool `json:"disableDefaultAdminSecret,omitempty"`
+	// Suspend pauses reconciliation of owned resources like deployments, Services, Etc. upon changes
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 	// DisableDefaultSecurityContext prevents the operator from populating securityContext on deployments
 	// +kubebuilder:validation:Enum=Pod;Container;All
 	DisableDefaultSecurityContext string `json:"disableDefaultSecurityContext,omitempty"`

--- a/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -263,6 +263,10 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
             required:
             - instanceSelector
             - interval

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -116,6 +116,10 @@ spec:
                 type: string
               settings:
                 x-kubernetes-preserve-unknown-fields: true
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               type:
                 minLength: 1
                 type: string

--- a/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
@@ -331,6 +331,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   Manually specify the uid, overwrites uids already present in the json model.

--- a/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
@@ -163,6 +163,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   The UID, for the datasource, fallback to the deprecated spec.datasource.uid

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -124,6 +124,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               title:
                 description: Display name of the folder in Grafana
                 type: string

--- a/config/crd/bases/grafana.integreatly.org_grafanalibrarypanels.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanalibrarypanels.yaml
@@ -326,6 +326,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   Manually specify the uid, overwrites uids already present in the json model.

--- a/config/crd/bases/grafana.integreatly.org_grafanamutetimings.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanamutetimings.yaml
@@ -120,6 +120,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               time_intervals:
                 description: Time intervals for muting
                 items:

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -241,6 +241,10 @@ spec:
                 required:
                 - receiver
                 type: object
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
             required:
             - instanceSelector
             - route

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationtemplates.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationtemplates.yaml
@@ -121,6 +121,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               template:
                 description: Template content
                 type: string

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -4944,6 +4944,9 @@ spec:
                         x-kubernetes-map-type: atomic
                       type: array
                   type: object
+                suspend:
+                  description: Suspend pauses reconciliation of owned resources like deployments, Services, Etc. upon changes
+                  type: boolean
                 version:
                   description: Version specifies the version of Grafana to use for this deployment. It follows the same format as the docker.io/grafana/grafana tags
                   type: string

--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -86,6 +86,7 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 
 	if group.Spec.Suspend {
 		setSuspended(&group.Status.Conditions, group.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&group.Status.Conditions, conditionAlertGroupSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&group.Status.Conditions)

--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -84,6 +84,12 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 
 	defer UpdateStatus(ctx, r.Client, group)
 
+	if group.Spec.Suspend {
+		setSuspended(&group.Status.Conditions, group.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&group.Status.Conditions)
+
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, group)
 	if err != nil {
 		setNoMatchingInstancesCondition(&group.Status.Conditions, group.Generation, err)

--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -85,7 +85,7 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 	defer UpdateStatus(ctx, r.Client, group)
 
 	if group.Spec.Suspend {
-		setSuspended(&group.Status.Conditions, group.Generation, conditionApplySuspended)
+		setSuspended(&group.Status.Conditions, group.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&group.Status.Conditions, conditionAlertGroupSynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/alertrulegroup_controller_test.go
+++ b/controllers/alertrulegroup_controller_test.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"time"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -11,46 +10,70 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("AlertRulegroup: Reconciler", func() {
-	It("Results in NoMatchingInstances Condition", func() {
-		// Create object
-		noDataState := "NoData"
-		cr := &v1beta1.GrafanaAlertRuleGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "no-match",
-				Namespace: "default",
-			},
-			Spec: v1beta1.GrafanaAlertRuleGroupSpec{
-				GrafanaCommonSpec: instanceSelectorNoMatchingInstances,
-				FolderUID:         "GroupUID",
-				Rules: []v1beta1.AlertRule{
-					{
-						Title:        "TestRule",
-						UID:          "akdj-wonvo",
-						ExecErrState: "KeepLast",
-						NoDataState:  &noDataState,
-						For:          &metav1.Duration{Duration: 60 * time.Second},
-						Data:         []*v1beta1.AlertQuery{},
-					},
+var _ = Describe("AlertRulegroup Reconciler: Provoke Conditions", func() {
+	noDataState := "NoData"
+	rules := []v1beta1.AlertRule{
+		{
+			Title:        "TestRule",
+			UID:          "akdj-wonvo",
+			ExecErrState: "KeepLast",
+			NoDataState:  &noDataState,
+			For:          &metav1.Duration{Duration: 60 * time.Second},
+			Data:         []*v1beta1.AlertQuery{},
+		},
+	}
+	tests := []struct {
+		name          string
+		cr            *v1beta1.GrafanaAlertRuleGroup
+		wantCondition string
+		wantReason    string
+	}{
+		{
+			name: "Suspend Condition",
+			cr: &v1beta1.GrafanaAlertRuleGroup{
+				ObjectMeta: objectMetaSuspended,
+				Spec: v1beta1.GrafanaAlertRuleGroupSpec{
+					GrafanaCommonSpec: commonSpecSuspended,
+					FolderUID:         "GroupUID",
+					Rules:             rules,
 				},
 			},
-		}
-		ctx := context.Background()
-		err := k8sClient.Create(ctx, cr)
-		Expect(err).ToNot(HaveOccurred())
+			wantCondition: conditionSuspended,
+			wantReason:    conditionReasonApplySuspended,
+		},
+		{
+			name: "NoMatchingInstances Condition",
+			cr: &v1beta1.GrafanaAlertRuleGroup{
+				ObjectMeta: objectMetaNoMatchingInstances,
+				Spec: v1beta1.GrafanaAlertRuleGroupSpec{
+					GrafanaCommonSpec: commonSpecNoMatchingInstances,
+					FolderUID:         "GroupUID",
+					Rules:             rules,
+				},
+			},
+			wantCondition: conditionNoMatchingInstance,
+			wantReason:    conditionReasonEmptyAPIReply,
+		},
+	}
 
-		// Reconciliation Request
-		req := requestFromMeta(cr.ObjectMeta)
+	for _, test := range tests {
+		It(test.name, func() {
+			err := k8sClient.Create(testCtx, test.cr)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Reconcile
-		r := GrafanaAlertRuleGroupReconciler{Client: k8sClient}
-		_, err = r.Reconcile(ctx, req)
-		Expect(err).ShouldNot(HaveOccurred()) // NoMatchingInstances is a valid reconciliation result
+			req := requestFromMeta(test.cr.ObjectMeta)
 
-		resultCr := &v1beta1.GrafanaAlertRuleGroup{}
-		Expect(r.Get(ctx, req.NamespacedName, resultCr)).Should(Succeed()) // NoMatchingInstances is a valid status
+			// Reconcile
+			r := GrafanaAlertRuleGroupReconciler{Client: k8sClient}
+			_, err = r.Reconcile(testCtx, req)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Verify NoMatchingInstances condition
-		Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", conditionNoMatchingInstance)))
-	})
+			resultCr := &v1beta1.GrafanaAlertRuleGroup{}
+			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+
+			// Verify condition
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+		})
+	}
 })

--- a/controllers/contactpoint_controller.go
+++ b/controllers/contactpoint_controller.go
@@ -81,7 +81,7 @@ func (r *GrafanaContactPointReconciler) Reconcile(ctx context.Context, req ctrl.
 	defer UpdateStatus(ctx, r.Client, contactPoint)
 
 	if contactPoint.Spec.Suspend {
-		setSuspended(&contactPoint.Status.Conditions, contactPoint.Generation, conditionApplySuspended)
+		setSuspended(&contactPoint.Status.Conditions, contactPoint.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&contactPoint.Status.Conditions, conditionContactPointSynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/contactpoint_controller.go
+++ b/controllers/contactpoint_controller.go
@@ -80,6 +80,12 @@ func (r *GrafanaContactPointReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	defer UpdateStatus(ctx, r.Client, contactPoint)
 
+	if contactPoint.Spec.Suspend {
+		setSuspended(&contactPoint.Status.Conditions, contactPoint.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&contactPoint.Status.Conditions)
+
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, contactPoint)
 	if err != nil {
 		setNoMatchingInstancesCondition(&contactPoint.Status.Conditions, contactPoint.Generation, err)

--- a/controllers/contactpoint_controller.go
+++ b/controllers/contactpoint_controller.go
@@ -82,6 +82,7 @@ func (r *GrafanaContactPointReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	if contactPoint.Spec.Suspend {
 		setSuspended(&contactPoint.Status.Conditions, contactPoint.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&contactPoint.Status.Conditions, conditionContactPointSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&contactPoint.Status.Conditions)

--- a/controllers/contactpoint_controller_test.go
+++ b/controllers/contactpoint_controller_test.go
@@ -1,47 +1,69 @@
 package controllers
 
 import (
-	"context"
-
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ContactPoint: Reconciler", func() {
-	It("Results in NoMatchingInstances Condition", func() {
-		// Create object
-		cr := &v1beta1.GrafanaContactPoint{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "no-match",
-				Namespace: "default",
+var _ = Describe("ContactPoint Reconciler: Provoke Conditions", func() {
+	tests := []struct {
+		name          string
+		cr            *v1beta1.GrafanaContactPoint
+		wantCondition string
+		wantReason    string
+	}{
+		{
+			name: "Suspended Condition",
+			cr: &v1beta1.GrafanaContactPoint{
+				ObjectMeta: objectMetaSuspended,
+				Spec: v1beta1.GrafanaContactPointSpec{
+					GrafanaCommonSpec: commonSpecSuspended,
+					Name:              "ContactPointName",
+					Settings:          &v1.JSON{Raw: []byte("{}")},
+					Type:              "webhook",
+				},
 			},
-			Spec: v1beta1.GrafanaContactPointSpec{
-				GrafanaCommonSpec: instanceSelectorNoMatchingInstances,
-				Name:              "ContactPointName",
-				Settings:          &v1.JSON{Raw: []byte("{}")},
-				Type:              "webhook",
+			wantCondition: conditionSuspended,
+			wantReason:    conditionReasonApplySuspended,
+		},
+		{
+			name: "NoMatchingInstances Condition",
+			cr: &v1beta1.GrafanaContactPoint{
+				ObjectMeta: objectMetaNoMatchingInstances,
+				Spec: v1beta1.GrafanaContactPointSpec{
+					GrafanaCommonSpec: commonSpecNoMatchingInstances,
+					Name:              "ContactPointName",
+					Settings:          &v1.JSON{Raw: []byte("{}")},
+					Type:              "webhook",
+				},
 			},
-		}
-		ctx := context.Background()
-		err := k8sClient.Create(ctx, cr)
-		Expect(err).ToNot(HaveOccurred())
+			wantCondition: conditionNoMatchingInstance,
+			wantReason:    conditionReasonEmptyAPIReply,
+		},
+	}
 
-		// Reconciliation Request
-		req := requestFromMeta(cr.ObjectMeta)
+	for _, test := range tests {
+		It(test.name, func() {
+			err := k8sClient.Create(testCtx, test.cr)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Reconcile
-		r := GrafanaContactPointReconciler{Client: k8sClient}
-		_, err = r.Reconcile(ctx, req)
-		Expect(err).ShouldNot(HaveOccurred()) // NoMatchingInstances is a valid reconciliation result
+			// Reconciliation Request
+			req := requestFromMeta(test.cr.ObjectMeta)
 
-		resultCr := &v1beta1.GrafanaContactPoint{}
-		Expect(r.Get(ctx, req.NamespacedName, resultCr)).Should(Succeed()) // NoMatchingInstances is a valid status
+			// Reconcile
+			r := GrafanaContactPointReconciler{Client: k8sClient}
+			_, err = r.Reconcile(testCtx, req)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Verify NoMatchingInstances condition
-		Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", conditionNoMatchingInstance)))
-	})
+			resultCr := &v1beta1.GrafanaContactPoint{}
+			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+
+			// Verify Condition
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+		})
+	}
 })

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -41,9 +41,10 @@ const (
 	conditionSuspended                      = "Suspended"
 
 	// condition reasons
-	conditionApplySuccessful = "ApplySuccessful"
-	conditionApplyFailed     = "ApplyFailed"
-	conditionApplySuspended  = "ApplySuspended"
+	conditionReasonApplySuccessful = "ApplySuccessful"
+	conditionReasonApplyFailed     = "ApplyFailed"
+	conditionReasonApplySuspended  = "ApplySuspended"
+	conditionReasonEmptyAPIReply   = "EmptyAPIReply"
 
 	// Finalizer
 	grafanaFinalizer = "operator.grafana.com/finalizer"
@@ -223,7 +224,7 @@ func setNoMatchingInstancesCondition(conditions *[]metav1.Condition, generation 
 		reason = "ErrFetchingInstances"
 		message = fmt.Sprintf("error occurred during fetching of instances: %s", err.Error())
 	} else {
-		reason = "EmptyAPIReply"
+		reason = conditionReasonEmptyAPIReply
 		message = "None of the available Grafana instances matched the selector, skipping reconciliation"
 	}
 	meta.SetStatusCondition(conditions, metav1.Condition{
@@ -313,11 +314,11 @@ func buildSynchronizedCondition(resource string, syncType string, generation int
 
 	if len(applyErrors) == 0 {
 		condition.Status = metav1.ConditionTrue
-		condition.Reason = conditionApplySuccessful
+		condition.Reason = conditionReasonApplySuccessful
 		condition.Message = fmt.Sprintf("%s was successfully applied to %d instances", resource, total)
 	} else {
 		condition.Status = metav1.ConditionFalse
-		condition.Reason = conditionApplyFailed
+		condition.Reason = conditionReasonApplyFailed
 
 		var sb strings.Builder
 		for i, err := range applyErrors {

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -38,10 +38,12 @@ const (
 	conditionNoMatchingFolder               = "NoMatchingFolder"
 	conditionInvalidSpec                    = "InvalidSpec"
 	conditionNotificationPolicyLoopDetected = "NotificationPolicyLoopDetected"
+	conditionSuspended                      = "Suspended"
 
 	// condition reasons
 	conditionApplySuccessful = "ApplySuccessful"
 	conditionApplyFailed     = "ApplyFailed"
+	conditionApplySuspended  = "ApplySuspended"
 
 	// Finalizer
 	grafanaFinalizer = "operator.grafana.com/finalizer"
@@ -272,6 +274,23 @@ func setInvalidSpec(conditions *[]metav1.Condition, generation int64, reason, me
 
 func removeInvalidSpec(conditions *[]metav1.Condition) {
 	meta.RemoveStatusCondition(conditions, conditionInvalidSpec)
+}
+
+func setSuspended(conditions *[]metav1.Condition, generation int64, reason string) {
+	*conditions = []metav1.Condition{{
+		Type:               conditionSuspended,
+		Reason:             reason,
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: generation,
+		LastTransitionTime: metav1.Time{
+			Time: time.Now(),
+		},
+		Message: "Resource changes are ignored",
+	}}
+}
+
+func removeSuspended(conditions *[]metav1.Condition) {
+	meta.RemoveStatusCondition(conditions, conditionSuspended)
 }
 
 func ignoreStatusUpdates() predicate.Predicate {

--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -31,11 +31,28 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var instanceSelectorNoMatchingInstances = v1beta1.GrafanaCommonSpec{
-	InstanceSelector: &metav1.LabelSelector{
-		MatchLabels: map[string]string{"test": "no-matching-instances"},
-	},
-}
+var (
+	objectMetaNoMatchingInstances = metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "no-match",
+	}
+	commonSpecNoMatchingInstances = v1beta1.GrafanaCommonSpec{
+		InstanceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"test": "no-matching-instances"},
+		},
+	}
+
+	objectMetaSuspended = metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "suspended",
+	}
+	commonSpecSuspended = v1beta1.GrafanaCommonSpec{
+		Suspend: true,
+		InstanceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"test": "suspended"},
+		},
+	}
+)
 
 func requestFromMeta(obj metav1.ObjectMeta) ctrl.Request {
 	GinkgoHelper()

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -91,6 +91,12 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	defer UpdateStatus(ctx, r.Client, cr)
 
+	if cr.Spec.Suspend {
+		setSuspended(&cr.Status.Conditions, cr.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&cr.Status.Conditions)
+
 	// Retrieving the model before the loop ensures to exit early in case of failure and not fail once per matching instance
 	resolver := content.NewContentResolver(cr, r.Client)
 	dashboardModel, hash, err := resolver.Resolve(ctx)

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -93,6 +93,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDashboardSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&cr.Status.Conditions)

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -92,7 +92,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	defer UpdateStatus(ctx, r.Client, cr)
 
 	if cr.Spec.Suspend {
-		setSuspended(&cr.Status.Conditions, cr.Generation, conditionApplySuspended)
+		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDashboardSynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -84,7 +84,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	defer UpdateStatus(ctx, r.Client, cr)
 
 	if cr.Spec.Suspend {
-		setSuspended(&cr.Status.Conditions, cr.Generation, conditionApplySuspended)
+		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDatasourceSynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -83,6 +83,12 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	defer UpdateStatus(ctx, r.Client, cr)
 
+	if cr.Spec.Suspend {
+		setSuspended(&cr.Status.Conditions, cr.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&cr.Status.Conditions)
+
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -85,6 +85,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDatasourceSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&cr.Status.Conditions)

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -82,7 +82,7 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	defer UpdateStatus(ctx, r.Client, folder)
 
 	if folder.Spec.Suspend {
-		setSuspended(&folder.Status.Conditions, folder.Generation, conditionApplySuspended)
+		setSuspended(&folder.Status.Conditions, folder.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&folder.Status.Conditions, conditionFolderSynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -81,6 +81,12 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	defer UpdateStatus(ctx, r.Client, folder)
 
+	if folder.Spec.Suspend {
+		setSuspended(&folder.Status.Conditions, folder.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&folder.Status.Conditions)
+
 	if folder.Spec.ParentFolderUID == folder.CustomUIDOrUID() {
 		setInvalidSpec(&folder.Status.Conditions, folder.Generation, "CyclicParent", "The value of parentFolderUID must not be the uid of the current folder")
 		meta.RemoveStatusCondition(&folder.Status.Conditions, conditionFolderSynchronized)

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -83,6 +83,7 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if folder.Spec.Suspend {
 		setSuspended(&folder.Status.Conditions, folder.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&folder.Status.Conditions, conditionFolderSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&folder.Status.Conditions)

--- a/controllers/folder_controller_test.go
+++ b/controllers/folder_controller_test.go
@@ -1,43 +1,62 @@
 package controllers
 
 import (
-	"context"
-
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Folder: Reconciler", func() {
-	It("Results in NoMatchingInstances Condition", func() {
-		// Create object
-		cr := &v1beta1.GrafanaFolder{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "no-match",
-				Namespace: "default",
+var _ = Describe("Folder Reconciler: Provoke Conditions", func() {
+	tests := []struct {
+		name          string
+		cr            *v1beta1.GrafanaFolder
+		wantCondition string
+		wantReason    string
+	}{
+		{
+			name: "Suspended Condition",
+			cr: &v1beta1.GrafanaFolder{
+				ObjectMeta: objectMetaSuspended,
+				Spec: v1beta1.GrafanaFolderSpec{
+					GrafanaCommonSpec: commonSpecSuspended,
+				},
 			},
-			Spec: v1beta1.GrafanaFolderSpec{
-				GrafanaCommonSpec: instanceSelectorNoMatchingInstances,
+			wantCondition: conditionSuspended,
+			wantReason:    conditionReasonApplySuspended,
+		},
+		{
+			name: "NoMatchingInstances Condition",
+			cr: &v1beta1.GrafanaFolder{
+				ObjectMeta: objectMetaNoMatchingInstances,
+				Spec: v1beta1.GrafanaFolderSpec{
+					GrafanaCommonSpec: commonSpecNoMatchingInstances,
+				},
 			},
-		}
-		ctx := context.Background()
-		err := k8sClient.Create(ctx, cr)
-		Expect(err).ToNot(HaveOccurred())
+			wantCondition: conditionNoMatchingInstance,
+			wantReason:    conditionReasonEmptyAPIReply,
+		},
+	}
 
-		// Reconciliation Request
-		req := requestFromMeta(cr.ObjectMeta)
+	for _, test := range tests {
+		It(test.name, func() {
+			err := k8sClient.Create(testCtx, test.cr)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Reconcile
-		r := GrafanaFolderReconciler{Client: k8sClient}
-		_, err = r.Reconcile(ctx, req)
-		Expect(err).ShouldNot(HaveOccurred()) // NoMatchingInstances is a valid reconciliation result
+			// Reconciliation Request
+			req := requestFromMeta(test.cr.ObjectMeta)
 
-		resultCr := &v1beta1.GrafanaFolder{}
-		Expect(r.Get(ctx, req.NamespacedName, resultCr)).Should(Succeed()) // NoMatchingInstances is a valid status
+			// Reconcile
+			r := GrafanaFolderReconciler{Client: k8sClient}
+			_, err = r.Reconcile(testCtx, req)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Verify NoMatchingInstances condition
-		Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", conditionNoMatchingInstance)))
-	})
+			resultCr := &v1beta1.GrafanaFolder{}
+			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+
+			// Verify Condition
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+		})
+	}
 })

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -92,6 +92,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReconcileSuspended)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, ConditionTypeGrafanaReady)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&cr.Status.Conditions)

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -46,7 +46,8 @@ import (
 )
 
 const (
-	ConditionTypeGrafanaReady = "GrafanaReady"
+	ConditionTypeGrafanaReady   = "GrafanaReady"
+	conditionReconcileSuspended = "ReconcileSuspended"
 )
 
 // GrafanaReconciler reconciles a Grafana object
@@ -88,6 +89,12 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			log.Error(err, "updating status")
 		}
 	}()
+
+	if cr.Spec.Suspend {
+		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReconcileSuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&cr.Status.Conditions)
 
 	var stages []grafanav1beta1.OperatorStageName
 	if cr.IsExternal() {

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -46,8 +46,8 @@ import (
 )
 
 const (
-	ConditionTypeGrafanaReady   = "GrafanaReady"
-	conditionReconcileSuspended = "ReconcileSuspended"
+	conditionTypeGrafanaReady         = "GrafanaReady"
+	conditionReasonReconcileSuspended = "ReconcileSuspended"
 )
 
 // GrafanaReconciler reconciles a Grafana object
@@ -91,8 +91,8 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}()
 
 	if cr.Spec.Suspend {
-		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReconcileSuspended)
-		meta.RemoveStatusCondition(&cr.Status.Conditions, ConditionTypeGrafanaReady)
+		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonReconcileSuspended)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionTypeGrafanaReady)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&cr.Status.Conditions)
@@ -111,7 +111,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if cr.Spec.Version == "" {
 			err := r.setDefaultGrafanaVersion(ctx, cr)
 			if err != nil {
-				meta.RemoveStatusCondition(&cr.Status.Conditions, ConditionTypeGrafanaReady)
+				meta.RemoveStatusCondition(&cr.Status.Conditions, conditionTypeGrafanaReady)
 				return ctrl.Result{}, fmt.Errorf("patching grafana version in spec: %w", err)
 			}
 		}
@@ -135,7 +135,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			cr.Status.LastMessage = err.Error()
 
 			metrics.GrafanaFailedReconciles.WithLabelValues(cr.Namespace, cr.Name, string(stage)).Inc()
-			meta.RemoveStatusCondition(&cr.Status.Conditions, ConditionTypeGrafanaReady)
+			meta.RemoveStatusCondition(&cr.Status.Conditions, conditionTypeGrafanaReady)
 			return ctrl.Result{}, fmt.Errorf("reconciler error in stage '%s': %w", stage, err)
 		}
 	}
@@ -144,7 +144,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	cr.Status.LastMessage = ""
 
 	meta.SetStatusCondition(&cr.Status.Conditions, metav1.Condition{
-		Type:               ConditionTypeGrafanaReady, // Maybe use Grafana instead to be consistent with other conditions
+		Type:               conditionTypeGrafanaReady, // Maybe use Grafana instead to be consistent with other conditions
 		Reason:             "GrafanaReady",
 		Message:            "Grafana reconcile completed",
 		ObservedGeneration: cr.Generation,

--- a/controllers/grafana_controller_test.go
+++ b/controllers/grafana_controller_test.go
@@ -6,6 +6,9 @@ import (
 	v1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func TestRemoveMissingCRs(t *testing.T) {
@@ -45,3 +48,45 @@ func TestRemoveMissingCRs(t *testing.T) {
 	found, _ := statusList.Find("default", "unrelated-dashboard")
 	assert.False(t, found, "Dashboard is not in status and should not be")
 }
+
+var _ = Describe("Grafana Reconciler: Provoke Conditions", func() {
+	tests := []struct {
+		name          string
+		cr            *v1beta1.Grafana
+		wantCondition string
+		wantReason    string
+	}{
+		{
+			name: "Suspend Condition",
+			cr: &v1beta1.Grafana{
+				ObjectMeta: objectMetaSuspended,
+				Spec: v1beta1.GrafanaSpec{
+					Suspend: true,
+				},
+			},
+			wantCondition: conditionSuspended,
+			wantReason:    conditionReasonReconcileSuspended,
+		},
+	}
+
+	for _, test := range tests {
+		It(test.name, func() {
+			err := k8sClient.Create(testCtx, test.cr)
+			Expect(err).ToNot(HaveOccurred())
+
+			req := requestFromMeta(test.cr.ObjectMeta)
+
+			// Reconcile
+			r := GrafanaReconciler{Client: k8sClient}
+			_, err = r.Reconcile(testCtx, req)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			resultCr := &v1beta1.Grafana{}
+			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+
+			// Verify condition
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+		})
+	}
+})

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -90,7 +90,11 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	defer UpdateStatus(ctx, r.Client, libraryPanel)
 
-	// begin validation checks
+	if libraryPanel.Spec.Suspend {
+		setSuspended(&libraryPanel.Status.Conditions, libraryPanel.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&libraryPanel.Status.Conditions)
 
 	resolver := content.NewContentResolver(libraryPanel, r.Client, content.WithDisabledSources([]content.ContentSourceType{
 		// grafana.com does not currently support hosting library panels for distribution, but perhaps

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -92,6 +92,7 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	if libraryPanel.Spec.Suspend {
 		setSuspended(&libraryPanel.Status.Conditions, libraryPanel.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&libraryPanel.Status.Conditions, conditionLibraryPanelSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&libraryPanel.Status.Conditions)

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -91,7 +91,7 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 	defer UpdateStatus(ctx, r.Client, libraryPanel)
 
 	if libraryPanel.Spec.Suspend {
-		setSuspended(&libraryPanel.Status.Conditions, libraryPanel.Generation, conditionApplySuspended)
+		setSuspended(&libraryPanel.Status.Conditions, libraryPanel.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&libraryPanel.Status.Conditions, conditionLibraryPanelSynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/librarypanel_controller_test.go
+++ b/controllers/librarypanel_controller_test.go
@@ -1,44 +1,64 @@
 package controllers
 
 import (
-	"context"
-
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("LibraryPanel: Reconciler", func() {
-	It("Results in NoMatchingInstances Condition", func() {
-		// Create object
-		cr := &v1beta1.GrafanaLibraryPanel{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "no-match",
-				Namespace: "default",
+var _ = Describe("LibraryPanel Reconciler: Provoke Conditions", func() {
+	tests := []struct {
+		name          string
+		cr            *v1beta1.GrafanaLibraryPanel
+		wantCondition string
+		wantReason    string
+	}{
+		{
+			name: "Suspended Condition",
+			cr: &v1beta1.GrafanaLibraryPanel{
+				ObjectMeta: objectMetaSuspended,
+				Spec: v1beta1.GrafanaLibraryPanelSpec{
+					GrafanaCommonSpec:  commonSpecSuspended,
+					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
+				},
 			},
-			Spec: v1beta1.GrafanaLibraryPanelSpec{
-				GrafanaCommonSpec:  instanceSelectorNoMatchingInstances,
-				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
+			wantCondition: conditionSuspended,
+			wantReason:    conditionReasonApplySuspended,
+		},
+		{
+			name: "NoMatchingInstances Condition",
+			cr: &v1beta1.GrafanaLibraryPanel{
+				ObjectMeta: objectMetaNoMatchingInstances,
+				Spec: v1beta1.GrafanaLibraryPanelSpec{
+					GrafanaCommonSpec:  commonSpecNoMatchingInstances,
+					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
+				},
 			},
-		}
-		ctx := context.Background()
-		err := k8sClient.Create(ctx, cr)
-		Expect(err).ToNot(HaveOccurred())
+			wantCondition: conditionNoMatchingInstance,
+			wantReason:    conditionReasonEmptyAPIReply,
+		},
+	}
 
-		// Reconciliation Request
-		req := requestFromMeta(cr.ObjectMeta)
+	for _, test := range tests {
+		It(test.name, func() {
+			err := k8sClient.Create(testCtx, test.cr)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Reconcile
-		r := GrafanaLibraryPanelReconciler{Client: k8sClient}
-		_, err = r.Reconcile(ctx, req)
-		Expect(err).ShouldNot(HaveOccurred()) // NoMatchingInstances is a valid reconciliation result
+			// Reconciliation Request
+			req := requestFromMeta(test.cr.ObjectMeta)
 
-		resultCr := &v1beta1.GrafanaLibraryPanel{}
-		Expect(r.Get(ctx, req.NamespacedName, resultCr)).Should(Succeed()) // NoMatchingInstances is a valid status
+			// Reconcile
+			r := GrafanaLibraryPanelReconciler{Client: k8sClient}
+			_, err = r.Reconcile(testCtx, req)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Verify NoMatchingInstances condition
-		Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", conditionNoMatchingInstance)))
-	})
+			resultCr := &v1beta1.GrafanaLibraryPanel{}
+			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+
+			// Verify Condition
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+		})
+	}
 })

--- a/controllers/mutetiming_controller.go
+++ b/controllers/mutetiming_controller.go
@@ -79,6 +79,7 @@ func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if muteTiming.Spec.Suspend {
 		setSuspended(&muteTiming.Status.Conditions, muteTiming.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&muteTiming.Status.Conditions, conditionMuteTimingSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&muteTiming.Status.Conditions)

--- a/controllers/mutetiming_controller.go
+++ b/controllers/mutetiming_controller.go
@@ -78,7 +78,7 @@ func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	defer UpdateStatus(ctx, r.Client, muteTiming)
 
 	if muteTiming.Spec.Suspend {
-		setSuspended(&muteTiming.Status.Conditions, muteTiming.Generation, conditionApplySuspended)
+		setSuspended(&muteTiming.Status.Conditions, muteTiming.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&muteTiming.Status.Conditions, conditionMuteTimingSynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/mutetiming_controller.go
+++ b/controllers/mutetiming_controller.go
@@ -77,6 +77,12 @@ func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	defer UpdateStatus(ctx, r.Client, muteTiming)
 
+	if muteTiming.Spec.Suspend {
+		setSuspended(&muteTiming.Status.Conditions, muteTiming.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&muteTiming.Status.Conditions)
+
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, muteTiming)
 	if err != nil {
 		setNoMatchingInstancesCondition(&muteTiming.Status.Conditions, muteTiming.Generation, err)

--- a/controllers/mutetiming_controller_test.go
+++ b/controllers/mutetiming_controller_test.go
@@ -1,58 +1,92 @@
 package controllers
 
 import (
-	"context"
-
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("MuteTiming: Reconciler", func() {
-	It("Results in NoMatchingInstances Condition", func() {
-		// Create object
-		cr := &v1beta1.GrafanaMuteTiming{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "no-match",
-				Namespace: "default",
-			},
-			Spec: v1beta1.GrafanaMuteTimingSpec{
-				GrafanaCommonSpec: instanceSelectorNoMatchingInstances,
-				TimeIntervals: []*v1beta1.TimeInterval{
-					{
-						DaysOfMonth: []string{"1"},
-						Location:    "Europe/Copenhagen",
-						Months:      []string{"1"},
-						Times: []*v1beta1.TimeRange{
-							{
-								StartTime: "00:00",
-								EndTime:   "02:00",
+var _ = Describe("MuteTiming Reconciler: Provoke Conditions", func() {
+	tests := []struct {
+		name          string
+		cr            *v1beta1.GrafanaMuteTiming
+		wantCondition string
+		wantReason    string
+	}{
+		{
+			name: "Suspended Condition",
+			cr: &v1beta1.GrafanaMuteTiming{
+				ObjectMeta: objectMetaSuspended,
+				Spec: v1beta1.GrafanaMuteTimingSpec{
+					GrafanaCommonSpec: commonSpecSuspended,
+					TimeIntervals: []*v1beta1.TimeInterval{
+						{
+							DaysOfMonth: []string{"1"},
+							Location:    "Europe/Copenhagen",
+							Months:      []string{"1"},
+							Times: []*v1beta1.TimeRange{
+								{
+									StartTime: "00:00",
+									EndTime:   "02:00",
+								},
 							},
+							Weekdays: []string{"1"},
+							Years:    []string{"2025"},
 						},
-						Weekdays: []string{"1"},
-						Years:    []string{"2025"},
 					},
 				},
 			},
-		}
-		ctx := context.Background()
-		err := k8sClient.Create(ctx, cr)
-		Expect(err).ToNot(HaveOccurred())
+			wantCondition: conditionSuspended,
+			wantReason:    conditionReasonApplySuspended,
+		},
+		{
+			name: "NoMatchingInstances Condition",
+			cr: &v1beta1.GrafanaMuteTiming{
+				ObjectMeta: objectMetaNoMatchingInstances,
+				Spec: v1beta1.GrafanaMuteTimingSpec{
+					GrafanaCommonSpec: commonSpecNoMatchingInstances,
+					TimeIntervals: []*v1beta1.TimeInterval{
+						{
+							DaysOfMonth: []string{"1"},
+							Location:    "Europe/Copenhagen",
+							Months:      []string{"1"},
+							Times: []*v1beta1.TimeRange{
+								{
+									StartTime: "00:00",
+									EndTime:   "02:00",
+								},
+							},
+							Weekdays: []string{"1"},
+							Years:    []string{"2025"},
+						},
+					},
+				},
+			},
+			wantCondition: conditionNoMatchingInstance,
+			wantReason:    conditionReasonEmptyAPIReply,
+		},
+	}
 
-		// Reconciliation Request
-		req := requestFromMeta(cr.ObjectMeta)
+	for _, test := range tests {
+		It(test.name, func() {
+			err := k8sClient.Create(testCtx, test.cr)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Reconcile
-		r := GrafanaMuteTimingReconciler{Client: k8sClient}
-		_, err = r.Reconcile(ctx, req)
-		Expect(err).ShouldNot(HaveOccurred()) // NoMatchingInstances is a valid reconciliation result
+			// Reconciliation Request
+			req := requestFromMeta(test.cr.ObjectMeta)
 
-		resultCr := &v1beta1.GrafanaMuteTiming{}
-		Expect(r.Get(ctx, req.NamespacedName, resultCr)).Should(Succeed()) // NoMatchingInstances is a valid status
+			// Reconcile
+			r := GrafanaMuteTimingReconciler{Client: k8sClient}
+			_, err = r.Reconcile(testCtx, req)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Verify NoMatchingInstances condition
-		Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", conditionNoMatchingInstance)))
-	})
+			resultCr := &v1beta1.GrafanaMuteTiming{}
+			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+
+			// Verify Condition
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+		})
+	}
 })

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -91,6 +91,12 @@ func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req
 
 	defer UpdateStatus(ctx, r.Client, notificationPolicy)
 
+	if notificationPolicy.Spec.Suspend {
+		setSuspended(&notificationPolicy.Status.Conditions, notificationPolicy.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&notificationPolicy.Status.Conditions)
+
 	// check if spec is valid
 	if !notificationPolicy.Spec.Route.IsRouteSelectorMutuallyExclusive() {
 		setInvalidSpecMutuallyExclusive(&notificationPolicy.Status.Conditions, notificationPolicy.Generation)

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -93,6 +93,7 @@ func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req
 
 	if notificationPolicy.Spec.Suspend {
 		setSuspended(&notificationPolicy.Status.Conditions, notificationPolicy.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&notificationPolicy.Status.Conditions, conditionNotificationPolicySynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&notificationPolicy.Status.Conditions)
@@ -100,6 +101,7 @@ func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req
 	// check if spec is valid
 	if !notificationPolicy.Spec.Route.IsRouteSelectorMutuallyExclusive() {
 		setInvalidSpecMutuallyExclusive(&notificationPolicy.Status.Conditions, notificationPolicy.Generation)
+		meta.RemoveStatusCondition(&notificationPolicy.Status.Conditions, conditionNotificationPolicySynchronized)
 		return ctrl.Result{}, fmt.Errorf("invalid route spec discovered: routeSelector is mutually exclusive with routes")
 	}
 	removeInvalidSpec(&notificationPolicy.Status.Conditions)

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -92,7 +92,7 @@ func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req
 	defer UpdateStatus(ctx, r.Client, notificationPolicy)
 
 	if notificationPolicy.Spec.Suspend {
-		setSuspended(&notificationPolicy.Status.Conditions, notificationPolicy.Generation, conditionApplySuspended)
+		setSuspended(&notificationPolicy.Status.Conditions, notificationPolicy.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&notificationPolicy.Status.Conditions, conditionNotificationPolicySynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/notificationtemplate_controller.go
+++ b/controllers/notificationtemplate_controller.go
@@ -76,6 +76,12 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 
 	defer UpdateStatus(ctx, r.Client, notificationTemplate)
 
+	if notificationTemplate.Spec.Suspend {
+		setSuspended(&notificationTemplate.Status.Conditions, notificationTemplate.Generation, conditionApplySuspended)
+		return ctrl.Result{}, nil
+	}
+	removeSuspended(&notificationTemplate.Status.Conditions)
+
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, notificationTemplate)
 	if err != nil {
 		setNoMatchingInstancesCondition(&notificationTemplate.Status.Conditions, notificationTemplate.Generation, err)

--- a/controllers/notificationtemplate_controller.go
+++ b/controllers/notificationtemplate_controller.go
@@ -77,7 +77,7 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 	defer UpdateStatus(ctx, r.Client, notificationTemplate)
 
 	if notificationTemplate.Spec.Suspend {
-		setSuspended(&notificationTemplate.Status.Conditions, notificationTemplate.Generation, conditionApplySuspended)
+		setSuspended(&notificationTemplate.Status.Conditions, notificationTemplate.Generation, conditionReasonApplySuspended)
 		meta.RemoveStatusCondition(&notificationTemplate.Status.Conditions, conditionNotificationTemplateSynchronized)
 		return ctrl.Result{}, nil
 	}

--- a/controllers/notificationtemplate_controller.go
+++ b/controllers/notificationtemplate_controller.go
@@ -78,6 +78,7 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 
 	if notificationTemplate.Spec.Suspend {
 		setSuspended(&notificationTemplate.Status.Conditions, notificationTemplate.Generation, conditionApplySuspended)
+		meta.RemoveStatusCondition(&notificationTemplate.Status.Conditions, conditionNotificationTemplateSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&notificationTemplate.Status.Conditions)

--- a/controllers/notificationtemplate_controller_test.go
+++ b/controllers/notificationtemplate_controller_test.go
@@ -1,44 +1,64 @@
 package controllers
 
 import (
-	"context"
-
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("NotificationTemplate: Reconciler", func() {
-	It("Results in NoMatchingInstances Condition", func() {
-		// Create object
-		cr := &v1beta1.GrafanaNotificationTemplate{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "no-match",
-				Namespace: "default",
+var _ = Describe("NotificationTemplate Reconciler: Provoke Conditions", func() {
+	tests := []struct {
+		name          string
+		cr            *v1beta1.GrafanaNotificationTemplate
+		wantCondition string
+		wantReason    string
+	}{
+		{
+			name: "Suspended Condition",
+			cr: &v1beta1.GrafanaNotificationTemplate{
+				ObjectMeta: objectMetaSuspended,
+				Spec: v1beta1.GrafanaNotificationTemplateSpec{
+					GrafanaCommonSpec: commonSpecSuspended,
+					Name:              "Suspended",
+				},
 			},
-			Spec: v1beta1.GrafanaNotificationTemplateSpec{
-				GrafanaCommonSpec: instanceSelectorNoMatchingInstances,
-				Name:              "NoMatch",
+			wantCondition: conditionSuspended,
+			wantReason:    conditionReasonApplySuspended,
+		},
+		{
+			name: "NoMatchingInstances Condition",
+			cr: &v1beta1.GrafanaNotificationTemplate{
+				ObjectMeta: objectMetaNoMatchingInstances,
+				Spec: v1beta1.GrafanaNotificationTemplateSpec{
+					GrafanaCommonSpec: commonSpecNoMatchingInstances,
+					Name:              "NoMatch",
+				},
 			},
-		}
-		ctx := context.Background()
-		err := k8sClient.Create(ctx, cr)
-		Expect(err).ToNot(HaveOccurred())
+			wantCondition: conditionNoMatchingInstance,
+			wantReason:    conditionReasonEmptyAPIReply,
+		},
+	}
 
-		// Reconciliation Request
-		req := requestFromMeta(cr.ObjectMeta)
+	for _, test := range tests {
+		It(test.name, func() {
+			err := k8sClient.Create(testCtx, test.cr)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Reconcile
-		r := GrafanaNotificationTemplateReconciler{Client: k8sClient}
-		_, err = r.Reconcile(ctx, req)
-		Expect(err).ShouldNot(HaveOccurred()) // NoMatchingInstances is a valid reconciliation result
+			// Reconciliation Request
+			req := requestFromMeta(test.cr.ObjectMeta)
 
-		resultCr := &v1beta1.GrafanaNotificationTemplate{}
-		Expect(r.Get(ctx, req.NamespacedName, resultCr)).Should(Succeed()) // NoMatchingInstances is a valid status
+			// Reconcile
+			r := GrafanaNotificationTemplateReconciler{Client: k8sClient}
+			_, err = r.Reconcile(testCtx, req)
+			Expect(err).ShouldNot(HaveOccurred())
 
-		// Verify NoMatchingInstances condition
-		Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", conditionNoMatchingInstance)))
-	})
+			resultCr := &v1beta1.GrafanaNotificationTemplate{}
+			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+
+			// Verify Condition
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
+			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+		})
+	}
 })

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -38,6 +39,7 @@ import (
 var (
 	k8sClient client.Client
 	testEnv   *envtest.Environment
+	testCtx   context.Context
 )
 
 func TestAPIs(t *testing.T) {
@@ -47,6 +49,8 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	testCtx = context.Background()
+
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -263,6 +263,10 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
             required:
             - instanceSelector
             - interval

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -116,6 +116,10 @@ spec:
                 type: string
               settings:
                 x-kubernetes-preserve-unknown-fields: true
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               type:
                 minLength: 1
                 type: string

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
@@ -331,6 +331,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   Manually specify the uid, overwrites uids already present in the json model.

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanadatasources.yaml
@@ -163,6 +163,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   The UID, for the datasource, fallback to the deprecated spec.datasource.uid

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -124,6 +124,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               title:
                 description: Display name of the folder in Grafana
                 type: string

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanalibrarypanels.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanalibrarypanels.yaml
@@ -326,6 +326,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   Manually specify the uid, overwrites uids already present in the json model.

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanamutetimings.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanamutetimings.yaml
@@ -120,6 +120,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               time_intervals:
                 description: Time intervals for muting
                 items:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -241,6 +241,10 @@ spec:
                 required:
                 - receiver
                 type: object
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
             required:
             - instanceSelector
             - route

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationtemplates.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafananotificationtemplates.yaml
@@ -121,6 +121,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               template:
                 description: Template content
                 type: string

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
@@ -4944,6 +4944,9 @@ spec:
                         x-kubernetes-map-type: atomic
                       type: array
                   type: object
+                suspend:
+                  description: Suspend pauses reconciliation of owned resources like deployments, Services, Etc. upon changes
+                  type: boolean
                 version:
                   description: Version specifies the version of Grafana to use for this deployment. It follows the same format as the docker.io/grafana/grafana tags
                   type: string

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -262,6 +262,10 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
             required:
             - instanceSelector
             - interval
@@ -476,6 +480,10 @@ spec:
                 type: string
               settings:
                 x-kubernetes-preserve-unknown-fields: true
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               type:
                 minLength: 1
                 type: string
@@ -974,6 +982,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   Manually specify the uid, overwrites uids already present in the json model.
@@ -1315,6 +1327,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   The UID, for the datasource, fallback to the deprecated spec.datasource.uid
@@ -1614,6 +1630,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               title:
                 description: Display name of the folder in Grafana
                 type: string
@@ -2049,6 +2069,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               uid:
                 description: |-
                   Manually specify the uid, overwrites uids already present in the json model.
@@ -2339,6 +2363,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               time_intervals:
                 description: Time intervals for muting
                 items:
@@ -2721,6 +2749,10 @@ spec:
                 required:
                 - receiver
                 type: object
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
             required:
             - instanceSelector
             - route
@@ -3172,6 +3204,10 @@ spec:
                   not set
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
+              suspend:
+                description: Suspend pauses synchronizing attempts and tells the operator
+                  to ignore changes
+                type: boolean
               template:
                 description: Template content
                 type: string
@@ -8298,6 +8334,10 @@ spec:
                       x-kubernetes-map-type: atomic
                     type: array
                 type: object
+              suspend:
+                description: Suspend pauses reconciliation of owned resources like
+                  deployments, Services, Etc. upon changes
+                type: boolean
               version:
                 description: Version specifies the version of Grafana to use for this
                   deployment. It follows the same format as the docker.io/grafana/grafana

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -186,6 +186,13 @@ Overrides the FolderSelector<br/>
             <i>Default</i>: 10m0s<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -812,6 +819,13 @@ GrafanaContactPointSpec defines the desired state of GrafanaContactPoint
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>uid</b></td>
         <td>string</td>
         <td>
@@ -1386,6 +1400,13 @@ GrafanaDashboardSpec defines the desired state of GrafanaDashboard
           How often the resource is synced, defaults to 10m0s if not set<br/>
           <br/>
             <i>Default</i>: 10m0s<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2415,6 +2436,13 @@ GrafanaDatasourceSpec defines the desired state of GrafanaDatasource
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>uid</b></td>
         <td>string</td>
         <td>
@@ -3097,6 +3125,13 @@ GrafanaFolderSpec defines the desired state of GrafanaFolder
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>title</b></td>
         <td>string</td>
         <td>
@@ -3514,6 +3549,13 @@ GrafanaLibraryPanelSpec defines the desired state of GrafanaLibraryPanel
           How often the resource is synced, defaults to 10m0s if not set<br/>
           <br/>
             <i>Default</i>: 10m0s<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4545,6 +4587,13 @@ GrafanaMuteTimingSpec defines the desired state of GrafanaMuteTiming
             <i>Default</i>: 10m0s<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -4956,6 +5005,13 @@ GrafanaNotificationPolicySpec defines the desired state of GrafanaNotificationPo
           How often the resource is synced, defaults to 10m0s if not set<br/>
           <br/>
             <i>Default</i>: 10m0s<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5931,6 +5987,13 @@ GrafanaNotificationTemplateSpec defines the desired state of GrafanaNotification
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses synchronizing attempts and tells the operator to ignore changes<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>template</b></td>
         <td>string</td>
         <td>
@@ -6296,6 +6359,13 @@ GrafanaSpec defines the desired state of Grafana
         <td>object</td>
         <td>
           ServiceAccount sets how the ServiceAccount object should look like with your grafana instance, contains a number of defaults.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>suspend</b></td>
+        <td>boolean</td>
+        <td>
+          Suspend pauses reconciliation of owned resources like deployments, Services, Etc. upon changes<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -127,6 +127,33 @@ Disabling requires a full recreate, delete and apply.
 
 This helps guaranteeing proper cleanup across all matched Grafana instances.
 
+## Suspending resources
+
+It can in many scenarios be useful to temporarily halt the reconciliation and synchronization of resources.
+
+This can be achieved with the `.spec.suspend` option on all resources, with the exception of `GrafanaNotificationPolicyRoutes`.
+
+```yaml
+apiVersion: grafana.integreatly.org/v1beta1
+kind: ...
+metadata:
+  name: suspended
+spec:
+  suspend: true
+...
+status:
+  conditions:
+  - lastTransitionTime: "2025-07-06T15:58:29Z"
+    message: Resource changes are ignored
+    observedGeneration: 2
+    reason: ApplySuspended
+    status: "True"
+    type: Suspended
+  lastResync: "2025-07-06T15:58:29Z"
+```
+
+When `.spec.suspend` is `true` The Operator will ignore any changes where they are normally synchronized immediately.
+
 ## Using a proxy server
 
 The Operator can use a proxy server when fetching URL-based / Grafana.com dashboards or making requests to external Grafana instances.


### PR DESCRIPTION
### Result
All controllers and CRDs now implement handling `.spec.suspend` boolean field for all CRs with the exception of `GrafanaNotificationPolicyRoute`.

When set to true, all controllers will:
1. Set `Condition[].Type`: `Suspended` and `Condition[].Reason`: `ApplySuspended` condition.
  `Grafana` Has a different `Condition[].Reason`: `ReconcileSuspended`
2. Return immediately without a `RequeueAfter` Duration.

Any changes to the Spec will be picked up by the operator, but ignored as long as `suspend=true`.

Routes were omitted due to:
- They are implicitly suspended if the notification policies.
- If individually suspended, Should they be omitted or retained from the policy?
  Omitting doesn't make sense with the `suspend` keyword.
  Retaining would be quite complex to implement.

#### Side effects:
When suspended, `lastResync` will be updated every time the generation changes.

#### Sample status:
```yaml
status:
  conditions:
  - lastTransitionTime: "2025-07-06T15:58:29Z"
    message: Resource changes are ignored
    observedGeneration: 2
    reason: ApplySuspended
    status: "True"
    type: Suspended
  lastResync: "2025-07-06T15:58:29Z"
```

### Questions for reviewers:
- Removing all conditions or just `Ready/Synchronized`?
- Conditions test refactor
  Can be further refined to modify go through stages by using the same ObjectMeta in multiple cases

#### Change distribution:
- Manifests: +149
- Docs: +27
- Controllers: +107 -10
- Tests: +545 -277

#### New test failure example
![image](https://github.com/user-attachments/assets/c69036c5-f889-43f7-b12c-6f68177ff795)


<details>
<summary>Alternative Ginkgo table implementation</summary>
<br>

```go

var _ = DescribeTable("ContactPoint Reconciler: Provoke Conditions", func(cr *v1beta1.GrafanaContactPoint, wantCondition, wantReason string) {
	err := k8sClient.Create(testCtx, cr)
	Expect(err).ToNot(HaveOccurred())

	// Reconciliation Request
	req := requestFromMeta(cr.ObjectMeta)

	// Reconcile
	r := GrafanaContactPointReconciler{Client: k8sClient}
	_, err = r.Reconcile(testCtx, req)
	Expect(err).ShouldNot(HaveOccurred())

	resultCr := &v1beta1.GrafanaContactPoint{}
	Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())

	// Verify Condition
	Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", wantCondition)))
	Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", wantReason)))
},
	Entry("Suspended Condition", &v1beta1.GrafanaContactPoint{
		ObjectMeta: objectMetaSuspended,
		Spec: v1beta1.GrafanaContactPointSpec{
			GrafanaCommonSpec: commonSpecSuspended,
			Name:              "ContactPointName",
			Settings:          &v1.JSON{Raw: []byte("{}")},
			Type:              "webhook",
		},
	},
		conditionSuspended,
		conditionReasonApplySuspended,
	),
	Entry("NoMatchingInstances Condition", &v1beta1.GrafanaContactPoint{
		ObjectMeta: objectMetaNoMatchingInstances,
		Spec: v1beta1.GrafanaContactPointSpec{
			GrafanaCommonSpec: commonSpecNoMatchingInstances,
			Name:              "ContactPointName",
			Settings:          &v1.JSON{Raw: []byte("{}")},
			Type:              "webhook",
		},
	},
		conditionNoMatchingInstance,
		conditionReasonEmptyAPIReply,
	),
)
```

</details>