### PR TITLE
chore(e2e): faster grafana reconciliation, deprecate default initial delay for readinessProbe

### DIFF
--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -21,15 +21,14 @@ import (
 )
 
 const (
-	MemoryRequest                           = "256Mi"
-	CPURequest                              = "100m"
-	MemoryLimit                             = "1024Mi"
-	GrafanaHealthEndpoint                   = "/api/health"
-	ReadinessProbeFailureThreshold    int32 = 1
-	ReadinessProbeInitialDelaySeconds int32 = 5
-	ReadinessProbePeriodSeconds       int32 = 10
-	ReadinessProbeSuccessThreshold    int32 = 1
-	ReadinessProbeTimeoutSeconds      int32 = 3
+	MemoryRequest                        = "256Mi"
+	CPURequest                           = "100m"
+	MemoryLimit                          = "1024Mi"
+	GrafanaHealthEndpoint                = "/api/health"
+	ReadinessProbeFailureThreshold int32 = 1
+	ReadinessProbePeriodSeconds    int32 = 10
+	ReadinessProbeSuccessThreshold int32 = 1
+	ReadinessProbeTimeoutSeconds   int32 = 3
 )
 
 type DeploymentReconciler struct {
@@ -315,11 +314,10 @@ func getReadinessProbe(cr *v1beta1.Grafana) *corev1.Probe {
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},
-		InitialDelaySeconds: ReadinessProbeInitialDelaySeconds,
-		TimeoutSeconds:      ReadinessProbeTimeoutSeconds,
-		PeriodSeconds:       ReadinessProbePeriodSeconds,
-		SuccessThreshold:    ReadinessProbeSuccessThreshold,
-		FailureThreshold:    ReadinessProbeFailureThreshold,
+		TimeoutSeconds:   ReadinessProbeTimeoutSeconds,
+		PeriodSeconds:    ReadinessProbePeriodSeconds,
+		SuccessThreshold: ReadinessProbeSuccessThreshold,
+		FailureThreshold: ReadinessProbeFailureThreshold,
 	}
 }
 

--- a/tests/e2e/example-test/00-create-external-grafana.yaml
+++ b/tests/e2e/example-test/00-create-external-grafana.yaml
@@ -16,6 +16,14 @@ spec:
     security:
       admin_user: root
       admin_password: secret
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              readinessProbe:
+                periodSeconds: 2
   ingress:
     spec:
       ingressClassName: nginx

--- a/tests/e2e/example-test/00-create-grafana.yaml
+++ b/tests/e2e/example-test/00-create-grafana.yaml
@@ -21,3 +21,11 @@ spec:
     recording_rules:
       enabled: "true"
       url: http://prometheus:9090/api/prom/push
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              readinessProbe:
+                periodSeconds: 2

--- a/tests/e2e/example-test/00-create-versioned-grafana.yaml
+++ b/tests/e2e/example-test/00-create-versioned-grafana.yaml
@@ -16,3 +16,11 @@ spec:
     security:
       admin_user: root
       admin_password: secret
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              readinessProbe:
+                periodSeconds: 2

--- a/tests/e2e/examples/basic/resources.yaml
+++ b/tests/e2e/examples/basic/resources.yaml
@@ -13,6 +13,14 @@ spec:
     security:
       admin_user: root
       admin_password: secret
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              readinessProbe:
+                periodSeconds: 2
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard

--- a/tests/e2e/examples/crossnamespace/resources.yaml
+++ b/tests/e2e/examples/crossnamespace/resources.yaml
@@ -29,6 +29,7 @@ spec:
                 readOnlyRootFilesystem: false
               readinessProbe:
                 failureThreshold: 3
+                periodSeconds: 2
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource

--- a/tests/e2e/examples/dashboard_immutable_uid/base-resources.yaml
+++ b/tests/e2e/examples/dashboard_immutable_uid/base-resources.yaml
@@ -14,6 +14,14 @@ spec:
     security:
       admin_user: root
       admin_password: secret
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              readinessProbe:
+                periodSeconds: 2
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard


### PR DESCRIPTION
- controllers:
  - deprecated initial delay for `readinessProbe` as it was impossible to set it to 0 and it has never made sense anyway;
    - as a side-effect for user deployments, existing pods will get recreated, but I think that should be fine due to dynamic nature of k8s. We can add a side-note about that to release description;
- e2e:
  - reduced `periodSeconds` for `readinessProbe` from 10 (default) to 2 seconds. With the initial delay removed (5 sec), initial reconciliation of a `Grafana` resource should go down from 15sec+ down to a few seconds (we rely on k8s Service, which adds an Endpoint only when a pod is ready).