### PR TITLE
chore: Remove `resyncPeriodHasElapsed` checks

### DIFF
--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -109,11 +107,6 @@ func (in *GrafanaDashboard) Conditions() *[]metav1.Condition {
 // CurrentGeneration implements FolderReferencer.
 func (in *GrafanaDashboard) CurrentGeneration() int64 {
 	return in.Generation
-}
-
-func (in *GrafanaDashboard) ResyncPeriodHasElapsed() bool {
-	deadline := in.Status.LastResync.Add(in.Spec.ResyncPeriod.Duration)
-	return time.Now().After(deadline)
 }
 
 // GrafanaContentSpec implements GrafanaContentResource

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"encoding/json"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -119,11 +118,6 @@ type GrafanaDatasourceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []GrafanaDatasource `json:"items"`
-}
-
-func (in *GrafanaDatasource) ResyncPeriodHasElapsed() bool {
-	deadline := in.Status.LastResync.Add(in.Spec.ResyncPeriod.Duration)
-	return time.Now().After(deadline)
 }
 
 func (in *GrafanaDatasource) Unchanged(hash string) bool {

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"crypto/sha256"
 	"fmt"
-	"time"
 
 	operatorapi "github.com/grafana/grafana-operator/v5/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -159,11 +158,6 @@ func (in *GrafanaFolder) GetTitle() string {
 	}
 
 	return in.Name
-}
-
-func (in *GrafanaFolder) ResyncPeriodHasElapsed() bool {
-	deadline := in.Status.LastResync.Add(in.Spec.ResyncPeriod.Duration)
-	return time.Now().After(deadline)
 }
 
 func (in *GrafanaFolder) MatchLabels() *metav1.LabelSelector {

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -329,8 +329,9 @@ func (r *GrafanaDashboardReconciler) onDashboardCreated(ctx context.Context, gra
 		exists = false
 	}
 
+	// Update when missing or the CR is updated
 	if exists && content.Unchanged(cr, hash) {
-		log.V(1).Info("dashboard model unchanged and resyncPeriod not reached. skipping remaining requests")
+		log.V(1).Info("dashboard model unchanged. skipping remaining requests")
 		return nil
 	}
 

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -329,7 +329,7 @@ func (r *GrafanaDashboardReconciler) onDashboardCreated(ctx context.Context, gra
 		exists = false
 	}
 
-	if exists && content.Unchanged(cr, hash) && !cr.ResyncPeriodHasElapsed() {
+	if exists && content.Unchanged(cr, hash) {
 		log.V(1).Info("dashboard model unchanged and resyncPeriod not reached. skipping remaining requests")
 		return nil
 	}

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -262,7 +262,7 @@ func (r *GrafanaDatasourceReconciler) onDatasourceCreated(ctx context.Context, g
 		return err
 	}
 
-	if exists && cr.Unchanged(hash) && !cr.ResyncPeriodHasElapsed() {
+	if exists && cr.Unchanged(hash) {
 		return nil
 	}
 

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -172,6 +172,8 @@ func (r *GrafanaFolderReconciler) finalize(ctx context.Context, folder *grafanav
 }
 
 func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *grafanav1beta1.Grafana, cr *grafanav1beta1.GrafanaFolder) error {
+	log := logf.FromContext(ctx)
+
 	title := cr.GetTitle()
 	uid := cr.CustomUIDOrUID()
 
@@ -190,8 +192,9 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 		return err
 	}
 
-	// always update after resync period has elapsed even if cr is unchanged.
+	// Update when missing, the CR is updated or parentFolder has changed.
 	if exists && cr.Unchanged() && parentFolderUID == remoteParent {
+		log.V(1).Info("folder unchanged. skipping remaining requests")
 		return nil
 	}
 

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -191,7 +191,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 	}
 
 	// always update after resync period has elapsed even if cr is unchanged.
-	if exists && cr.Unchanged() && !cr.ResyncPeriodHasElapsed() && parentFolderUID == remoteParent {
+	if exists && cr.Unchanged() && parentFolderUID == remoteParent {
 		return nil
 	}
 


### PR DESCRIPTION
Thanks to the `ignoreStatusUpdates` event filter on all the reconcilers, we can expect every `reconcile.Request` to happen on spec changes or the resyncPeriod elapsing, but managed by the `controller.Runtime`

Hence, the check is always true or irrelevant as the Content diff verifies the spec changes.