### PR TITLE
chore(controllers): Test CR deletion, Update finalizer behaviour of Dashboard, Datasource, and Folder

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -292,6 +292,7 @@ func (r *GrafanaAlertRuleGroupReconciler) reconcileWithInstance(ctx context.Cont
 
 func (r *GrafanaAlertRuleGroupReconciler) finalize(ctx context.Context, group *grafanav1beta1.GrafanaAlertRuleGroup) error {
 	log := logf.FromContext(ctx)
+	log.Info("Finalizing GrafanaAlertRuleGroup")
 
 	isCleanupInGrafanaRequired := true
 

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -219,6 +219,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 func (r *GrafanaDashboardReconciler) finalize(ctx context.Context, cr *v1beta1.GrafanaDashboard) error {
 	log := logf.FromContext(ctx)
+	log.Info("Finalizing GrafanaDashboard")
 
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
@@ -228,6 +229,7 @@ func (r *GrafanaDashboardReconciler) finalize(ctx context.Context, cr *v1beta1.G
 	for _, grafana := range instances {
 		found, uid := grafana.Status.Dashboards.Find(cr.Namespace, cr.Name)
 		if !found {
+			log.Info("dashboard not found on instance - skipping finalize", "grafana", grafana.Name, "uid", uid)
 			continue
 		}
 

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -214,6 +214,9 @@ func (r *GrafanaDatasourceReconciler) deleteOldDatasource(ctx context.Context, c
 }
 
 func (r *GrafanaDatasourceReconciler) finalize(ctx context.Context, cr *v1beta1.GrafanaDatasource) error {
+	log := logf.FromContext(ctx)
+	log.Info("Finalizing GrafanaDatasource")
+
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
@@ -222,6 +225,7 @@ func (r *GrafanaDatasourceReconciler) finalize(ctx context.Context, cr *v1beta1.
 	for _, grafana := range instances {
 		found, uid := grafana.Status.Datasources.Find(cr.Namespace, cr.Name)
 		if !found {
+			log.Info("datasource not found on instance - skipping finalize", "grafana", grafana.Name, "uid", uid)
 			continue
 		}
 

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -151,6 +151,9 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *GrafanaFolderReconciler) finalize(ctx context.Context, folder *grafanav1beta1.GrafanaFolder) error {
+	log := logf.FromContext(ctx)
+	log.Info("Finalizing GrafanaFolder")
+
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, folder)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
@@ -162,6 +165,7 @@ func (r *GrafanaFolderReconciler) finalize(ctx context.Context, folder *grafanav
 	for _, grafana := range instances {
 		found, uid := grafana.Status.Folders.Find(folder.Namespace, folder.Name)
 		if !found {
+			log.Info("folder not found on instance - skipping finalize", "grafana", grafana.Name, "uid", uid)
 			continue
 		}
 

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -237,7 +237,7 @@ func (r *GrafanaLibraryPanelReconciler) reconcileWithInstance(ctx context.Contex
 
 func (r *GrafanaLibraryPanelReconciler) finalize(ctx context.Context, libraryPanel *v1beta1.GrafanaLibraryPanel) error {
 	log := logf.FromContext(ctx)
-	log.Info("finalizing GrafanaLibraryPanel")
+	log.Info("Finalizing GrafanaLibraryPanel")
 
 	uid := content.CustomUIDOrUID(libraryPanel, libraryPanel.Status.UID)
 

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -308,6 +308,7 @@ func (r *GrafanaNotificationPolicyReconciler) reconcileWithInstance(ctx context.
 
 func (r *GrafanaNotificationPolicyReconciler) finalize(ctx context.Context, notificationPolicy *v1beta1.GrafanaNotificationPolicy) error {
 	log := logf.FromContext(ctx)
+	log.Info("Finalizing GrafanaNotificationPolicy")
 
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, notificationPolicy)
 	if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -255,4 +256,14 @@ func reconcileAndValidateCondition(r GrafanaCommonReconciler, cr v1beta1.CommonR
 	require.NoError(t, err)
 
 	containsEqualCondition(cr.CommonStatus().Conditions, condition)
+
+	err = k8sClient.Delete(testCtx, cr)
+	require.NoError(t, err)
+
+	_, err = r.Reconcile(testCtx, req)
+	if err != nil && strings.Contains(err.Error(), "dummy-deployment") {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
The initial goal was to just delete created CRs and trigger the finalizer.
Unfortunately `GrafanaDashboard`, `GrafanaDatasource`, and `GrafanaFolder` all returned successful when attempting to finalize against the `dummy` Grafana instance used to provoke Synchronization failures.

I removed the early exit in favour of attempting and potentially failing to delete the resource.
All finalizers will now return a success if the resource was deleted or didn't exist, and an error otherwise.

This should lead to a few more requests when finalizing resources, but more correct deletion outcomes in edge cases.

The downside of this is the need to expect an error when the `dummy` instance, which never responds, is being deleted from.