### PR TITLE
chore(tests): `ApplySuccessful` conditions

### DIFF
--- a/controllers/alertrulegroup_controller_test.go
+++ b/controllers/alertrulegroup_controller_test.go
@@ -1,7 +1,11 @@
 package controllers
 
 import (
+	"time"
+
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -64,6 +68,74 @@ var _ = Describe("AlertRulegroup Reconciler: Provoke Conditions", func() {
 			wantCondition: conditionAlertGroupSynchronized,
 			wantReason:    conditionReasonApplyFailed,
 			wantErr:       "failed to apply to all instances",
+		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaAlertRuleGroup{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaAlertRuleGroupSpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+					FolderRef:         "pre-existing",
+					Interval:          metav1.Duration{Duration: 60 * time.Second},
+					Rules: []v1beta1.AlertRule{
+						{
+							Title:     "MathRule",
+							UID:       "oefiodwa-dam-dwa",
+							Condition: "A",
+							Data: []*v1beta1.AlertQuery{
+								{
+									RefID:             "A",
+									RelativeTimeRange: nil,
+									DatasourceUID:     "__expr__",
+									Model: &v1.JSON{Raw: []byte(`{
+		                                "conditions": [
+		                                    {
+		                                        "evaluator": {
+		                                            "params": [
+		                                                0,
+		                                                0
+		                                            ],
+		                                            "type": "gt"
+		                                        },
+		                                        "operator": {
+		                                            "type": "and"
+		                                        },
+		                                        "query": {
+		                                            "params": []
+		                                        },
+		                                        "reducer": {
+		                                            "params": [],
+		                                            "type": "avg"
+		                                        },
+		                                        "type": "query"
+		                                    }
+		                                ],
+		                                "datasource": {
+		                                    "name": "Expression",
+		                                    "type": "__expr__",
+		                                    "uid": "__expr__"
+		                                },
+		                                "expression": "1 > 0",
+		                                "hide": false,
+		                                "intervalMs": 1000,
+		                                "maxDataPoints": 100,
+		                                "refId": "B",
+		                                "type": "math"
+		                            }`)},
+								},
+							},
+							NoDataState:  &noDataState,
+							ExecErrState: "Error",
+							For:          &metav1.Duration{Duration: 60 * time.Second},
+							Annotations:  map[string]string{},
+							Labels:       map[string]string{},
+							IsPaused:     true,
+						},
+					},
+				},
+			},
+			wantCondition: conditionAlertGroupSynchronized,
+			wantReason:    conditionReasonApplySuccessful,
 		},
 	}
 

--- a/controllers/alertrulegroup_controller_test.go
+++ b/controllers/alertrulegroup_controller_test.go
@@ -57,7 +57,7 @@ var _ = Describe("AlertRulegroup Reconciler: Provoke Conditions", func() {
 				ObjectMeta: objectMetaApplyFailed,
 				Spec: v1beta1.GrafanaAlertRuleGroupSpec{
 					GrafanaCommonSpec: commonSpecApplyFailed,
-					FolderRef:         "apply-failed-helper",
+					FolderRef:         "pre-existing",
 					Rules:             rules,
 				},
 			},

--- a/controllers/contactpoint_controller_test.go
+++ b/controllers/contactpoint_controller_test.go
@@ -84,6 +84,20 @@ var _ = Describe("ContactPoint Reconciler: Provoke Conditions", func() {
 			wantReason:    conditionReasonInvalidSettings,
 			wantErr:       "building contactpoint settings",
 		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaContactPoint{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaContactPointSpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+					Name:              "ContactPointName",
+					Settings:          &v1.JSON{Raw: []byte(`{"url": "http://test.io"}`)},
+					Type:              "webhook",
+				},
+			},
+			wantCondition: conditionContactPointSynchronized,
+			wantReason:    conditionReasonApplySuccessful,
+		},
 	}
 
 	for _, test := range tests {

--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -97,6 +97,23 @@ var _ = Describe("Dashboard Reconciler: Provoke Conditions", func() {
 			wantReason:    conditionReasonInvalidModelResolution,
 			wantErr:       "resolving dashboard contents",
 		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaDashboard{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaDashboardSpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+					GrafanaContentSpec: v1beta1.GrafanaContentSpec{
+						JSON: `{
+							"title": "Minimal Dashboard",
+							"links": []
+						}`,
+					},
+				},
+			},
+			wantCondition: conditionDashboardSynchronized,
+			wantReason:    conditionReasonApplySuccessful,
+		},
 	}
 
 	for _, test := range tests {

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -239,6 +239,23 @@ var _ = Describe("Datasource Reconciler: Provoke Conditions", func() {
 			wantReason:    conditionReasonInvalidModel,
 			wantErr:       "building datasource model",
 		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaDatasource{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaDatasourceSpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+					Datasource: &v1beta1.GrafanaDatasourceInternal{
+						Name:   "synced-prometheus",
+						Type:   "prometheus",
+						Access: "proxy",
+						URL:    "https://demo.promlabs.com",
+					},
+				},
+			},
+			wantCondition: conditionDatasourceSynchronized,
+			wantReason:    conditionReasonApplySuccessful,
+		},
 	}
 
 	for _, test := range tests {

--- a/controllers/folder_controller_test.go
+++ b/controllers/folder_controller_test.go
@@ -63,6 +63,17 @@ var _ = Describe("Folder Reconciler: Provoke Conditions", func() {
 			wantReason:    conditionReasonCyclicParent,
 			wantErr:       "cyclic folder reference",
 		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaFolder{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaFolderSpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+				},
+			},
+			wantCondition: conditionFolderSynchronized,
+			wantReason:    conditionReasonApplySuccessful,
+		},
 	}
 
 	for _, test := range tests {

--- a/controllers/librarypanel_controller_test.go
+++ b/controllers/librarypanel_controller_test.go
@@ -52,6 +52,26 @@ var _ = Describe("LibraryPanel Reconciler: Provoke Conditions", func() {
 			wantReason:    conditionReasonApplyFailed,
 			wantErr:       "failed to apply to all instances",
 		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaLibraryPanel{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaLibraryPanelSpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+					GrafanaContentSpec: v1beta1.GrafanaContentSpec{
+						JSON: `{
+							"uid": "do-adhv-ank",
+							"name": "API docs Example",
+							"type": "text",
+							"model": {},
+							"version": 1
+						}`,
+					},
+				},
+			},
+			wantCondition: conditionLibraryPanelSynchronized,
+			wantReason:    conditionReasonApplySuccessful,
+		},
 	}
 
 	for _, test := range tests {

--- a/controllers/mutetiming_controller_test.go
+++ b/controllers/mutetiming_controller_test.go
@@ -12,15 +12,13 @@ var _ = Describe("MuteTiming Reconciler: Provoke Conditions", func() {
 		{
 			DaysOfMonth: []string{"1"},
 			Location:    "Europe/Copenhagen",
-			Months:      []string{"1"},
 			Times: []*v1beta1.TimeRange{
 				{
 					StartTime: "00:00",
 					EndTime:   "02:00",
 				},
 			},
-			Weekdays: []string{"1"},
-			Years:    []string{"2025"},
+			Weekdays: []string{"sunday"},
 		},
 	}
 
@@ -67,6 +65,19 @@ var _ = Describe("MuteTiming Reconciler: Provoke Conditions", func() {
 			wantCondition: conditionMuteTimingSynchronized,
 			wantReason:    conditionReasonApplyFailed,
 			wantErr:       "failed to apply to all instances",
+		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaMuteTiming{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaMuteTimingSpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+					Name:              "Synchronized",
+					TimeIntervals:     timeInterval,
+				},
+			},
+			wantCondition: conditionMuteTimingSynchronized,
+			wantReason:    conditionReasonApplySuccessful,
 		},
 	}
 

--- a/controllers/notificationpolicy_controller_test.go
+++ b/controllers/notificationpolicy_controller_test.go
@@ -448,6 +448,20 @@ var _ = Describe("NotificationPolicy Reconciler: Provoke Conditions", func() {
 			wantReason:    conditionReasonFieldsMutuallyExclusive,
 			wantErr:       "invalid route spec discovered: routeSelector is mutually exclusive with routes",
 		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaNotificationPolicy{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaNotificationPolicySpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+					Route: &v1beta1.Route{
+						Receiver: "grafana-default-email",
+					},
+				},
+			},
+			wantCondition: conditionNotificationPolicySynchronized,
+			wantReason:    conditionReasonApplySuccessful,
+		},
 	}
 
 	for _, test := range tests {

--- a/controllers/notificationtemplate_controller_test.go
+++ b/controllers/notificationtemplate_controller_test.go
@@ -45,12 +45,25 @@ var _ = Describe("NotificationTemplate Reconciler: Provoke Conditions", func() {
 				ObjectMeta: objectMetaApplyFailed,
 				Spec: v1beta1.GrafanaNotificationTemplateSpec{
 					GrafanaCommonSpec: commonSpecApplyFailed,
-					Name:              "NoMatch",
+					Name:              "ApplyFailed",
 				},
 			},
 			wantCondition: conditionNotificationTemplateSynchronized,
 			wantReason:    conditionReasonApplyFailed,
 			wantErr:       "failed to apply to all instances",
+		},
+		{
+			name: "Successfully applied resource to instance",
+			cr: &v1beta1.GrafanaNotificationTemplate{
+				ObjectMeta: objectMetaSynchronized,
+				Spec: v1beta1.GrafanaNotificationTemplateSpec{
+					GrafanaCommonSpec: commonSpecSynchronized,
+					Name:              "Synchronized",
+					Template:          `{{ define "StatusAlert" }}{{.Status}}{{ end }}`,
+				},
+			},
+			wantCondition: conditionNotificationTemplateSynchronized,
+			wantReason:    conditionReasonApplySuccessful,
 		},
 	}
 


### PR DESCRIPTION
Adds `ApplySuccessful` to all resource controllers.

Additionally, it synchronizes the `pre-existing` `GrafanaFolder` into the Grafana testcontainer so it's available to all controller tests.
Previously a `apply-failed-helper` `GrafanaFolder` was created but not synchronized.

Coverage of controllers has gone from `42.2%` to `52.6%`