### PR TITLE
feat(Grafana): Allow specifying subdomain on routes. `.spec.route.subdomain`

### DIFF
--- a/api/v1beta1/typeoverrides.go
+++ b/api/v1beta1/typeoverrides.go
@@ -475,6 +475,9 @@ type RouteOpenShiftV1Spec struct {
 
 	TLS *OpenshiftTLSConfig `json:"tls,omitempty" protobuf:"bytes,6,opt,name=tls"`
 
+	// +optional
+	Subdomain string `json:"subdomain,omitempty" protobuf:"bytes,8,opt,name=subdomain"`
+
 	WildcardPolicy WildcardPolicyType `json:"wildcardPolicy,omitempty" protobuf:"bytes,7,opt,name=wildcardPolicy"`
 }
 

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -4397,6 +4397,8 @@ spec:
                           required:
                             - targetPort
                           type: object
+                        subdomain:
+                          type: string
                         tls:
                           description: TLSConfig defines config used to secure a route and provide termination
                           properties:

--- a/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/crds/grafana.integreatly.org_grafanas.yaml
@@ -4397,6 +4397,8 @@ spec:
                           required:
                             - targetPort
                           type: object
+                        subdomain:
+                          type: string
                         tls:
                           description: TLSConfig defines config used to secure a route and provide termination
                           properties:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -7770,6 +7770,8 @@ spec:
                         required:
                         - targetPort
                         type: object
+                      subdomain:
+                        type: string
                       tls:
                         description: TLSConfig defines config used to secure a route
                           and provide termination

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -21333,6 +21333,13 @@ ObjectMeta contains only a [subset of the fields included in k8s.io/apimachinery
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>subdomain</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#grafanaspecroutespectls">tls</a></b></td>
         <td>object</td>
         <td>


### PR DESCRIPTION
closes #2056 

I took a look at what it would take to implement the remaining [`HTTPHeaders`](https://github.com/openshift/api/blob/674ad74beffcbdf6aa7a577bf23a269c24f92fe8/route/v1/types.go#L162C2-L162C14). 
Turns out it requires a LOT of structs and hence will leave it until requested.