### PR TITLE
chore: call getFolderUID once before looping instances

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -114,8 +114,12 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 	log.Info("found matching Grafana instances for group", "count", len(instances))
 
 	folderUID, err := getFolderUID(ctx, r.Client, group)
-	if err != nil || folderUID == "" {
-		return ctrl.Result{}, fmt.Errorf("folder uid not found: %w", err)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf(ErrFetchingFolder, err)
+	}
+
+	if folderUID == "" {
+		return ctrl.Result{}, fmt.Errorf("folder uid not found, alert rule must reference a folder")
 	}
 
 	editable := "true" //nolint:goconst

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -50,7 +50,10 @@ const (
 	grafanaFinalizer = "operator.grafana.com/finalizer"
 )
 
-var ErrNoMatchingInstances = fmt.Errorf("no matching instances")
+var (
+	ErrNoMatchingInstances = fmt.Errorf("no matching instances")
+	ErrFetchingFolder      = "fetching folder to resolve uid: %w"
+)
 
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
@@ -125,7 +128,7 @@ func GetScopedMatchingInstances(ctx context.Context, k8sClient client.Client, cr
 	return selectedList, nil
 }
 
-// getFolderUID fetches the folderUID from an existing GrafanaFolder CR declared in the specified namespace
+// getFolderUID returns the folderUID from an existing GrafanaFolder CR within the same namespace
 func getFolderUID(ctx context.Context, k8sClient client.Client, ref operatorapi.FolderReferencer) (string, error) {
 	if ref.FolderUID() != "" {
 		return ref.FolderUID(), nil


### PR DESCRIPTION
I noticed that in a few controllers `getFolderUID` is called once per instance rather than once overall.
Moved getFolderUID before the main synchronize loop in relevant controllers which gives a few benefits

- The k8sclient cache is checked for the `folder` once per reconcile.
- Early exit in AlertRuleGroup when folderUID cannot be resolved.