### PR TITLE
chore(workflows): pre-pull kind image

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,6 +52,10 @@ jobs:
           - v1.32.2
           - v1.33.0
     steps:
+      - name: Pre-pull kind image
+        run: |
+          docker pull kindest/node:${{ matrix.version }} > /dev/null 2>&1 &
+
       - name: Clone repo and checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
- `workflows`:
  - Added pre-pull step for kind image to make the e2e workflow a bit faster (~7-10 sec).