### PR TITLE
chore(SuspendCondition): Correctly update the suspend condition

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -86,7 +86,6 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 
 	if group.Spec.Suspend {
 		setSuspended(&group.Status.Conditions, group.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&group.Status.Conditions, conditionAlertGroupSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&group.Status.Conditions)

--- a/controllers/contactpoint_controller.go
+++ b/controllers/contactpoint_controller.go
@@ -82,7 +82,6 @@ func (r *GrafanaContactPointReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	if contactPoint.Spec.Suspend {
 		setSuspended(&contactPoint.Status.Conditions, contactPoint.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&contactPoint.Status.Conditions, conditionContactPointSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&contactPoint.Status.Conditions)

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -93,7 +93,6 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDashboardSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&cr.Status.Conditions)

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -85,7 +85,6 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDatasourceSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&cr.Status.Conditions)

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -83,7 +83,6 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if folder.Spec.Suspend {
 		setSuspended(&folder.Status.Conditions, folder.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&folder.Status.Conditions, conditionFolderSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&folder.Status.Conditions)

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -92,7 +92,6 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonReconcileSuspended)
-		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionTypeGrafanaReady)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&cr.Status.Conditions)

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -92,7 +92,6 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	if libraryPanel.Spec.Suspend {
 		setSuspended(&libraryPanel.Status.Conditions, libraryPanel.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&libraryPanel.Status.Conditions, conditionLibraryPanelSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&libraryPanel.Status.Conditions)

--- a/controllers/mutetiming_controller.go
+++ b/controllers/mutetiming_controller.go
@@ -79,7 +79,6 @@ func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if muteTiming.Spec.Suspend {
 		setSuspended(&muteTiming.Status.Conditions, muteTiming.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&muteTiming.Status.Conditions, conditionMuteTimingSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&muteTiming.Status.Conditions)

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -93,7 +93,6 @@ func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req
 
 	if notificationPolicy.Spec.Suspend {
 		setSuspended(&notificationPolicy.Status.Conditions, notificationPolicy.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&notificationPolicy.Status.Conditions, conditionNotificationPolicySynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&notificationPolicy.Status.Conditions)

--- a/controllers/notificationtemplate_controller.go
+++ b/controllers/notificationtemplate_controller.go
@@ -78,7 +78,6 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 
 	if notificationTemplate.Spec.Suspend {
 		setSuspended(&notificationTemplate.Status.Conditions, notificationTemplate.Generation, conditionReasonApplySuspended)
-		meta.RemoveStatusCondition(&notificationTemplate.Status.Conditions, conditionNotificationTemplateSynchronized)
 		return ctrl.Result{}, nil
 	}
 	removeSuspended(&notificationTemplate.Status.Conditions)


### PR DESCRIPTION
Realised my initial implementation of Suspend was a bit off.

1. After changing to overwriting of all conditions there's no need to remove the Synchronized/Ready conditions.
2. The existing status was not correctly updated but rather replaced on every change.
Only the `ObservedGeneration` is supposed to change when the CR is updated.