### PR TITLE
fix(Grafana): `.spec.config.security.admin_*` as fallback for external instances

### DIFF
--- a/controllers/client/grafana_client.go
+++ b/controllers/client/grafana_client.go
@@ -27,7 +27,6 @@ func getExternalAdminUser(ctx context.Context, c client.Client, cr *v1beta1.Graf
 	case cr.Spec.External.AdminUser != nil:
 		adminUser, err := GetValueFromSecretKey(ctx, cr.Spec.External.AdminUser, c, cr.Namespace)
 		if err != nil {
-			println("got here")
 			return "", err
 		}
 

--- a/controllers/client/grafana_client.go
+++ b/controllers/client/grafana_client.go
@@ -17,9 +17,43 @@ import (
 )
 
 type grafanaAdminCredentials struct {
-	username string
-	password string
-	apikey   string
+	adminUser     string
+	adminPassword string
+	apikey        string
+}
+
+func getExternalAdminUser(ctx context.Context, c client.Client, cr *v1beta1.Grafana) (string, error) {
+	switch {
+	case cr.Spec.External.AdminUser != nil:
+		adminUser, err := GetValueFromSecretKey(ctx, cr.Spec.External.AdminUser, c, cr.Namespace)
+		if err != nil {
+			println("got here")
+			return "", err
+		}
+
+		return string(adminUser), nil
+	case cr.Spec.Config["security"] != nil && cr.Spec.Config["security"]["admin_user"] != "":
+		return cr.Spec.Config["security"]["admin_user"], nil
+	default:
+		return "", fmt.Errorf("authentication undefined, set apiKey or userName for external instance: %s/%s", cr.Namespace, cr.Name)
+	}
+}
+
+func getExternalAdminPassword(ctx context.Context, c client.Client, cr *v1beta1.Grafana) (string, error) {
+	switch {
+	case cr.Spec.External.AdminPassword != nil:
+		adminPassword, err := GetValueFromSecretKey(ctx, cr.Spec.External.AdminPassword, c, cr.Namespace)
+		if err != nil {
+			return "", err
+		}
+
+		return string(adminPassword), nil
+	case cr.Spec.Config["security"] != nil && cr.Spec.Config["security"]["admin_password"] != "":
+		return cr.Spec.Config["security"]["admin_password"], nil
+	default:
+		// If username is defined, we can assume apiKey will not be used
+		return "", fmt.Errorf("password not set for external instance: %s/%s", cr.Namespace, cr.Name)
+	}
 }
 
 func getAdminCredentials(ctx context.Context, c client.Client, grafana *v1beta1.Grafana) (*grafanaAdminCredentials, error) {
@@ -38,19 +72,17 @@ func getAdminCredentials(ctx context.Context, c client.Client, grafana *v1beta1.
 			return credentials, nil
 		}
 
-		// rely on username and password otherwise
-		username, err := GetValueFromSecretKey(ctx, grafana.Spec.External.AdminUser, c, grafana.Namespace)
+		var err error
+
+		credentials.adminUser, err = getExternalAdminUser(ctx, c, grafana)
 		if err != nil {
 			return nil, err
 		}
 
-		password, err := GetValueFromSecretKey(ctx, grafana.Spec.External.AdminPassword, c, grafana.Namespace)
+		credentials.adminPassword, err = getExternalAdminPassword(ctx, c, grafana)
 		if err != nil {
 			return nil, err
 		}
-
-		credentials.username = string(username)
-		credentials.password = string(password)
 
 		return credentials, nil
 	}
@@ -70,7 +102,7 @@ func getAdminCredentials(ctx context.Context, c client.Client, grafana *v1beta1.
 		for _, env := range container.Env {
 			if env.Name == config.GrafanaAdminUserEnvVar {
 				if env.Value != "" {
-					credentials.username = env.Value
+					credentials.adminUser = env.Value
 					continue
 				}
 
@@ -81,14 +113,14 @@ func getAdminCredentials(ctx context.Context, c client.Client, grafana *v1beta1.
 							return nil, err
 						}
 
-						credentials.username = string(usernameFromSecret)
+						credentials.adminUser = string(usernameFromSecret)
 					}
 				}
 			}
 
 			if env.Name == config.GrafanaAdminPasswordEnvVar {
 				if env.Value != "" {
-					credentials.password = env.Value
+					credentials.adminPassword = env.Value
 					continue
 				}
 
@@ -99,7 +131,7 @@ func getAdminCredentials(ctx context.Context, c client.Client, grafana *v1beta1.
 							return nil, err
 						}
 
-						credentials.password = string(passwordFromSecret)
+						credentials.adminPassword = string(passwordFromSecret)
 					}
 				}
 			}
@@ -118,7 +150,7 @@ func InjectAuthHeaders(ctx context.Context, c client.Client, grafana *v1beta1.Gr
 	if creds.apikey != "" {
 		req.Header.Add("Authorization", "Bearer "+creds.apikey)
 	} else {
-		req.SetBasicAuth(creds.username, creds.password)
+		req.SetBasicAuth(creds.adminUser, creds.adminPassword)
 	}
 
 	return nil
@@ -185,8 +217,8 @@ func NewGeneratedGrafanaClient(ctx context.Context, c client.Client, grafana *v1
 			Timeout:   timeout * time.Second,
 		},
 	}
-	if credentials.username != "" {
-		cfg.BasicAuth = url.UserPassword(credentials.username, credentials.password)
+	if credentials.adminUser != "" {
+		cfg.BasicAuth = url.UserPassword(credentials.adminUser, credentials.adminPassword)
 	}
 
 	cl := genapi.NewHTTPClientWithConfig(nil, cfg)

--- a/controllers/client/grafana_client_test.go
+++ b/controllers/client/grafana_client_test.go
@@ -1,10 +1,16 @@
 package client
 
 import (
+	"context"
 	"testing"
 
+	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestParseAdminURL(t *testing.T) {
@@ -72,6 +78,285 @@ func TestParseAdminURL(t *testing.T) {
 				assert.Equal(t, tt.wantPath, got.Path, "Path does not match")
 				assert.Equal(t, tt.wantHost, got.Host, "Host does not match")
 				assert.Contains(t, got.Path, "api", "/api is not appended to path correctly")
+			}
+		})
+	}
+}
+
+func TestGetExternalAdminCredentials(t *testing.T) {
+	tests := []struct {
+		name          string
+		grafana       *v1beta1.Grafana
+		wantAdminUser string
+		wantAdminPass string
+		wantErr       bool
+	}{
+		{
+			name: "User and Password from Secret",
+			grafana: &v1beta1.Grafana{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "grafana",
+				},
+				Spec: v1beta1.GrafanaSpec{
+					External: &v1beta1.External{
+						AdminUser: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "grafana-credentials",
+							},
+							Key: "user",
+						},
+						AdminPassword: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "grafana-credentials",
+							},
+							Key: "pass",
+						},
+					},
+				},
+			},
+			wantAdminUser: "root",
+			wantAdminPass: "secret",
+			wantErr:       false,
+		},
+		{
+			name: "User from config and Password from Secret",
+			grafana: &v1beta1.Grafana{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "grafana",
+				},
+				Spec: v1beta1.GrafanaSpec{
+					External: &v1beta1.External{
+						AdminPassword: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "grafana-credentials",
+							},
+							Key: "pass",
+						},
+					},
+					Config: map[string]map[string]string{
+						"security": {
+							"admin_user": "root",
+						},
+					},
+				},
+			},
+			wantAdminUser: "root",
+			wantAdminPass: "secret",
+			wantErr:       false,
+		},
+		{
+			name: "User and Password from config",
+			grafana: &v1beta1.Grafana{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "grafana",
+				},
+				Spec: v1beta1.GrafanaSpec{
+					External: &v1beta1.External{},
+					Config: map[string]map[string]string{
+						"security": {
+							"admin_user":     "root",
+							"admin_password": "secret",
+						},
+					},
+				},
+			},
+			wantAdminUser: "root",
+			wantAdminPass: "secret",
+			wantErr:       false,
+		},
+		{
+			name: "err from empty config",
+			grafana: &v1beta1.Grafana{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "grafana",
+				},
+				Spec: v1beta1.GrafanaSpec{
+					External: &v1beta1.External{},
+					Config: map[string]map[string]string{
+						"security": {},
+					},
+				},
+			},
+			wantAdminUser: "",
+			wantAdminPass: "",
+			wantErr:       true,
+		},
+		{
+			name: "err when reference is unset or security.admin_user/password is set",
+			grafana: &v1beta1.Grafana{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "grafana",
+				},
+				Spec: v1beta1.GrafanaSpec{
+					External: &v1beta1.External{},
+				},
+			},
+			wantAdminUser: "",
+			wantAdminPass: "",
+			wantErr:       true,
+		},
+	}
+
+	credSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "grafana-credentials",
+		},
+		Data: map[string][]byte{
+			"user": []byte("root"),
+			"pass": []byte("secret"),
+		},
+	}
+
+	testCtx := context.Background()
+	s := runtime.NewScheme()
+	err := v1.AddToScheme(s)
+	require.NoError(t, err, "adding scheme")
+
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(credSecret).
+		Build()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adminUser, err := getExternalAdminUser(testCtx, client, tt.grafana)
+			if tt.wantErr {
+				require.Error(t, err, "getExternalAdminUser() should return an error")
+			} else {
+				require.NoError(t, err, "getExternalAdminUser() should not return an error")
+			}
+
+			adminPassword, err := getExternalAdminPassword(testCtx, client, tt.grafana)
+			if tt.wantErr {
+				require.Error(t, err, "getExternalAdminPassword() should return an error")
+			} else {
+				require.NoError(t, err, "getExternalAdminPassword() should not return an error")
+			}
+
+			require.Equal(t, tt.wantAdminUser, adminUser)
+			require.Equal(t, tt.wantAdminPass, adminPassword)
+		})
+	}
+}
+
+// TODO currently only tests code paths for external grafanas
+func TestGetAdminCredentials(t *testing.T) {
+	tests := []struct {
+		name            string
+		grafana         *v1beta1.Grafana
+		wantCredentials *grafanaAdminCredentials
+		wantErr         bool
+	}{
+		{
+			name: "ApiKey from Secret ignoring config",
+			grafana: &v1beta1.Grafana{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "grafana",
+				},
+				Spec: v1beta1.GrafanaSpec{
+					External: &v1beta1.External{
+						APIKey: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "grafana-credentials",
+							},
+							Key: "token",
+						},
+					},
+					Config: map[string]map[string]string{
+						"security": {
+							"admin_user":     "root",
+							"admin_password": "secret",
+						},
+					},
+				},
+			},
+			wantCredentials: &grafanaAdminCredentials{
+				adminUser:     "",
+				adminPassword: "",
+				apikey:        "service-account-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "fallback to admin user/password",
+			grafana: &v1beta1.Grafana{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "grafana",
+				},
+				Spec: v1beta1.GrafanaSpec{
+					External: &v1beta1.External{},
+					Config: map[string]map[string]string{
+						"security": {
+							"admin_user":     "root",
+							"admin_password": "secret",
+						},
+					},
+				},
+			},
+			wantCredentials: &grafanaAdminCredentials{
+				adminUser:     "root",
+				adminPassword: "secret",
+				apikey:        "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "err when neither apiKey or admin user/password is set",
+			grafana: &v1beta1.Grafana{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "grafana",
+				},
+				Spec: v1beta1.GrafanaSpec{
+					External: &v1beta1.External{},
+				},
+			},
+			wantCredentials: nil,
+			wantErr:         true,
+		},
+	}
+
+	credSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "grafana-credentials",
+		},
+		Data: map[string][]byte{
+			"token": []byte("service-account-key"),
+			"user":  []byte("root"),
+			"pass":  []byte("secret"),
+		},
+	}
+
+	testCtx := context.Background()
+	s := runtime.NewScheme()
+	err := v1.AddToScheme(s)
+	require.NoError(t, err, "adding scheme")
+
+	client := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(credSecret).
+		Build()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credentials, err := getAdminCredentials(testCtx, client, tt.grafana)
+			if tt.wantErr {
+				require.Error(t, err, "getAdminCredentials() should return an error")
+				require.Nil(t, credentials, "credentials should be nil on error")
+			} else {
+				require.NoError(t, err, "getAdminCredentials() should not return an error")
+				require.Equal(t, tt.wantCredentials.apikey, credentials.apikey)
+				require.Equal(t, tt.wantCredentials.adminUser, credentials.adminUser)
+				require.Equal(t, tt.wantCredentials.adminPassword, credentials.adminPassword)
 			}
 		})
 	}


### PR DESCRIPTION
This allows using the `.spec.config` as a source of credentials for external instances.