### PR TITLE
chore(workflows): warm up Go cache

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -6,7 +6,7 @@ name: PR Validation
 on:
   pull_request:
   merge_group:
-  # Helps to cut execution time in PRs by generating pre-commit/go/tryvy cache (branches inherit cache from master)
+  # Helps to cut execution time in PRs and the merge queue by generating pre-commit/go/tryvy cache (branches inherit cache from master)
   push:
     branches:
       - master

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -6,7 +6,7 @@ name: PR Validation
 on:
   pull_request:
   merge_group:
-  # Helps to cut execution time in PRs and the merge queue by generating pre-commit/go/tryvy cache (branches inherit cache from master)
+  # Helps to cut execution time in PRs and the merge queue by generating pre-commit/go/trivy cache (branches inherit cache from master)
   push:
     branches:
       - master

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -6,6 +6,10 @@ name: PR Validation
 on:
   pull_request:
   merge_group:
+  # Helps to cut execution time in PRs by generating pre-commit/go/tryvy cache (branches inherit cache from master)
+  push:
+    branches:
+      - master
 
 jobs:
   pre-commit:


### PR DESCRIPTION
As we currently don't have any builds running from master branch, its cache is always empty causing:
  - the first execution of builds in PRs to be much slower:
    - e.g. ~4m for [the first run](https://github.com/grafana/grafana-operator/actions/runs/16562377844/attempts/1), ~2m - for [the second](https://github.com/grafana/grafana-operator/actions/runs/16562377844). - The second execution is faster only because it re-uses the cache uploaded during the first run;
  - causing all merge queue executions to be much slower as they rely on temporary read-only branches, which also don't have cache for the same reason.

To mitigate the behaviour, added a workflow trigger that would run jobs from PR validation workflow upon merge to master (all of those jobs generate cache, the main focus of the PR is the Go cache though).

<img width="1668" height="512" alt="image" src="https://github.com/user-attachments/assets/6c87d65f-0810-4a0b-bdad-36c13e98fbd3" />
