### PR TITLE
chore(tests, linters): more linters, test refactoring, unification of Exists method

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     - revive
     - thelper
     - unparam
+    - usestdlibvars
     - whitespace
 
   settings:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - nilerr
     - prealloc
     - revive
+    - testifylint
     - thelper
     - unparam
     - usestdlibvars

--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -217,11 +217,12 @@ type GrafanaAlertRuleGroupList struct {
 }
 
 func (in *GrafanaAlertRuleGroupList) Exists(namespace, name string) bool {
-	for _, contactpoint := range in.Items {
-		if contactpoint.Namespace == namespace && contactpoint.Name == name {
+	for _, item := range in.Items {
+		if item.Namespace == namespace && item.Name == name {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -78,11 +78,12 @@ type GrafanaContactPointList struct {
 }
 
 func (in *GrafanaContactPointList) Exists(namespace, name string) bool {
-	for _, contactpoint := range in.Items {
-		if contactpoint.Namespace == namespace && contactpoint.Name == name {
+	for _, item := range in.Items {
+		if item.Namespace == namespace && item.Name == name {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -129,11 +129,12 @@ func (in *GrafanaDashboard) GrafanaContentStatus() *GrafanaContentStatus {
 var _ GrafanaContentResource = &GrafanaDashboard{}
 
 func (in *GrafanaDashboardList) Exists(namespace, name string) bool {
-	for _, dashboard := range in.Items {
-		if dashboard.Namespace == namespace && dashboard.Name == name {
+	for _, item := range in.Items {
+		if item.Namespace == namespace && item.Name == name {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -153,11 +153,12 @@ func (in *GrafanaDatasource) CustomUIDOrUID() string {
 }
 
 func (in *GrafanaDatasourceList) Exists(namespace, name string) bool {
-	for _, datasource := range in.Items {
-		if datasource.Namespace == namespace && datasource.Name == name {
+	for _, item := range in.Items {
+		if item.Namespace == namespace && item.Name == name {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -134,11 +134,12 @@ func init() {
 }
 
 func (in *GrafanaFolderList) Exists(namespace, name string) bool {
-	for _, folder := range in.Items {
-		if folder.Namespace == namespace && folder.Name == name {
+	for _, item := range in.Items {
+		if item.Namespace == namespace && item.Name == name {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/api/v1beta1/grafanalibrarypanel_types.go
+++ b/api/v1beta1/grafanalibrarypanel_types.go
@@ -116,11 +116,12 @@ func (in *GrafanaLibraryPanel) NamespacedResource(uid string) NamespacedResource
 var _ GrafanaContentResource = &GrafanaLibraryPanel{}
 
 func (in *GrafanaLibraryPanelList) Exists(namespace, name string) bool {
-	for _, e := range in.Items {
-		if e.Namespace == namespace && e.Name == name {
+	for _, item := range in.Items {
+		if item.Namespace == namespace && item.Name == name {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/api/v1beta1/grafanamutetiming_types.go
+++ b/api/v1beta1/grafanamutetiming_types.go
@@ -123,11 +123,12 @@ type GrafanaMuteTimingList struct {
 }
 
 func (in *GrafanaMuteTimingList) Exists(namespace, name string) bool {
-	for _, muteTiming := range in.Items {
-		if muteTiming.Namespace == namespace && muteTiming.Name == name {
+	for _, item := range in.Items {
+		if item.Namespace == namespace && item.Name == name {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/api/v1beta1/grafananotificationtemplate_types.go
+++ b/api/v1beta1/grafananotificationtemplate_types.go
@@ -84,11 +84,12 @@ type GrafanaNotificationTemplateList struct {
 }
 
 func (in *GrafanaNotificationTemplateList) Exists(namespace, name string) bool {
-	for _, notificationTemplate := range in.Items {
-		if notificationTemplate.Namespace == namespace && notificationTemplate.Name == name {
+	for _, item := range in.Items {
+		if item.Namespace == namespace && item.Name == name {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/api/v1beta1/namespaced_resource_test.go
+++ b/api/v1beta1/namespaced_resource_test.go
@@ -65,33 +65,43 @@ func TestFind(t *testing.T) {
 }
 
 func TestIndexOf(t *testing.T) {
-	in := mockNamespacedResourceList()
+	list := NamespacedResourceList{
+		NamespacedResource("default/folder0/aaaa"),
+		NamespacedResource("default/folder1/bbbb"),
+		NamespacedResource("default/folder2/cccc"),
+	}
 
 	tests := []struct {
-		testName   string
+		name       string
 		rNamespace string
 		rName      string
-		wantIdx    int
+		want       int
 	}{
 		{
-			testName:   "Missing from list",
+			name:       "Not found",
 			rNamespace: "default",
 			rName:      "not-found",
-			wantIdx:    -1,
+			want:       -1,
 		},
 		{
-			testName:   "Present in list",
+			name:       "Found at 0",
+			rNamespace: "default",
+			rName:      "folder0",
+			want:       0,
+		},
+		{
+			name:       "Found at 2",
 			rNamespace: "default",
 			rName:      "folder2",
-			wantIdx:    2,
+			want:       2,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.testName, func(t *testing.T) {
-			gotIdx := in.IndexOf(tt.rNamespace, tt.rName)
+		t.Run(tt.name, func(t *testing.T) {
+			got := list.IndexOf(tt.rNamespace, tt.rName)
 
-			assert.Equal(t, tt.wantIdx, gotIdx)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/api/v1beta1/namespaced_resource_test.go
+++ b/api/v1beta1/namespaced_resource_test.go
@@ -6,17 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func strP(s string) *string {
-	return &s
-}
+func strP(t *testing.T, s string) *string {
+	t.Helper()
 
-func mockNamespacedResourceList() NamespacedResourceList {
-	return NamespacedResourceList{
-		NamespacedResource("default/folder0/aaaa"),
-		NamespacedResource("default/folder1/bbbb"),
-		NamespacedResource("default/folder2/cccc"),
-		NamespacedResource("default/folder3/dddd"),
-	}
+	return &s
 }
 
 func TestSplit(t *testing.T) {
@@ -29,37 +22,40 @@ func TestSplit(t *testing.T) {
 }
 
 func TestFind(t *testing.T) {
-	in := mockNamespacedResourceList()
+	list := NamespacedResourceList{
+		NamespacedResource("default/folder0/aaaa"),
+		NamespacedResource("default/folder1/bbbb"),
+	}
 
 	tests := []struct {
-		testName   string
-		rNamespace string
-		rName      string
-		found      bool
-		wantIdent  *string
+		name           string
+		rNamespace     string
+		rName          string
+		wantFound      bool
+		wantIdentifier *string
 	}{
 		{
-			testName:   "Missing from list",
-			rNamespace: "default",
-			rName:      "not-found",
-			found:      false,
-			wantIdent:  nil,
+			name:           "Not found",
+			rNamespace:     "default",
+			rName:          "not-found",
+			wantFound:      false,
+			wantIdentifier: nil,
 		},
 		{
-			testName:   "Present in list",
-			rNamespace: "default",
-			rName:      "folder2",
-			found:      true,
-			wantIdent:  strP("cccc"),
+			name:           "Found",
+			rNamespace:     "default",
+			rName:          "folder1",
+			wantFound:      true,
+			wantIdentifier: strP(t, "bbbb"),
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.testName, func(t *testing.T) {
-			found, gotIdent := in.Find(tt.rNamespace, tt.rName)
+		t.Run(tt.name, func(t *testing.T) {
+			found, gotIdent := list.Find(tt.rNamespace, tt.rName)
 
-			assert.Equal(t, tt.found, found)
-			assert.Equal(t, tt.wantIdent, gotIdent)
+			assert.Equal(t, tt.wantFound, found)
+			assert.Equal(t, tt.wantIdentifier, gotIdent)
 		})
 	}
 }

--- a/api/v1beta1/namespaced_resource_test.go
+++ b/api/v1beta1/namespaced_resource_test.go
@@ -23,9 +23,9 @@ func TestSplit(t *testing.T) {
 	r := NamespacedResource("namespace/name/identifier")
 	ns, n, i := r.Split()
 
-	assert.Equal(t, ns, "namespace")
-	assert.Equal(t, n, "name")
-	assert.Equal(t, i, "identifier")
+	assert.Equal(t, "namespace", ns)
+	assert.Equal(t, "name", n)
+	assert.Equal(t, "identifier", i)
 }
 
 func TestFind(t *testing.T) {

--- a/api/v1beta1/namespaced_resource_test.go
+++ b/api/v1beta1/namespaced_resource_test.go
@@ -97,54 +97,62 @@ func TestIndexOf(t *testing.T) {
 }
 
 func TestRemoveEntries(t *testing.T) {
-	in := mockNamespacedResourceList()
+	r1 := NamespacedResource("1/1/1")
+	r2 := NamespacedResource("1/1/2")
+	r3 := NamespacedResource("3/3/3")
+	r4 := NamespacedResource("3/3/4")
 
 	tests := []struct {
 		name     string
+		list     NamespacedResourceList
 		toRemove NamespacedResourceList
-		wantLen  int
+		want     NamespacedResourceList
 	}{
 		{
 			name:     "Remove 'missing' entry from list",
-			toRemove: NamespacedResourceList{},
-			wantLen:  len(in),
+			list:     NamespacedResourceList{r1, r2, r3},
+			toRemove: NamespacedResourceList{r4},
+			want:     NamespacedResourceList{r1, r2, r3},
 		},
 		{
 			name:     "Remove first entry from the list",
-			toRemove: NamespacedResourceList{"default/folder0/aaaa"},
-			wantLen:  len(in) - 1,
+			list:     NamespacedResourceList{r1, r2, r3},
+			toRemove: NamespacedResourceList{r1},
+			want:     NamespacedResourceList{r2, r3},
 		},
 		{
 			name:     "Remove middle entry from the list",
-			toRemove: NamespacedResourceList{"default/folder2/cccc"},
-			wantLen:  len(in) - 1,
+			list:     NamespacedResourceList{r1, r2, r3},
+			toRemove: NamespacedResourceList{r2},
+			want:     NamespacedResourceList{r1, r3},
 		},
 		{
 			name:     "Remove last entry from the list",
-			toRemove: NamespacedResourceList{"default/folder3/dddd"},
-			wantLen:  len(in) - 1,
+			list:     NamespacedResourceList{r1, r2, r3},
+			toRemove: NamespacedResourceList{r3},
+			want:     NamespacedResourceList{r1, r2},
 		},
 		{
 			name:     "Remove multiple entries from the list",
-			toRemove: NamespacedResourceList{"default/folder1/bbbb", "default/folder2/cccc", "default/folder3/dddd"},
-			wantLen:  len(in) - 3,
+			list:     NamespacedResourceList{r1, r2, r3},
+			toRemove: NamespacedResourceList{r1, r2},
+			want:     NamespacedResourceList{r3},
 		},
 		{
 			name:     "Remove all entries from the list",
-			toRemove: NamespacedResourceList{"default/folder0/aaaa", "default/folder1/bbbb", "default/folder2/cccc", "default/folder3/dddd"},
-			wantLen:  0,
+			list:     NamespacedResourceList{r1, r2, r3},
+			toRemove: NamespacedResourceList{r1, r2, r3},
+			want:     NamespacedResourceList{},
 		},
 	}
 
 	for _, tt := range tests {
-		list := mockNamespacedResourceList()
-
 		t.Run(tt.name, func(t *testing.T) {
-			gotList := list.RemoveEntries(&tt.toRemove)
+			got := tt.list.RemoveEntries(&tt.toRemove)
 
-			assert.Equal(t, tt.wantLen, len(gotList))
+			assert.Equal(t, tt.want, got)
 			for _, r := range tt.toRemove {
-				assert.NotContainsf(t, gotList, r, "Resources should have removed from the source list")
+				assert.NotContainsf(t, got, r, "Resources should have removed from the source list")
 			}
 		})
 	}

--- a/controllers/autodetect/main_test.go
+++ b/controllers/autodetect/main_test.go
@@ -47,11 +47,8 @@ func TestDetectPlatformBasedOnAvailableAPIGroups(t *testing.T) {
 		autoDetect, err := autodetect.New(&rest.Config{Host: server.URL})
 		require.NoError(t, err)
 
-		// test
 		plt, err := autoDetect.IsOpenshift()
-
-		// verify
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, tt.expected, plt)
 	}
 }

--- a/controllers/autodetect/main_test.go
+++ b/controllers/autodetect/main_test.go
@@ -35,12 +35,12 @@ func TestDetectPlatformBasedOnAvailableAPIGroups(t *testing.T) {
 	} {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			output, err := json.Marshal(tt.apiGroupList)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, err = w.Write(output)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}))
 		defer server.Close()
 

--- a/controllers/client/grafana_client_test.go
+++ b/controllers/client/grafana_client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseAdminURL(t *testing.T) {
@@ -67,7 +68,7 @@ func TestParseAdminURL(t *testing.T) {
 			if tt.wantError {
 				assert.Error(t, err, "This should be an invalid url input")
 			} else {
-				assert.Nil(t, err, "This should be a valid url")
+				require.NoError(t, err, "This should be a valid url")
 				assert.Equal(t, tt.wantPath, got.Path, "Path does not match")
 				assert.Equal(t, tt.wantHost, got.Host, "Host does not match")
 				assert.Contains(t, got.Path, "api", "/api is not appended to path correctly")

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,7 +31,7 @@ func TestGrafanaDashboardStatus_getContentCache(t *testing.T) {
 	dashboardJSON := []byte(`{"dummyField": "dummyData"}`)
 
 	cachedDashboard, err := Gzip(dashboardJSON)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	url := "http://127.0.0.1:8080/1.json"
 

--- a/controllers/content/fetchers/grafana_com_fetcher_test.go
+++ b/controllers/content/fetchers/grafana_com_fetcher_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFetchDashboardFromGrafanaCom(t *testing.T) {
@@ -21,7 +22,7 @@ func TestFetchDashboardFromGrafanaCom(t *testing.T) {
 	}
 
 	fetchedDashboard, err := FetchFromGrafanaCom(context.Background(), dashboard, k8sClient)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, fetchedDashboard, "Fetched dashboard shouldn't be empty")
 	assert.GreaterOrEqual(t, *dashboard.Spec.GrafanaCom.Revision, 30, "At least 30 revisions exist for dashboard 1860 as of 2023-03-29")
 

--- a/controllers/content/fetchers/jsonnet_fetcher_test.go
+++ b/controllers/content/fetchers/jsonnet_fetcher_test.go
@@ -189,14 +189,15 @@ func TestBuildProjectAndFetchJsonnetFrom(t *testing.T) {
 func TestGetJsonProjectBuildRoundName(t *testing.T) {
 	roundName, err := getJSONProjectBuildRoundName("test")
 	require.NoError(t, err)
+
 	roundNameParts := strings.Split(roundName, "-")
-	require.Equal(t, 3, len(roundNameParts))
+	require.Len(t, roundNameParts, 3)
 	require.Equal(t, "test", roundNameParts[0])
 }
 
 func TestGetGzipArchiveFileNameWithExtension(t *testing.T) {
 	archiveName := getGzipArchiveFileNameWithExtension("test")
-	require.Equal(t, archiveName, "test.tar.gz")
+	require.Equal(t, "test.tar.gz", archiveName)
 }
 
 func TestStoreByteArrayGzipOnDisk(t *testing.T) {

--- a/controllers/content/resolver_test.go
+++ b/controllers/content/resolver_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -44,7 +45,7 @@ func TestGetDashboardEnvs(t *testing.T) {
 
 	envs, err := resolver.getContentEnvs(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, envs)
 	assert.True(t, len(envs) == 1, "Expected 1 env, got %d", len(envs))
 }

--- a/controllers/content/resolver_test.go
+++ b/controllers/content/resolver_test.go
@@ -47,7 +47,7 @@ func TestGetDashboardEnvs(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, envs)
-	assert.True(t, len(envs) == 1, "Expected 1 env, got %d", len(envs))
+	assert.Len(t, envs, 1)
 }
 
 func TestContentIsUpdatedUID(t *testing.T) {

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -248,7 +248,7 @@ func (r *GrafanaDashboardReconciler) finalize(ctx context.Context, cr *v1beta1.G
 				if err != nil {
 					return fmt.Errorf("deleting empty parent folder from instance: %w", err)
 				}
-				if resp.StatusCode == 200 {
+				if resp.StatusCode == http.StatusOK {
 					log.Info("unused folder successfully removed")
 				}
 				if resp.StatusCode == 432 {
@@ -490,7 +490,7 @@ func (r *GrafanaDashboardReconciler) DeleteFolderIfEmpty(client *genapi.GrafanaH
 	if err != nil {
 		return http.Response{
 			Status:     "internal grafana client error getting dashboards",
-			StatusCode: 500,
+			StatusCode: http.StatusInternalServerError,
 		}, err
 	}
 	if len(results.GetPayload()) > 0 {
@@ -506,13 +506,13 @@ func (r *GrafanaDashboardReconciler) DeleteFolderIfEmpty(client *genapi.GrafanaH
 		if !errors.As(err, &notFound) {
 			return http.Response{
 				Status:     "internal grafana client error deleting grafana folder",
-				StatusCode: 500,
+				StatusCode: http.StatusInternalServerError,
 			}, err
 		}
 	}
 	return http.Response{
 		Status:     "grafana folder deleted",
-		StatusCode: 200,
+		StatusCode: http.StatusOK,
 	}, nil
 }
 

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	v1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -35,7 +36,7 @@ func TestGetDatasourceContent(t *testing.T) {
 		content, hash, err := reconciler.buildDatasourceModel(testCtx, cr)
 		got := content.SecureJSONData["httpHeaderValue1"]
 
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, hash)
 		assert.Equal(t, want, got)
 	})

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -174,6 +174,7 @@ func (r *GrafanaReconciler) setDefaultGrafanaVersion(ctx context.Context, cr cli
 
 func removeMissingCRs(statusList *grafanav1beta1.NamespacedResourceList, crs grafanav1beta1.NamespacedResourceImpl, updateStatus *bool) {
 	toRemove := grafanav1beta1.NamespacedResourceList{}
+
 	for _, r := range *statusList {
 		namespace, name, _ := r.Split()
 		if !crs.Exists(namespace, name) {

--- a/controllers/notificationpolicy_controller_test.go
+++ b/controllers/notificationpolicy_controller_test.go
@@ -18,11 +18,11 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -360,18 +360,20 @@ func TestAssembleNotificationPolicyRoutes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			s := runtime.NewScheme()
+
 			err := v1beta1.AddToScheme(s)
-			assert.NoError(t, err, "adding scheme")
+			require.NoError(t, err, "adding scheme")
+
 			client := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(routesToRuntimeObjects(tt.existingRoutes)...).Build()
 
 			_, err = assembleNotificationPolicyRoutes(ctx, client, tt.notificationPolicy)
 			if tt.wantLoopDetectedErr {
-				assert.True(t, errors.Is(err, ErrLoopDetected))
+				require.ErrorIs(t, err, ErrLoopDetected)
 			}
 			if tt.wantErr {
-				assert.Error(t, err, "assembleNotificationPolicyRoutes() should return an error")
+				require.Error(t, err, "assembleNotificationPolicyRoutes() should return an error")
 			} else {
-				assert.NoError(t, err, "assembleNotificationPolicyRoutes() should not return an error")
+				require.NoError(t, err, "assembleNotificationPolicyRoutes() should not return an error")
 				assert.Equal(t, tt.want, tt.notificationPolicy, "assembleNotificationPolicyRoutes() returned unexpected policy")
 			}
 		})

--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -52,7 +52,7 @@ func (r *CompleteReconciler) getVersion(ctx context.Context, cr *v1beta1.Grafana
 	}
 
 	instanceURL := gURL.JoinPath("/frontend/settings").String()
-	req, err := http.NewRequest("GET", instanceURL, nil)
+	req, err := http.NewRequest(http.MethodGet, instanceURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("building request to fetch version: %w", err)
 	}


### PR DESCRIPTION
- linters:
  - added `usestdlibvars`, it catches cases where we can use variables from standard library such as `http`;
  - added `testifylint`, it catches cases like swapped want/got, usage of `require` in httptest server, manual implementation of checks that are already offered by testify, etc;
- tests:
  - fixed issues based on the linters feedback:
    - use `require` for errors;
    - use `Len` for testing length;
    - swap want and got;
    - don't use `require` for httptest server
    - use `http` vars;
  - refactored for Namespaced Resource for better readability;
- api:
  - unified `Exists` method implementation across all resources.
