### PR TITLE
chore: override default ctx in Grafana httpclient

### DIFF
--- a/controllers/client/grafana_client.go
+++ b/controllers/client/grafana_client.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"time"
 
+	httptransport "github.com/go-openapi/runtime/client"
 	genapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers/config"
@@ -225,6 +226,13 @@ func NewGeneratedGrafanaClient(ctx context.Context, c client.Client, grafana *v1
 	}
 
 	cl := genapi.NewHTTPClientWithConfig(nil, cfg)
+
+	runtime, ok := cl.Transport.(*httptransport.Runtime)
+	if !ok {
+		return nil, fmt.Errorf("casting client transport into *httptransport.Runtime to overwrite the default context")
+	}
+
+	runtime.Context = ctx
 
 	return cl, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/docker/go-connections v0.6.0
 	github.com/go-logr/logr v1.4.3
+	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/go-jsonnet v0.21.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250617151817-c0f8cbb88d5c
@@ -47,7 +48,6 @@ require (
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.1 // indirect
 	github.com/go-openapi/loads v0.22.0 // indirect
-	github.com/go-openapi/runtime v0.28.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect


### PR DESCRIPTION
This solves the "issue" of the Grafana HTTP Client using the default internal [`context.Background()`](https://github.com/go-openapi/runtime/blob/master/client/runtime.go#L270) by propagating the top-level ctx into the client overwriting the default.

In general, we have relied on the default request timeout of 10 seconds, but an alternative approach exists where a context can be attached to a Params struct which can then be used to cancel requests.
But, unless necessary, we do not create a Params struct and use the special variant functions accepting the parameters.

Idiomatic Go would mean passing a context in as a function argument, but the HTTP client does not support that.
This avoids having to update almost all the usages of the HTTP Client across the controllers.