### PR TITLE
chore(workflows): pre-pull grafana image to speed up CI

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -29,6 +29,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Pre-pull Grafana test image
+        run: |
+          make test-image-pre-pull
+
       - name: Setup go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ kustomize-github-assets: $(KUSTOMIZE) ## Generates GitHub assets.
 muffet-dev: $(MUFFET) ## Detect broken internal links in docs.
 	$(MUFFET) --include=http://localhost:1313 http://localhost:1313
 
+.PHONY:
+test-image-pre-pull: ## Pre-pulls Grafana image used in tests to speed up CI
+	docker pull $(GRAFANA_IMAGE):$(GRAFANA_VERSION) > /dev/null 2>&1 &
+
 .PHONY: test
 test: $(ENVTEST) manifests generate vet golangci-lint api-docs kustomize-lint helm-docs helm-lint ## Run tests.
 	$(info $(M) running $@)


### PR DESCRIPTION
- workflows:
  - as we now depend on Grafana image in `test` job (used in tests covering external instances), it makes sense to pre-pull the image to make it available by the time the tests begin instead of waiting for extra ~10-20 seconds till the pulling process is over.

I'll check how to speed up e2e workflow in a similar way.