### PR TITLE
chore(controllers): simplify tests around conditions

### DIFF
--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -54,6 +54,7 @@ type CommonResource interface {
 	client.Object
 	MatchLabels() *metav1.LabelSelector
 	MatchNamespace() string
+	Metadata() metav1.ObjectMeta
 	AllowCrossNamespace() bool
 	CommonStatus() *GrafanaCommonStatus
 }

--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -202,6 +202,10 @@ func (in *GrafanaAlertRuleGroup) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaAlertRuleGroup) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaAlertRuleGroup) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -104,6 +104,10 @@ func (in *GrafanaContactPoint) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaContactPoint) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaContactPoint) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -139,6 +139,10 @@ func (in *GrafanaDashboard) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaDashboard) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaDashboard) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -164,6 +164,10 @@ func (in *GrafanaDatasource) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaDatasource) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaDatasource) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -171,6 +171,10 @@ func (in *GrafanaFolder) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaFolder) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaFolder) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/api/v1beta1/grafanalibrarypanel_types.go
+++ b/api/v1beta1/grafanalibrarypanel_types.go
@@ -89,6 +89,10 @@ func (in *GrafanaLibraryPanel) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaLibraryPanel) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaLibraryPanel) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/api/v1beta1/grafanamutetiming_types.go
+++ b/api/v1beta1/grafanamutetiming_types.go
@@ -101,6 +101,10 @@ func (in *GrafanaMuteTiming) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaMuteTiming) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaMuteTiming) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/api/v1beta1/grafananotificationpolicy_types.go
+++ b/api/v1beta1/grafananotificationpolicy_types.go
@@ -216,6 +216,10 @@ func (in *GrafanaNotificationPolicy) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaNotificationPolicy) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaNotificationPolicy) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/api/v1beta1/grafananotificationtemplate_types.go
+++ b/api/v1beta1/grafananotificationtemplate_types.go
@@ -62,6 +62,10 @@ func (in *GrafanaNotificationTemplate) MatchNamespace() string {
 	return in.Namespace
 }
 
+func (in *GrafanaNotificationTemplate) Metadata() metav1.ObjectMeta {
+	return in.ObjectMeta
+}
+
 func (in *GrafanaNotificationTemplate) AllowCrossNamespace() bool {
 	return in.Spec.AllowCrossNamespaceImport
 }

--- a/controllers/alertrulegroup_controller_test.go
+++ b/controllers/alertrulegroup_controller_test.go
@@ -4,14 +4,16 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("AlertRulegroup Reconciler: Provoke Conditions", func() {
+	t := GinkgoT()
+
 	noDataState := "NoData"
 	rules := []v1beta1.AlertRule{
 		{
@@ -22,73 +24,73 @@ var _ = Describe("AlertRulegroup Reconciler: Provoke Conditions", func() {
 			Data:         []*v1beta1.AlertQuery{},
 		},
 	}
+
 	tests := []struct {
-		name          string
-		cr            *v1beta1.GrafanaAlertRuleGroup
-		wantCondition string
-		wantReason    string
-		wantErr       string
+		name    string
+		meta    metav1.ObjectMeta
+		spec    v1beta1.GrafanaAlertRuleGroupSpec
+		want    metav1.Condition
+		wantErr string
 	}{
 		{
 			name: ".spec.suspend=true",
-			cr: &v1beta1.GrafanaAlertRuleGroup{
-				ObjectMeta: objectMetaSuspended,
-				Spec: v1beta1.GrafanaAlertRuleGroupSpec{
-					GrafanaCommonSpec: commonSpecSuspended,
-					FolderUID:         "GroupUID",
-					Rules:             rules,
-				},
+			meta: objectMetaSuspended,
+			spec: v1beta1.GrafanaAlertRuleGroupSpec{
+				GrafanaCommonSpec: commonSpecSuspended,
+				FolderUID:         "GroupUID",
+				Rules:             rules,
 			},
-			wantCondition: conditionSuspended,
-			wantReason:    conditionReasonApplySuspended,
+			want: metav1.Condition{
+				Type:   conditionSuspended,
+				Reason: conditionReasonApplySuspended,
+			},
 		},
 		{
 			name: "GetScopedMatchingInstances returns empty list",
-			cr: &v1beta1.GrafanaAlertRuleGroup{
-				ObjectMeta: objectMetaNoMatchingInstances,
-				Spec: v1beta1.GrafanaAlertRuleGroupSpec{
-					GrafanaCommonSpec: commonSpecNoMatchingInstances,
-					FolderUID:         "GroupUID",
-					Rules:             rules,
-				},
+			meta: objectMetaNoMatchingInstances,
+			spec: v1beta1.GrafanaAlertRuleGroupSpec{
+				GrafanaCommonSpec: commonSpecNoMatchingInstances,
+				FolderUID:         "GroupUID",
+				Rules:             rules,
 			},
-			wantCondition: conditionNoMatchingInstance,
-			wantReason:    conditionReasonEmptyAPIReply,
-			wantErr:       ErrNoMatchingInstances.Error(),
+			want: metav1.Condition{
+				Type:   conditionNoMatchingInstance,
+				Reason: conditionReasonEmptyAPIReply,
+			},
+			wantErr: ErrNoMatchingInstances.Error(),
 		},
 		{
 			name: "Failed to apply to instance",
-			cr: &v1beta1.GrafanaAlertRuleGroup{
-				ObjectMeta: objectMetaApplyFailed,
-				Spec: v1beta1.GrafanaAlertRuleGroupSpec{
-					GrafanaCommonSpec: commonSpecApplyFailed,
-					FolderRef:         "pre-existing",
-					Rules:             rules,
-				},
+			meta: objectMetaApplyFailed,
+			spec: v1beta1.GrafanaAlertRuleGroupSpec{
+				GrafanaCommonSpec: commonSpecApplyFailed,
+				FolderRef:         "pre-existing",
+				Rules:             rules,
 			},
-			wantCondition: conditionAlertGroupSynchronized,
-			wantReason:    conditionReasonApplyFailed,
-			wantErr:       "failed to apply to all instances",
+			want: metav1.Condition{
+				Type:   conditionAlertGroupSynchronized,
+				Reason: conditionReasonApplyFailed,
+			},
+			wantErr: "failed to apply to all instances",
 		},
 		{
 			name: "Successfully applied resource to instance",
-			cr: &v1beta1.GrafanaAlertRuleGroup{
-				ObjectMeta: objectMetaSynchronized,
-				Spec: v1beta1.GrafanaAlertRuleGroupSpec{
-					GrafanaCommonSpec: commonSpecSynchronized,
-					FolderRef:         "pre-existing",
-					Interval:          metav1.Duration{Duration: 60 * time.Second},
-					Rules: []v1beta1.AlertRule{
-						{
-							Title:     "MathRule",
-							UID:       "oefiodwa-dam-dwa",
-							Condition: "A",
-							Data: []*v1beta1.AlertQuery{
-								{
-									RefID:             "A",
-									RelativeTimeRange: nil,
-									DatasourceUID:     "__expr__",
-									Model: &v1.JSON{Raw: []byte(`{
+			meta: objectMetaSynchronized,
+			spec: v1beta1.GrafanaAlertRuleGroupSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
+				FolderRef:         "pre-existing",
+				Interval:          metav1.Duration{Duration: 60 * time.Second},
+				Rules: []v1beta1.AlertRule{
+					{
+						Title:     "MathRule",
+						UID:       "oefiodwa-dam-dwa",
+						Condition: "A",
+						Data: []*v1beta1.AlertQuery{
+							{
+								RefID:             "A",
+								RelativeTimeRange: nil,
+								DatasourceUID:     "__expr__",
+								Model: &v1.JSON{Raw: []byte(`{
 		                                "conditions": [
 		                                    {
 		                                        "evaluator": {
@@ -123,46 +125,52 @@ var _ = Describe("AlertRulegroup Reconciler: Provoke Conditions", func() {
 		                                "refId": "B",
 		                                "type": "math"
 		                            }`)},
-								},
 							},
-							NoDataState:  &noDataState,
-							ExecErrState: "Error",
-							For:          &metav1.Duration{Duration: 60 * time.Second},
-							Annotations:  map[string]string{},
-							Labels:       map[string]string{},
-							IsPaused:     true,
 						},
+						NoDataState:  &noDataState,
+						ExecErrState: "Error",
+						For:          &metav1.Duration{Duration: 60 * time.Second},
+						Annotations:  map[string]string{},
+						Labels:       map[string]string{},
+						IsPaused:     true,
 					},
 				},
 			},
-			wantCondition: conditionAlertGroupSynchronized,
-			wantReason:    conditionReasonApplySuccessful,
+			want: metav1.Condition{
+				Type:   conditionAlertGroupSynchronized,
+				Reason: conditionReasonApplySuccessful,
+			},
 		},
 	}
 
-	for _, test := range tests {
-		It(test.name, func() {
-			err := k8sClient.Create(testCtx, test.cr)
-			Expect(err).ToNot(HaveOccurred())
-
-			req := requestFromMeta(test.cr.ObjectMeta)
-
-			// Reconcile
-			r := GrafanaAlertRuleGroupReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			_, err = r.Reconcile(testCtx, req)
-			if test.wantErr == "" {
-				Expect(err).ShouldNot(HaveOccurred())
-			} else {
-				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(HavePrefix(test.wantErr))
+	for _, tt := range tests {
+		It(tt.name, func() {
+			cr := &v1beta1.GrafanaAlertRuleGroup{
+				ObjectMeta: tt.meta,
+				Spec:       tt.spec,
 			}
 
-			resultCr := &v1beta1.GrafanaAlertRuleGroup{}
-			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+			err := k8sClient.Create(testCtx, cr)
+			require.NoError(t, err)
 
-			// Verify condition
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+			r := GrafanaAlertRuleGroupReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			req := requestFromMeta(tt.meta)
+
+			// Reconcile
+
+			_, err = r.Reconcile(testCtx, req)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+
+			cr = &v1beta1.GrafanaAlertRuleGroup{}
+
+			err = r.Get(testCtx, req.NamespacedName, cr)
+			require.NoError(t, err)
+
+			containsEqualCondition(cr.Status.Conditions, tt.want)
 		})
 	}
 })

--- a/controllers/contactpoint_controller_test.go
+++ b/controllers/contactpoint_controller_test.go
@@ -2,129 +2,134 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ContactPoint Reconciler: Provoke Conditions", func() {
+	t := GinkgoT()
+
 	tests := []struct {
-		name          string
-		cr            *v1beta1.GrafanaContactPoint
-		wantCondition string
-		wantReason    string
-		wantErr       string
+		name    string
+		meta    metav1.ObjectMeta
+		spec    v1beta1.GrafanaContactPointSpec
+		want    metav1.Condition
+		wantErr string
 	}{
 		{
 			name: ".spec.suspend=true",
-			cr: &v1beta1.GrafanaContactPoint{
-				ObjectMeta: objectMetaSuspended,
-				Spec: v1beta1.GrafanaContactPointSpec{
-					GrafanaCommonSpec: commonSpecSuspended,
-					Name:              "ContactPointName",
-					Settings:          &v1.JSON{Raw: []byte("{}")},
-					Type:              "webhook",
-				},
+			meta: objectMetaSuspended,
+			spec: v1beta1.GrafanaContactPointSpec{
+				GrafanaCommonSpec: commonSpecSuspended,
+				Name:              "ContactPointName",
+				Settings:          &v1.JSON{Raw: []byte("{}")},
+				Type:              "webhook",
 			},
-			wantCondition: conditionSuspended,
-			wantReason:    conditionReasonApplySuspended,
+			want: metav1.Condition{
+				Type:   conditionSuspended,
+				Reason: conditionReasonApplySuspended,
+			},
 		},
 		{
 			name: "GetScopedMatchingInstances returns empty list",
-			cr: &v1beta1.GrafanaContactPoint{
-				ObjectMeta: objectMetaNoMatchingInstances,
-				Spec: v1beta1.GrafanaContactPointSpec{
-					GrafanaCommonSpec: commonSpecNoMatchingInstances,
-					Name:              "ContactPointName",
-					Settings:          &v1.JSON{Raw: []byte("{}")},
-					Type:              "webhook",
-				},
+			meta: objectMetaNoMatchingInstances,
+			spec: v1beta1.GrafanaContactPointSpec{
+				GrafanaCommonSpec: commonSpecNoMatchingInstances,
+				Name:              "ContactPointName",
+				Settings:          &v1.JSON{Raw: []byte("{}")},
+				Type:              "webhook",
 			},
-			wantCondition: conditionNoMatchingInstance,
-			wantReason:    conditionReasonEmptyAPIReply,
-			wantErr:       ErrNoMatchingInstances.Error(),
+			want: metav1.Condition{
+				Type:   conditionNoMatchingInstance,
+				Reason: conditionReasonEmptyAPIReply,
+			},
+			wantErr: ErrNoMatchingInstances.Error(),
 		},
 		{
 			name: "Failed to apply to instance",
-			cr: &v1beta1.GrafanaContactPoint{
-				ObjectMeta: objectMetaApplyFailed,
-				Spec: v1beta1.GrafanaContactPointSpec{
-					GrafanaCommonSpec: commonSpecApplyFailed,
-					Name:              "ContactPointName",
-					Settings:          &v1.JSON{Raw: []byte("{}")},
-					Type:              "webhook",
-				},
+			meta: objectMetaApplyFailed,
+			spec: v1beta1.GrafanaContactPointSpec{
+				GrafanaCommonSpec: commonSpecApplyFailed,
+				Name:              "ContactPointName",
+				Settings:          &v1.JSON{Raw: []byte("{}")},
+				Type:              "webhook",
 			},
-			wantCondition: conditionContactPointSynchronized,
-			wantReason:    conditionReasonApplyFailed,
-			wantErr:       "failed to apply to all instances",
+			want: metav1.Condition{
+				Type:   conditionContactPointSynchronized,
+				Reason: conditionReasonApplyFailed,
+			},
+			wantErr: "failed to apply to all instances",
 		},
 		{
 			name: "Referenced secret does not exist",
-			cr: &v1beta1.GrafanaContactPoint{
-				ObjectMeta: objectMetaInvalidSpec,
-				Spec: v1beta1.GrafanaContactPointSpec{
-					GrafanaCommonSpec: commonSpecInvalidSpec,
-					Name:              "ContactPointName",
-					Settings:          &v1.JSON{Raw: []byte("{}")},
-					Type:              "email",
-					ValuesFrom: []v1beta1.ValueFrom{{
-						TargetPath: "addresses",
-						ValueFrom: v1beta1.ValueFromSource{SecretKeyRef: &corev1.SecretKeySelector{
-							Key: "contact-mails",
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "alert-mails",
-							},
-						}},
+			meta: objectMetaInvalidSpec,
+			spec: v1beta1.GrafanaContactPointSpec{
+				GrafanaCommonSpec: commonSpecInvalidSpec,
+				Name:              "ContactPointName",
+				Settings:          &v1.JSON{Raw: []byte("{}")},
+				Type:              "email",
+				ValuesFrom: []v1beta1.ValueFrom{{
+					TargetPath: "addresses",
+					ValueFrom: v1beta1.ValueFromSource{SecretKeyRef: &corev1.SecretKeySelector{
+						Key: "contact-mails",
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "alert-mails",
+						},
 					}},
-				},
+				}},
 			},
-			wantCondition: conditionInvalidSpec,
-			wantReason:    conditionReasonInvalidSettings,
-			wantErr:       "building contactpoint settings",
+			want: metav1.Condition{
+				Type:   conditionInvalidSpec,
+				Reason: conditionReasonInvalidSettings,
+			},
+			wantErr: "building contactpoint settings",
 		},
 		{
 			name: "Successfully applied resource to instance",
-			cr: &v1beta1.GrafanaContactPoint{
-				ObjectMeta: objectMetaSynchronized,
-				Spec: v1beta1.GrafanaContactPointSpec{
-					GrafanaCommonSpec: commonSpecSynchronized,
-					Name:              "ContactPointName",
-					Settings:          &v1.JSON{Raw: []byte(`{"url": "http://test.io"}`)},
-					Type:              "webhook",
-				},
+			meta: objectMetaSynchronized,
+			spec: v1beta1.GrafanaContactPointSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
+				Name:              "ContactPointName",
+				Settings:          &v1.JSON{Raw: []byte(`{"url": "http://test.io"}`)},
+				Type:              "webhook",
 			},
-			wantCondition: conditionContactPointSynchronized,
-			wantReason:    conditionReasonApplySuccessful,
+			want: metav1.Condition{
+				Type:   conditionContactPointSynchronized,
+				Reason: conditionReasonApplySuccessful,
+			},
 		},
 	}
 
-	for _, test := range tests {
-		It(test.name, func() {
-			err := k8sClient.Create(testCtx, test.cr)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Reconciliation Request
-			req := requestFromMeta(test.cr.ObjectMeta)
-
-			// Reconcile
-			r := GrafanaContactPointReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			_, err = r.Reconcile(testCtx, req)
-			if test.wantErr == "" {
-				Expect(err).ShouldNot(HaveOccurred())
-			} else {
-				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(HavePrefix(test.wantErr))
+	for _, tt := range tests {
+		It(tt.name, func() {
+			cr := &v1beta1.GrafanaContactPoint{
+				ObjectMeta: tt.meta,
+				Spec:       tt.spec,
 			}
 
-			resultCr := &v1beta1.GrafanaContactPoint{}
-			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+			err := k8sClient.Create(testCtx, cr)
+			require.NoError(t, err)
 
-			// Verify Condition
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+			r := GrafanaContactPointReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			req := requestFromMeta(tt.meta)
+
+			_, err = r.Reconcile(testCtx, req)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+
+			cr = &v1beta1.GrafanaContactPoint{}
+
+			err = r.Get(testCtx, req.NamespacedName, cr)
+			require.NoError(t, err)
+
+			containsEqualCondition(cr.Status.Conditions, tt.want)
 		})
 	}
 })

--- a/controllers/contactpoint_controller_test.go
+++ b/controllers/contactpoint_controller_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,8 +10,6 @@ import (
 )
 
 var _ = Describe("ContactPoint Reconciler: Provoke Conditions", func() {
-	t := GinkgoT()
-
 	tests := []struct {
 		name    string
 		meta    metav1.ObjectMeta
@@ -111,25 +108,9 @@ var _ = Describe("ContactPoint Reconciler: Provoke Conditions", func() {
 				Spec:       tt.spec,
 			}
 
-			err := k8sClient.Create(testCtx, cr)
-			require.NoError(t, err)
+			r := &GrafanaContactPointReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			r := GrafanaContactPointReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			req := requestFromMeta(tt.meta)
-
-			_, err = r.Reconcile(testCtx, req)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.wantErr)
-			}
-
-			cr = &v1beta1.GrafanaContactPoint{}
-
-			err = r.Get(testCtx, req.NamespacedName, cr)
-			require.NoError(t, err)
-
-			containsEqualCondition(cr.Status.Conditions, tt.want)
+			reconcileAndValidateCondition(r, cr, tt.want, tt.wantErr)
 		})
 	}
 })

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -51,6 +52,11 @@ const (
 )
 
 var ErrNoMatchingInstances = fmt.Errorf("no matching instances")
+
+type GrafanaCommonReconciler interface {
+	Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+	Reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error)
+}
 
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 

--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -18,15 +18,12 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("Dashboard Reconciler: Provoke Conditions", func() {
-	t := GinkgoT()
-
 	tests := []struct {
 		name    string
 		meta    metav1.ObjectMeta
@@ -126,25 +123,9 @@ var _ = Describe("Dashboard Reconciler: Provoke Conditions", func() {
 				Spec:       tt.spec,
 			}
 
-			err := k8sClient.Create(testCtx, cr)
-			require.NoError(t, err)
+			r := &GrafanaDashboardReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			r := GrafanaDashboardReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			req := requestFromMeta(tt.meta)
-
-			_, err = r.Reconcile(testCtx, req)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.wantErr)
-			}
-
-			cr = &v1beta1.GrafanaDashboard{}
-
-			err = r.Get(testCtx, req.NamespacedName, cr)
-			require.NoError(t, err)
-
-			containsEqualCondition(cr.Status.Conditions, tt.want)
+			reconcileAndValidateCondition(r, cr, tt.want, tt.wantErr)
 		})
 	}
 })

--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -18,129 +18,133 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Dashboard Reconciler: Provoke Conditions", func() {
+	t := GinkgoT()
+
 	tests := []struct {
-		name          string
-		cr            *v1beta1.GrafanaDashboard
-		wantCondition string
-		wantReason    string
-		wantErr       string
+		name    string
+		meta    metav1.ObjectMeta
+		spec    v1beta1.GrafanaDashboardSpec
+		want    metav1.Condition
+		wantErr string
 	}{
 		{
 			name: ".spec.suspend=true",
-			cr: &v1beta1.GrafanaDashboard{
-				ObjectMeta: objectMetaSuspended,
-				Spec: v1beta1.GrafanaDashboardSpec{
-					GrafanaCommonSpec:  commonSpecSuspended,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
-				},
+			meta: objectMetaSuspended,
+			spec: v1beta1.GrafanaDashboardSpec{
+				GrafanaCommonSpec:  commonSpecSuspended,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
 			},
-			wantCondition: conditionSuspended,
-			wantReason:    conditionReasonApplySuspended,
+			want: metav1.Condition{
+				Type:   conditionSuspended,
+				Reason: conditionReasonApplySuspended,
+			},
 		},
 		{
 			name: "GetScopedMatchingInstances returns empty list",
-			cr: &v1beta1.GrafanaDashboard{
-				ObjectMeta: objectMetaNoMatchingInstances,
-				Spec: v1beta1.GrafanaDashboardSpec{
-					GrafanaCommonSpec:  commonSpecNoMatchingInstances,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
-				},
+			meta: objectMetaNoMatchingInstances,
+			spec: v1beta1.GrafanaDashboardSpec{
+				GrafanaCommonSpec:  commonSpecNoMatchingInstances,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
 			},
-			wantCondition: conditionNoMatchingInstance,
-			wantReason:    conditionReasonEmptyAPIReply,
-			wantErr:       ErrNoMatchingInstances.Error(),
+			want: metav1.Condition{
+				Type:   conditionNoMatchingInstance,
+				Reason: conditionReasonEmptyAPIReply,
+			},
+			wantErr: ErrNoMatchingInstances.Error(),
 		},
 		{
 			name: "Failed to apply to instance",
-			cr: &v1beta1.GrafanaDashboard{
-				ObjectMeta: objectMetaApplyFailed,
-				Spec: v1beta1.GrafanaDashboardSpec{
-					GrafanaCommonSpec:  commonSpecApplyFailed,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
-				},
+			meta: objectMetaApplyFailed,
+			spec: v1beta1.GrafanaDashboardSpec{
+				GrafanaCommonSpec:  commonSpecApplyFailed,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
 			},
-			wantCondition: conditionDashboardSynchronized,
-			wantReason:    conditionReasonApplyFailed,
-			wantErr:       "failed to apply to all instances",
+			want: metav1.Condition{
+				Type:   conditionDashboardSynchronized,
+				Reason: conditionReasonApplyFailed,
+			},
+			wantErr: "failed to apply to all instances",
 		},
 		{
 			name: "Invalid JSON",
-			cr: &v1beta1.GrafanaDashboard{
-				ObjectMeta: objectMetaInvalidSpec,
-				Spec: v1beta1.GrafanaDashboardSpec{
-					GrafanaCommonSpec:  commonSpecInvalidSpec,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{]"}, // Invalid json
-				},
+			meta: objectMetaInvalidSpec,
+			spec: v1beta1.GrafanaDashboardSpec{
+				GrafanaCommonSpec:  commonSpecInvalidSpec,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{]"}, // Invalid json
 			},
-			wantCondition: conditionInvalidSpec,
-			wantReason:    conditionReasonInvalidModelResolution,
-			wantErr:       "resolving dashboard contents",
+			want: metav1.Condition{
+				Type:   conditionInvalidSpec,
+				Reason: conditionReasonInvalidModelResolution,
+			},
+			wantErr: "resolving dashboard contents",
 		},
 		{
 			name: "No model can be resolved, no model source is defined",
-			cr: &v1beta1.GrafanaDashboard{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "invalid-spec-no-model-source",
-				},
-				Spec: v1beta1.GrafanaDashboardSpec{
-					GrafanaCommonSpec: commonSpecInvalidSpec,
-				},
+			meta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "invalid-spec-no-model-source",
 			},
-			wantCondition: conditionInvalidSpec,
-			wantReason:    conditionReasonInvalidModelResolution,
-			wantErr:       "resolving dashboard contents",
+			spec: v1beta1.GrafanaDashboardSpec{
+				GrafanaCommonSpec: commonSpecInvalidSpec,
+			},
+			want: metav1.Condition{
+				Type:   conditionInvalidSpec,
+				Reason: conditionReasonInvalidModelResolution,
+			},
+			wantErr: "resolving dashboard contents",
 		},
 		{
 			name: "Successfully applied resource to instance",
-			cr: &v1beta1.GrafanaDashboard{
-				ObjectMeta: objectMetaSynchronized,
-				Spec: v1beta1.GrafanaDashboardSpec{
-					GrafanaCommonSpec: commonSpecSynchronized,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{
-						JSON: `{
+			meta: objectMetaSynchronized,
+			spec: v1beta1.GrafanaDashboardSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{
+					JSON: `{
 							"title": "Minimal Dashboard",
 							"links": []
 						}`,
-					},
 				},
 			},
-			wantCondition: conditionDashboardSynchronized,
-			wantReason:    conditionReasonApplySuccessful,
+			want: metav1.Condition{
+				Type:   conditionDashboardSynchronized,
+				Reason: conditionReasonApplySuccessful,
+			},
 		},
 	}
 
-	for _, test := range tests {
-		It(test.name, func() {
-			err := k8sClient.Create(testCtx, test.cr)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Reconciliation Request
-			req := requestFromMeta(test.cr.ObjectMeta)
-
-			// Reconcile
-			r := GrafanaDashboardReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			_, err = r.Reconcile(testCtx, req)
-			if test.wantErr == "" {
-				Expect(err).ShouldNot(HaveOccurred())
-			} else {
-				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(HavePrefix(test.wantErr))
+	for _, tt := range tests {
+		It(tt.name, func() {
+			cr := &v1beta1.GrafanaDashboard{
+				ObjectMeta: tt.meta,
+				Spec:       tt.spec,
 			}
 
-			resultCr := &v1beta1.GrafanaDashboard{}
-			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+			err := k8sClient.Create(testCtx, cr)
+			require.NoError(t, err)
 
-			// Verify Condition
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+			r := GrafanaDashboardReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			req := requestFromMeta(tt.meta)
+
+			_, err = r.Reconcile(testCtx, req)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+
+			cr = &v1beta1.GrafanaDashboard{}
+
+			err = r.Get(testCtx, req.NamespacedName, cr)
+			require.NoError(t, err)
+
+			containsEqualCondition(cr.Status.Conditions, tt.want)
 		})
 	}
 })

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -195,8 +195,6 @@ var _ = Describe("Datasource: substitute reference values", func() {
 })
 
 var _ = Describe("Datasource Reconciler: Provoke Conditions", func() {
-	t := GinkgoT()
-
 	tests := []struct {
 		name    string
 		meta    metav1.ObjectMeta
@@ -290,25 +288,9 @@ var _ = Describe("Datasource Reconciler: Provoke Conditions", func() {
 				Spec:       tt.spec,
 			}
 
-			err := k8sClient.Create(testCtx, cr)
-			require.NoError(t, err)
+			r := &GrafanaDatasourceReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			r := GrafanaDatasourceReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			req := requestFromMeta(tt.meta)
-
-			_, err = r.Reconcile(testCtx, req)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.wantErr)
-			}
-
-			cr = &v1beta1.GrafanaDatasource{}
-
-			err = r.Get(testCtx, req.NamespacedName, cr)
-			require.NoError(t, err)
-
-			containsEqualCondition(cr.Status.Conditions, tt.want)
+			reconcileAndValidateCondition(r, cr, tt.want, tt.wantErr)
 		})
 	}
 })

--- a/controllers/folder_controller_test.go
+++ b/controllers/folder_controller_test.go
@@ -2,105 +2,110 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Folder Reconciler: Provoke Conditions", func() {
+	t := GinkgoT()
+
 	tests := []struct {
-		name          string
-		cr            *v1beta1.GrafanaFolder
-		wantCondition string
-		wantReason    string
-		wantErr       string
+		name    string
+		meta    metav1.ObjectMeta
+		spec    v1beta1.GrafanaFolderSpec
+		want    metav1.Condition
+		wantErr string
 	}{
 		{
 			name: ".spec.suspend=true",
-			cr: &v1beta1.GrafanaFolder{
-				ObjectMeta: objectMetaSuspended,
-				Spec: v1beta1.GrafanaFolderSpec{
-					GrafanaCommonSpec: commonSpecSuspended,
-				},
+			meta: objectMetaSuspended,
+			spec: v1beta1.GrafanaFolderSpec{
+				GrafanaCommonSpec: commonSpecSuspended,
 			},
-			wantCondition: conditionSuspended,
-			wantReason:    conditionReasonApplySuspended,
+			want: metav1.Condition{
+				Type:   conditionSuspended,
+				Reason: conditionReasonApplySuspended,
+			},
 		},
 		{
 			name: "GetScopedMatchingInstances returns empty list",
-			cr: &v1beta1.GrafanaFolder{
-				ObjectMeta: objectMetaNoMatchingInstances,
-				Spec: v1beta1.GrafanaFolderSpec{
-					GrafanaCommonSpec: commonSpecNoMatchingInstances,
-				},
+			meta: objectMetaNoMatchingInstances,
+			spec: v1beta1.GrafanaFolderSpec{
+				GrafanaCommonSpec: commonSpecNoMatchingInstances,
 			},
-			wantCondition: conditionNoMatchingInstance,
-			wantReason:    conditionReasonEmptyAPIReply,
-			wantErr:       ErrNoMatchingInstances.Error(),
+			want: metav1.Condition{
+				Type:   conditionNoMatchingInstance,
+				Reason: conditionReasonEmptyAPIReply,
+			},
+			wantErr: ErrNoMatchingInstances.Error(),
 		},
 		{
 			name: "Failed to apply to instance",
-			cr: &v1beta1.GrafanaFolder{
-				ObjectMeta: objectMetaApplyFailed,
-				Spec: v1beta1.GrafanaFolderSpec{
-					GrafanaCommonSpec: commonSpecApplyFailed,
-				},
+			meta: objectMetaApplyFailed,
+			spec: v1beta1.GrafanaFolderSpec{
+				GrafanaCommonSpec: commonSpecApplyFailed,
 			},
-			wantCondition: conditionFolderSynchronized,
-			wantReason:    conditionReasonApplyFailed,
-			wantErr:       "failed to apply to all instances",
+			want: metav1.Condition{
+				Type:   conditionFolderSynchronized,
+				Reason: conditionReasonApplyFailed,
+			},
+			wantErr: "failed to apply to all instances",
 		},
 		{
 			name: "InvalidSpec Condition",
-			cr: &v1beta1.GrafanaFolder{
-				ObjectMeta: objectMetaInvalidSpec,
-				Spec: v1beta1.GrafanaFolderSpec{
-					GrafanaCommonSpec: commonSpecInvalidSpec,
-					CustomUID:         "self-ref",
-					ParentFolderUID:   "self-ref",
-				},
+			meta: objectMetaInvalidSpec,
+			spec: v1beta1.GrafanaFolderSpec{
+				GrafanaCommonSpec: commonSpecInvalidSpec,
+				CustomUID:         "self-ref",
+				ParentFolderUID:   "self-ref",
 			},
-			wantCondition: conditionInvalidSpec,
-			wantReason:    conditionReasonCyclicParent,
-			wantErr:       "cyclic folder reference",
+			want: metav1.Condition{
+				Type:   conditionInvalidSpec,
+				Reason: conditionReasonCyclicParent,
+			},
+			wantErr: "cyclic folder reference",
 		},
 		{
 			name: "Successfully applied resource to instance",
-			cr: &v1beta1.GrafanaFolder{
-				ObjectMeta: objectMetaSynchronized,
-				Spec: v1beta1.GrafanaFolderSpec{
-					GrafanaCommonSpec: commonSpecSynchronized,
-				},
+			meta: objectMetaSynchronized,
+			spec: v1beta1.GrafanaFolderSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
 			},
-			wantCondition: conditionFolderSynchronized,
-			wantReason:    conditionReasonApplySuccessful,
+			want: metav1.Condition{
+				Type:   conditionFolderSynchronized,
+				Reason: conditionReasonApplySuccessful,
+			},
 		},
 	}
 
-	for _, test := range tests {
-		It(test.name, func() {
-			err := k8sClient.Create(testCtx, test.cr)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Reconciliation Request
-			req := requestFromMeta(test.cr.ObjectMeta)
-
-			// Reconcile
-			r := GrafanaFolderReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			_, err = r.Reconcile(testCtx, req)
-			if test.wantErr == "" {
-				Expect(err).ShouldNot(HaveOccurred())
-			} else {
-				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(HavePrefix(test.wantErr))
+	for _, tt := range tests {
+		It(tt.name, func() {
+			cr := &v1beta1.GrafanaFolder{
+				ObjectMeta: tt.meta,
+				Spec:       tt.spec,
 			}
 
-			resultCr := &v1beta1.GrafanaFolder{}
-			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+			err := k8sClient.Create(testCtx, cr)
+			require.NoError(t, err)
 
-			// Verify Condition
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+			r := GrafanaFolderReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			req := requestFromMeta(tt.meta)
+
+			_, err = r.Reconcile(testCtx, req)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+
+			cr = &v1beta1.GrafanaFolder{}
+
+			err = r.Get(testCtx, req.NamespacedName, cr)
+			require.NoError(t, err)
+
+			containsEqualCondition(cr.Status.Conditions, tt.want)
 		})
 	}
 })

--- a/controllers/folder_controller_test.go
+++ b/controllers/folder_controller_test.go
@@ -2,15 +2,12 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	"github.com/stretchr/testify/require"
 
 	. "github.com/onsi/ginkgo/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Folder Reconciler: Provoke Conditions", func() {
-	t := GinkgoT()
-
 	tests := []struct {
 		name    string
 		meta    metav1.ObjectMeta
@@ -87,25 +84,9 @@ var _ = Describe("Folder Reconciler: Provoke Conditions", func() {
 				Spec:       tt.spec,
 			}
 
-			err := k8sClient.Create(testCtx, cr)
-			require.NoError(t, err)
+			r := &GrafanaFolderReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			r := GrafanaFolderReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			req := requestFromMeta(tt.meta)
-
-			_, err = r.Reconcile(testCtx, req)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.wantErr)
-			}
-
-			cr = &v1beta1.GrafanaFolder{}
-
-			err = r.Get(testCtx, req.NamespacedName, cr)
-			require.NoError(t, err)
-
-			containsEqualCondition(cr.Status.Conditions, tt.want)
+			reconcileAndValidateCondition(r, cr, tt.want, tt.wantErr)
 		})
 	}
 })

--- a/controllers/librarypanel_controller_test.go
+++ b/controllers/librarypanel_controller_test.go
@@ -2,103 +2,108 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("LibraryPanel Reconciler: Provoke Conditions", func() {
+	t := GinkgoT()
+
 	tests := []struct {
-		name          string
-		cr            *v1beta1.GrafanaLibraryPanel
-		wantCondition string
-		wantReason    string
-		wantErr       string
+		name    string
+		meta    metav1.ObjectMeta
+		spec    v1beta1.GrafanaLibraryPanelSpec
+		want    metav1.Condition
+		wantErr string
 	}{
 		{
 			name: ".spec.suspend=true",
-			cr: &v1beta1.GrafanaLibraryPanel{
-				ObjectMeta: objectMetaSuspended,
-				Spec: v1beta1.GrafanaLibraryPanelSpec{
-					GrafanaCommonSpec:  commonSpecSuspended,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
-				},
+			meta: objectMetaSuspended,
+			spec: v1beta1.GrafanaLibraryPanelSpec{
+				GrafanaCommonSpec:  commonSpecSuspended,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
 			},
-			wantCondition: conditionSuspended,
-			wantReason:    conditionReasonApplySuspended,
+			want: metav1.Condition{
+				Type:   conditionSuspended,
+				Reason: conditionReasonApplySuspended,
+			},
 		},
 		{
 			name: "GetScopedMatchingInstances returns empty list",
-			cr: &v1beta1.GrafanaLibraryPanel{
-				ObjectMeta: objectMetaNoMatchingInstances,
-				Spec: v1beta1.GrafanaLibraryPanelSpec{
-					GrafanaCommonSpec:  commonSpecNoMatchingInstances,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
-				},
+			meta: objectMetaNoMatchingInstances,
+			spec: v1beta1.GrafanaLibraryPanelSpec{
+				GrafanaCommonSpec:  commonSpecNoMatchingInstances,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
 			},
-			wantCondition: conditionNoMatchingInstance,
-			wantReason:    conditionReasonEmptyAPIReply,
-			wantErr:       ErrNoMatchingInstances.Error(),
+			want: metav1.Condition{
+				Type:   conditionNoMatchingInstance,
+				Reason: conditionReasonEmptyAPIReply,
+			},
+			wantErr: ErrNoMatchingInstances.Error(),
 		},
 		{
 			name: "Failed to apply to instance",
-			cr: &v1beta1.GrafanaLibraryPanel{
-				ObjectMeta: objectMetaApplyFailed,
-				Spec: v1beta1.GrafanaLibraryPanelSpec{
-					GrafanaCommonSpec:  commonSpecApplyFailed,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
-				},
+			meta: objectMetaApplyFailed,
+			spec: v1beta1.GrafanaLibraryPanelSpec{
+				GrafanaCommonSpec:  commonSpecApplyFailed,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
 			},
-			wantCondition: conditionLibraryPanelSynchronized,
-			wantReason:    conditionReasonApplyFailed,
-			wantErr:       "failed to apply to all instances",
+			want: metav1.Condition{
+				Type:   conditionLibraryPanelSynchronized,
+				Reason: conditionReasonApplyFailed,
+			},
+			wantErr: "failed to apply to all instances",
 		},
 		{
 			name: "Successfully applied resource to instance",
-			cr: &v1beta1.GrafanaLibraryPanel{
-				ObjectMeta: objectMetaSynchronized,
-				Spec: v1beta1.GrafanaLibraryPanelSpec{
-					GrafanaCommonSpec: commonSpecSynchronized,
-					GrafanaContentSpec: v1beta1.GrafanaContentSpec{
-						JSON: `{
+			meta: objectMetaSynchronized,
+			spec: v1beta1.GrafanaLibraryPanelSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{
+					JSON: `{
 							"uid": "do-adhv-ank",
 							"name": "API docs Example",
 							"type": "text",
 							"model": {},
 							"version": 1
 						}`,
-					},
 				},
 			},
-			wantCondition: conditionLibraryPanelSynchronized,
-			wantReason:    conditionReasonApplySuccessful,
+			want: metav1.Condition{
+				Type:   conditionLibraryPanelSynchronized,
+				Reason: conditionReasonApplySuccessful,
+			},
 		},
 	}
 
-	for _, test := range tests {
-		It(test.name, func() {
-			err := k8sClient.Create(testCtx, test.cr)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Reconciliation Request
-			req := requestFromMeta(test.cr.ObjectMeta)
-
-			// Reconcile
-			r := GrafanaLibraryPanelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			_, err = r.Reconcile(testCtx, req)
-			if test.wantErr == "" {
-				Expect(err).ShouldNot(HaveOccurred())
-			} else {
-				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(HavePrefix(test.wantErr))
+	for _, tt := range tests {
+		It(tt.name, func() {
+			cr := &v1beta1.GrafanaLibraryPanel{
+				ObjectMeta: tt.meta,
+				Spec:       tt.spec,
 			}
 
-			resultCr := &v1beta1.GrafanaLibraryPanel{}
-			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+			err := k8sClient.Create(testCtx, cr)
+			require.NoError(t, err)
 
-			// Verify Condition
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+			r := GrafanaLibraryPanelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			req := requestFromMeta(tt.meta)
+
+			_, err = r.Reconcile(testCtx, req)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+
+			cr = &v1beta1.GrafanaLibraryPanel{}
+
+			err = r.Get(testCtx, req.NamespacedName, cr)
+			require.NoError(t, err)
+
+			containsEqualCondition(cr.Status.Conditions, tt.want)
 		})
 	}
 })

--- a/controllers/librarypanel_controller_test.go
+++ b/controllers/librarypanel_controller_test.go
@@ -2,15 +2,12 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("LibraryPanel Reconciler: Provoke Conditions", func() {
-	t := GinkgoT()
-
 	tests := []struct {
 		name    string
 		meta    metav1.ObjectMeta
@@ -85,25 +82,9 @@ var _ = Describe("LibraryPanel Reconciler: Provoke Conditions", func() {
 				Spec:       tt.spec,
 			}
 
-			err := k8sClient.Create(testCtx, cr)
-			require.NoError(t, err)
+			r := &GrafanaLibraryPanelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			r := GrafanaLibraryPanelReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			req := requestFromMeta(tt.meta)
-
-			_, err = r.Reconcile(testCtx, req)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.wantErr)
-			}
-
-			cr = &v1beta1.GrafanaLibraryPanel{}
-
-			err = r.Get(testCtx, req.NamespacedName, cr)
-			require.NoError(t, err)
-
-			containsEqualCondition(cr.Status.Conditions, tt.want)
+			reconcileAndValidateCondition(r, cr, tt.want, tt.wantErr)
 		})
 	}
 })

--- a/controllers/mutetiming_controller_test.go
+++ b/controllers/mutetiming_controller_test.go
@@ -2,15 +2,12 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("MuteTiming Reconciler: Provoke Conditions", func() {
-	t := GinkgoT()
-
 	timeInterval := []*v1beta1.TimeInterval{
 		{
 			DaysOfMonth: []string{"1"},
@@ -92,25 +89,9 @@ var _ = Describe("MuteTiming Reconciler: Provoke Conditions", func() {
 				Spec:       tt.spec,
 			}
 
-			err := k8sClient.Create(testCtx, cr)
-			require.NoError(t, err)
+			r := &GrafanaMuteTimingReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			r := GrafanaMuteTimingReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			req := requestFromMeta(tt.meta)
-
-			_, err = r.Reconcile(testCtx, req)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.wantErr)
-			}
-
-			cr = &v1beta1.GrafanaMuteTiming{}
-
-			err = r.Get(testCtx, req.NamespacedName, cr)
-			require.NoError(t, err)
-
-			containsEqualCondition(cr.Status.Conditions, tt.want)
+			reconcileAndValidateCondition(r, cr, tt.want, tt.wantErr)
 		})
 	}
 })

--- a/controllers/notificationtemplate_controller_test.go
+++ b/controllers/notificationtemplate_controller_test.go
@@ -2,15 +2,12 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("NotificationTemplate Reconciler: Provoke Conditions", func() {
-	t := GinkgoT()
-
 	tests := []struct {
 		name    string
 		meta    metav1.ObjectMeta
@@ -78,26 +75,9 @@ var _ = Describe("NotificationTemplate Reconciler: Provoke Conditions", func() {
 				Spec:       tt.spec,
 			}
 
-			err := k8sClient.Create(testCtx, cr)
-			require.NoError(t, err)
+			r := &GrafanaNotificationTemplateReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			r := GrafanaNotificationTemplateReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-
-			req := requestFromMeta(tt.meta)
-
-			_, err = r.Reconcile(testCtx, req)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.wantErr)
-			}
-
-			cr = &v1beta1.GrafanaNotificationTemplate{}
-
-			err = r.Get(testCtx, req.NamespacedName, cr)
-			require.NoError(t, err)
-
-			containsEqualCondition(cr.Status.Conditions, tt.want)
+			reconcileAndValidateCondition(r, cr, tt.want, tt.wantErr)
 		})
 	}
 })

--- a/controllers/notificationtemplate_controller_test.go
+++ b/controllers/notificationtemplate_controller_test.go
@@ -2,96 +2,102 @@ package controllers
 
 import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("NotificationTemplate Reconciler: Provoke Conditions", func() {
+	t := GinkgoT()
+
 	tests := []struct {
-		name          string
-		cr            *v1beta1.GrafanaNotificationTemplate
-		wantCondition string
-		wantReason    string
-		wantErr       string
+		name    string
+		meta    metav1.ObjectMeta
+		spec    v1beta1.GrafanaNotificationTemplateSpec
+		want    metav1.Condition
+		wantErr string
 	}{
 		{
 			name: ".spec.suspend=true",
-			cr: &v1beta1.GrafanaNotificationTemplate{
-				ObjectMeta: objectMetaSuspended,
-				Spec: v1beta1.GrafanaNotificationTemplateSpec{
-					GrafanaCommonSpec: commonSpecSuspended,
-					Name:              "Suspended",
-				},
+			meta: objectMetaSuspended,
+			spec: v1beta1.GrafanaNotificationTemplateSpec{
+				GrafanaCommonSpec: commonSpecSuspended,
+				Name:              "Suspended",
 			},
-			wantCondition: conditionSuspended,
-			wantReason:    conditionReasonApplySuspended,
+			want: metav1.Condition{
+				Type:   conditionSuspended,
+				Reason: conditionReasonApplySuspended,
+			},
 		},
 		{
 			name: "GetScopedMatchingInstances returns empty list",
-			cr: &v1beta1.GrafanaNotificationTemplate{
-				ObjectMeta: objectMetaNoMatchingInstances,
-				Spec: v1beta1.GrafanaNotificationTemplateSpec{
-					GrafanaCommonSpec: commonSpecNoMatchingInstances,
-					Name:              "NoMatch",
-				},
+			meta: objectMetaNoMatchingInstances,
+			spec: v1beta1.GrafanaNotificationTemplateSpec{
+				GrafanaCommonSpec: commonSpecNoMatchingInstances,
+				Name:              "NoMatch",
 			},
-			wantCondition: conditionNoMatchingInstance,
-			wantReason:    conditionReasonEmptyAPIReply,
-			wantErr:       ErrNoMatchingInstances.Error(),
+			want: metav1.Condition{
+				Type:   conditionNoMatchingInstance,
+				Reason: conditionReasonEmptyAPIReply,
+			},
+			wantErr: ErrNoMatchingInstances.Error(),
 		},
 		{
 			name: "Failed to apply to instance",
-			cr: &v1beta1.GrafanaNotificationTemplate{
-				ObjectMeta: objectMetaApplyFailed,
-				Spec: v1beta1.GrafanaNotificationTemplateSpec{
-					GrafanaCommonSpec: commonSpecApplyFailed,
-					Name:              "ApplyFailed",
-				},
+			meta: objectMetaApplyFailed,
+			spec: v1beta1.GrafanaNotificationTemplateSpec{
+				GrafanaCommonSpec: commonSpecApplyFailed,
+				Name:              "ApplyFailed",
 			},
-			wantCondition: conditionNotificationTemplateSynchronized,
-			wantReason:    conditionReasonApplyFailed,
-			wantErr:       "failed to apply to all instances",
+			want: metav1.Condition{
+				Type:   conditionNotificationTemplateSynchronized,
+				Reason: conditionReasonApplyFailed,
+			},
+			wantErr: "failed to apply to all instances",
 		},
 		{
 			name: "Successfully applied resource to instance",
-			cr: &v1beta1.GrafanaNotificationTemplate{
-				ObjectMeta: objectMetaSynchronized,
-				Spec: v1beta1.GrafanaNotificationTemplateSpec{
-					GrafanaCommonSpec: commonSpecSynchronized,
-					Name:              "Synchronized",
-					Template:          `{{ define "StatusAlert" }}{{.Status}}{{ end }}`,
-				},
+			meta: objectMetaSynchronized,
+			spec: v1beta1.GrafanaNotificationTemplateSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
+				Name:              "Synchronized",
+				Template:          `{{ define "StatusAlert" }}{{.Status}}{{ end }}`,
 			},
-			wantCondition: conditionNotificationTemplateSynchronized,
-			wantReason:    conditionReasonApplySuccessful,
+			want: metav1.Condition{
+				Type:   conditionNotificationTemplateSynchronized,
+				Reason: conditionReasonApplySuccessful,
+			},
 		},
 	}
 
-	for _, test := range tests {
-		It(test.name, func() {
-			err := k8sClient.Create(testCtx, test.cr)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Reconciliation Request
-			req := requestFromMeta(test.cr.ObjectMeta)
-
-			// Reconcile
-			r := GrafanaNotificationTemplateReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			_, err = r.Reconcile(testCtx, req)
-			if test.wantErr == "" {
-				Expect(err).ShouldNot(HaveOccurred())
-			} else {
-				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(HavePrefix(test.wantErr))
+	for _, tt := range tests {
+		It(tt.name, func() {
+			cr := &v1beta1.GrafanaNotificationTemplate{
+				ObjectMeta: tt.meta,
+				Spec:       tt.spec,
 			}
 
-			resultCr := &v1beta1.GrafanaNotificationTemplate{}
-			Expect(r.Get(testCtx, req.NamespacedName, resultCr)).Should(Succeed())
+			err := k8sClient.Create(testCtx, cr)
+			require.NoError(t, err)
 
-			// Verify Condition
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Type", test.wantCondition)))
-			Expect(resultCr.Status.Conditions).Should(ContainElement(HaveField("Reason", test.wantReason)))
+			r := GrafanaNotificationTemplateReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+			req := requestFromMeta(tt.meta)
+
+			_, err = r.Reconcile(testCtx, req)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+
+			cr = &v1beta1.GrafanaNotificationTemplate{}
+
+			err = r.Get(testCtx, req.NamespacedName, cr)
+			require.NoError(t, err)
+
+			containsEqualCondition(cr.Status.Conditions, tt.want)
 		})
 	}
 })

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers/config"
+	"github.com/stretchr/testify/assert"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -217,4 +219,15 @@ func createSharedTestCRs() {
 	fr := GrafanaFolderReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 	_, err = fr.Reconcile(testCtx, req)
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func containsEqualCondition(conditions []metav1.Condition, target metav1.Condition) {
+	GinkgoHelper()
+	t := GinkgoT()
+
+	found := slices.ContainsFunc(conditions, func(c metav1.Condition) bool {
+		return c.Type == target.Type && c.Reason == target.Reason
+	})
+
+	assert.True(t, found)
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -224,6 +224,7 @@ func createSharedTestCRs() {
 
 func containsEqualCondition(conditions []metav1.Condition, target metav1.Condition) {
 	GinkgoHelper()
+
 	t := GinkgoT()
 
 	found := slices.ContainsFunc(conditions, func(c metav1.Condition) bool {
@@ -235,6 +236,7 @@ func containsEqualCondition(conditions []metav1.Condition, target metav1.Conditi
 
 func reconcileAndValidateCondition(r GrafanaCommonReconciler, cr v1beta1.CommonResource, condition metav1.Condition, wantErr string) {
 	GinkgoHelper()
+
 	t := GinkgoT()
 
 	err := k8sClient.Create(testCtx, cr)


### PR DESCRIPTION
- tests:
  - added two helpers:
    - `containsEqualCondition` - returns true if a CR has a condition of the same `Type` and `Reason`;
    - `reconcileAndValidateCondition` - helps to simplify tests for conditions (creates a resource, does a reconcile, requests the result and validates whether a condition and error text match):
      - for that to work, had to add `GrafanaCommonReconciler` interface and to expand `CommonResource` interface to expose `metav1.ObjectMeta`;
  - simplified condition tests by:
    - switching to the new helpers;
    - switching from ginkgo over-expressive asserts to testify;
    - slightly adjusting structs with tests.
