### PR TITLE
fix: add id-token: write permissions to helm release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -325,6 +326,7 @@ jobs:
       - attest
     permissions:
       packages: read
+      id-token: write
     steps:
       - name: Get secrets
         id: secrets


### PR DESCRIPTION
The shared action requires this permission to authenticate against the Grafana Labs vault instance