### PR TITLE
feat(plugins): add support for latest version, fix version preference for duplicate plugins

### DIFF
--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -27,6 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	PluginVersionLatest string = "latest"
+)
+
 type OperatorStageName string
 
 type OperatorStageStatus string

--- a/api/v1beta1/plugin_list.go
+++ b/api/v1beta1/plugin_list.go
@@ -1,9 +1,7 @@
 package v1beta1
 
 import (
-	"crypto/sha256"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
@@ -18,18 +16,6 @@ type GrafanaPlugin struct {
 type PluginList []GrafanaPlugin
 
 type PluginMap map[string]PluginList
-
-func (l PluginList) Hash() string {
-	sb := strings.Builder{}
-	for _, plugin := range l {
-		sb.WriteString(plugin.Name)
-		sb.WriteString(plugin.Version)
-	}
-
-	hash := sha256.New()
-	io.WriteString(hash, sb.String()) //nolint
-	return fmt.Sprintf("%x", hash.Sum(nil))
-}
 
 func (l PluginList) String() string {
 	plugins := make(sort.StringSlice, 0, len(l))

--- a/api/v1beta1/plugin_list.go
+++ b/api/v1beta1/plugin_list.go
@@ -81,17 +81,6 @@ func (l PluginList) HasSomeVersionOf(plugin *GrafanaPlugin) bool {
 	return false
 }
 
-// GetInstalledVersionOf gets the plugin from the list regardless of the version
-func (l PluginList) GetInstalledVersionOf(plugin *GrafanaPlugin) *GrafanaPlugin {
-	for _, listedPlugin := range l {
-		if listedPlugin.Name == plugin.Name {
-			return &listedPlugin
-		}
-	}
-
-	return nil
-}
-
 // HasExactVersionOf returns true if the list contains the same plugin in the same version
 func (l PluginList) HasExactVersionOf(plugin *GrafanaPlugin) bool {
 	for _, listedPlugin := range l {
@@ -126,17 +115,4 @@ func (l PluginList) HasNewerVersionOf(plugin *GrafanaPlugin) (bool, error) {
 	}
 
 	return false, nil
-}
-
-// VersionsOf returns the number of different versions of a given plugin in the list
-func (l PluginList) VersionsOf(plugin *GrafanaPlugin) int {
-	i := 0
-
-	for _, listedPlugin := range l {
-		if listedPlugin.Name == plugin.Name {
-			i++
-		}
-	}
-
-	return i
 }

--- a/api/v1beta1/plugin_list.go
+++ b/api/v1beta1/plugin_list.go
@@ -13,6 +13,20 @@ type GrafanaPlugin struct {
 	Version string `json:"version"`
 }
 
+func (p GrafanaPlugin) HasValidVersion() bool {
+	if p.Version == PluginVersionLatest {
+		return true
+	}
+
+	_, err := semver.Parse(p.Version)
+
+	return err == nil
+}
+
+func (p GrafanaPlugin) HasInvalidVersion() bool {
+	return !p.HasValidVersion()
+}
+
 func (p GrafanaPlugin) String() string {
 	if p.Version == PluginVersionLatest {
 		return p.Name
@@ -52,8 +66,7 @@ func (l PluginList) Sanitize() PluginList {
 	var sanitized PluginList
 
 	for _, plugin := range l {
-		_, err := semver.Parse(plugin.Version)
-		if err != nil && plugin.Version != PluginVersionLatest {
+		if plugin.HasInvalidVersion() {
 			continue
 		}
 

--- a/api/v1beta1/plugin_list.go
+++ b/api/v1beta1/plugin_list.go
@@ -36,9 +36,9 @@ func (l PluginList) String() string {
 
 // Update update plugin version
 func (l PluginList) Update(plugin *GrafanaPlugin) {
-	for _, installedPlugin := range l {
+	for i, installedPlugin := range l {
 		if installedPlugin.Name == plugin.Name {
-			installedPlugin.Version = plugin.Version
+			l[i].Version = plugin.Version
 			break
 		}
 	}

--- a/api/v1beta1/plugin_list.go
+++ b/api/v1beta1/plugin_list.go
@@ -13,20 +13,23 @@ type GrafanaPlugin struct {
 	Version string `json:"version"`
 }
 
+func (p GrafanaPlugin) String() string {
+	if p.Version == PluginVersionLatest {
+		return p.Name
+	}
+
+	return fmt.Sprintf("%s %s", p.Name, p.Version)
+}
+
 type PluginList []GrafanaPlugin
 
 type PluginMap map[string]PluginList
 
 func (l PluginList) String() string {
 	plugins := make(sort.StringSlice, 0, len(l))
+
 	for _, plugin := range l {
-		s := fmt.Sprintf("%s %s", plugin.Name, plugin.Version)
-
-		if plugin.Version == PluginVersionLatest {
-			s = plugin.Name
-		}
-
-		plugins = append(plugins, s)
+		plugins = append(plugins, plugin.String())
 	}
 
 	sort.Sort(plugins)

--- a/api/v1beta1/plugin_list.go
+++ b/api/v1beta1/plugin_list.go
@@ -34,7 +34,13 @@ func (l PluginList) Hash() string {
 func (l PluginList) String() string {
 	plugins := make(sort.StringSlice, 0, len(l))
 	for _, plugin := range l {
-		plugins = append(plugins, fmt.Sprintf("%s %s", plugin.Name, plugin.Version))
+		s := fmt.Sprintf("%s %s", plugin.Name, plugin.Version)
+
+		if plugin.Version == PluginVersionLatest {
+			s = plugin.Name
+		}
+
+		plugins = append(plugins, s)
 	}
 
 	sort.Sort(plugins)
@@ -58,7 +64,7 @@ func (l PluginList) Sanitize() PluginList {
 
 	for _, plugin := range l {
 		_, err := semver.Parse(plugin.Version)
-		if err != nil {
+		if err != nil && plugin.Version != PluginVersionLatest {
 			continue
 		}
 
@@ -97,6 +103,14 @@ func (l PluginList) HasNewerVersionOf(plugin *GrafanaPlugin) (bool, error) {
 	for _, listedPlugin := range l {
 		if listedPlugin.Name != plugin.Name {
 			continue
+		}
+
+		if listedPlugin.Version == PluginVersionLatest && plugin.Version != PluginVersionLatest {
+			return true, nil
+		}
+
+		if plugin.Version == PluginVersionLatest {
+			return false, nil
 		}
 
 		listedVersion, err := semver.Parse(listedPlugin.Version)

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -9,6 +9,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGrafanaPluginHasValidVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		plugin GrafanaPlugin
+		want   bool
+	}{
+		{
+			name: "latest version",
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "latest",
+			},
+			want: true,
+		},
+		{
+			name: "valid semver version",
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "1.0.0",
+			},
+			want: true,
+		},
+		{
+			name: "semver version with v prefix", // Not supported yet
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "v1.0.0",
+			},
+			want: false,
+		},
+		{
+			name: "invalid version",
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "a.b.c",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.plugin.HasValidVersion()
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGrafanaPluginString(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -6,6 +6,7 @@ import (
 	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPluginListString(t *testing.T) {
@@ -123,6 +124,66 @@ func TestPluginListSomeVersionOf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.plugins.HasSomeVersionOf(&tt.plugin)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPluginListHasExactVersionOf(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugins PluginList
+		plugin  GrafanaPlugin
+		want    bool
+	}{
+		{
+			name: "has same version",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "1.0.0",
+			},
+			want: true,
+		},
+		{
+			name: "has different version",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "2.0.0",
+			},
+			want: false,
+		},
+		{
+			name: "different plugin has same version",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "b",
+				Version: "2.0.0",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.plugins.HasExactVersionOf(&tt.plugin)
 
 			assert.Equal(t, tt.want, got)
 		})

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -70,22 +70,47 @@ func TestPluginListString(t *testing.T) {
 }
 
 func TestPluginListSanitize(t *testing.T) {
-	pl := PluginList{
+	tests := []struct {
+		name    string
+		plugins PluginList
+		want    PluginList
+	}{
 		{
-			Name:    "plugin-a",
-			Version: "1.0.0",
-		},
-		{
-			Name:    "plugin-b",
-			Version: "2.0.0",
-		},
-		{
-			Name:    "plugin-a",
-			Version: "3.0.0",
+			name: "duplicates removal",
+			plugins: PluginList{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+				{
+					Name:    "b",
+					Version: "2.0.0",
+				},
+				{
+					Name:    "a",
+					Version: "3.0.0",
+				},
+			},
+			want: PluginList{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+				{
+					Name:    "b",
+					Version: "2.0.0",
+				},
+			},
 		},
 	}
-	sanitized := pl.Sanitize()
-	assert.Len(t, sanitized, 2)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.plugins.Sanitize()
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestPluginListSomeVersionOf(t *testing.T) {

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -49,6 +49,24 @@ func TestPluginListString(t *testing.T) {
 	if err != nil {
 		t.Errorf("plugin list was not sorted: %s", err.Error())
 	}
+
+	t.Run("Correct string", func(t *testing.T) {
+		pl := PluginList{
+			{
+				Name:    "a",
+				Version: "1.0.0",
+			},
+			{
+				Name:    "c",
+				Version: "2.0.0",
+			},
+		}
+
+		got := pl.String()
+		want := "a 1.0.0,c 2.0.0"
+
+		assert.Equal(t, want, got)
+	})
 }
 
 func TestPluginListSanitize(t *testing.T) {

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -73,6 +73,64 @@ func TestPluginListString(t *testing.T) {
 	})
 }
 
+func TestPluginListUpdate(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugins PluginList
+		plugin  GrafanaPlugin
+		want    PluginList
+	}{
+		{
+			name: "version is updated",
+			plugins: PluginList{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "2.0.0",
+			},
+			want: PluginList{
+				{
+					Name:    "a",
+					Version: "2.0.0",
+				},
+			},
+		},
+		{
+			name: "no match",
+			plugins: PluginList{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "b",
+				Version: "2.0.0",
+			},
+			want: PluginList{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.plugins.Update(&tt.plugin)
+
+			got := tt.plugins
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestPluginListSanitize(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -9,6 +9,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGrafanaPluginString(t *testing.T) {
+	tests := []struct {
+		name   string
+		plugin GrafanaPlugin
+		want   string
+	}{
+		{
+			name: "latest version",
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "latest",
+			},
+			want: "a",
+		},
+		{
+			name: "semver",
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "1.0.0",
+			},
+			want: "a 1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.plugin.String()
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestPluginListString(t *testing.T) {
 	err := quick.Check(func(a string, b string, c string) bool {
 		if strings.Contains(a, ",") || strings.Contains(b, ",") || strings.Contains(c, ",") {

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -57,13 +57,17 @@ func TestPluginListString(t *testing.T) {
 				Version: "1.0.0",
 			},
 			{
+				Name:    "b",
+				Version: "latest",
+			},
+			{
 				Name:    "c",
 				Version: "2.0.0",
 			},
 		}
 
 		got := pl.String()
-		want := "a 1.0.0,c 2.0.0"
+		want := "a 1.0.0,b,c 2.0.0"
 
 		assert.Equal(t, want, got)
 	})
@@ -113,11 +117,19 @@ func TestPluginListSanitize(t *testing.T) {
 					Name:    "b",
 					Version: "2.0.0",
 				},
+				{
+					Name:    "c",
+					Version: "latest",
+				},
 			},
 			want: PluginList{
 				{
 					Name:    "b",
 					Version: "2.0.0",
+				},
+				{
+					Name:    "c",
+					Version: "latest",
 				},
 			},
 		},
@@ -274,6 +286,20 @@ func TestPluginListHasNewerVersionOf(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "has newer version (latest)",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "latest",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "1.0.0",
+			},
+			want: true,
+		},
+		{
 			name: "has older version",
 			plugins: []GrafanaPlugin{
 				{
@@ -284,6 +310,20 @@ func TestPluginListHasNewerVersionOf(t *testing.T) {
 			plugin: GrafanaPlugin{
 				Name:    "a",
 				Version: "1.1.0",
+			},
+			want: false,
+		},
+		{
+			name: "has older version (latest)",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "latest",
 			},
 			want: false,
 		},

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -68,3 +68,63 @@ func TestPluginListSanitize(t *testing.T) {
 	sanitized := pl.Sanitize()
 	assert.Len(t, sanitized, 2)
 }
+
+func TestPluginListSomeVersionOf(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugins PluginList
+		plugin  GrafanaPlugin
+		want    bool
+	}{
+		{
+			name: "has same version",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "1.0.0",
+			},
+			want: true,
+		},
+		{
+			name: "has different version",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "2.0.0",
+			},
+			want: true,
+		},
+		{
+			name: "doesn't have any versions of the same plugin",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "b",
+				Version: "1.0.0",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.plugins.HasSomeVersionOf(&tt.plugin)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -189,3 +189,106 @@ func TestPluginListHasExactVersionOf(t *testing.T) {
 		})
 	}
 }
+
+func TestPluginListHasNewerVersionOf(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugins PluginList
+		plugin  GrafanaPlugin
+		want    bool
+	}{
+		{
+			name: "has newer version",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.1.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "1.0.0",
+			},
+			want: true,
+		},
+		{
+			name: "has older version",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "1.1.0",
+			},
+			want: false,
+		},
+		{
+			name: "doesn't have any versions",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "b",
+				Version: "1.0.0",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.plugins.HasNewerVersionOf(&tt.plugin)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	// Error cases
+	tests2 := []struct {
+		name    string
+		plugins PluginList
+		plugin  GrafanaPlugin
+	}{
+		{
+			name: "broken version in plugin list",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "a.b.c",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "2.0.0",
+			},
+		},
+		{
+			name: "broken version of target plugin",
+			plugins: []GrafanaPlugin{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+			},
+			plugin: GrafanaPlugin{
+				Name:    "a",
+				Version: "a.b.c",
+			},
+		},
+	}
+
+	for _, tt := range tests2 {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.plugins.HasNewerVersionOf(&tt.plugin)
+			require.Error(t, err)
+			assert.False(t, got)
+		})
+	}
+}

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -102,6 +102,25 @@ func TestPluginListSanitize(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "skip incorrect versions",
+			plugins: PluginList{
+				{
+					Name:    "a",
+					Version: "a.b.c",
+				},
+				{
+					Name:    "b",
+					Version: "2.0.0",
+				},
+			},
+			want: PluginList{
+				{
+					Name:    "b",
+					Version: "2.0.0",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/api/v1beta1/plugin_list_test.go
+++ b/api/v1beta1/plugin_list_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPluginString(t *testing.T) {
+func TestPluginListString(t *testing.T) {
 	err := quick.Check(func(a string, b string, c string) bool {
 		if strings.Contains(a, ",") || strings.Contains(b, ",") || strings.Contains(c, ",") {
 			return true // skip plugins with ,
@@ -50,7 +50,7 @@ func TestPluginString(t *testing.T) {
 	}
 }
 
-func TestPluginSanitize(t *testing.T) {
+func TestPluginListSanitize(t *testing.T) {
 	pl := PluginList{
 		{
 			Name:    "plugin-a",

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -167,25 +167,8 @@ func getContainers(cr *v1beta1.Grafana, scheme *runtime.Scheme, vars *v1beta1.Op
 	var containers []corev1.Container
 
 	image := getGrafanaImage(cr)
-	plugins := model.GetPluginsConfigMap(cr, scheme)
-
-	// env var to restart containers if plugins change
-	t := true
 
 	var envVars []corev1.EnvVar
-
-	envVars = append(envVars, corev1.EnvVar{
-		Name: "PLUGINS_HASH",
-		ValueFrom: &corev1.EnvVarSource{
-			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: plugins.Name,
-				},
-				Key:      "PLUGINS_HASH",
-				Optional: &t,
-			},
-		},
-	})
 
 	// env var to restart container if config changes
 	envVars = append(envVars, corev1.EnvVar{

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -7,3 +7,5 @@ Due to the operator don't own and thus we can't set the environment variable tha
 
 {{< readfile file="dashboard.yaml" code="true" lang="yaml" >}}
 {{< readfile file="datasource.yaml" code="true" lang="yaml" >}}
+
+**NOTE**: A plugin doesn't have to be pinned to a specific version. If it's set to `latest` instead, Grafana will install the latest available version upon start. Please, keep in mind that the grafana-operator doesn't track new plugin releases, so it's up to an administrator to make sure Grafana pods are occasionally recreated (in most setups, it happens naturally due to dynamic nature of Kubernetes workloads).

--- a/examples/plugins/dashboard.yaml
+++ b/examples/plugins/dashboard.yaml
@@ -8,7 +8,7 @@ spec:
       dashboards: grafana
   plugins:
     - name: grafana-piechart-panel
-      version: 1.3.9
+      version: 1.3.9 # It can also be set to "latest"
   json: >
     {
       "__inputs": [

--- a/examples/plugins/datasource.yaml
+++ b/examples/plugins/datasource.yaml
@@ -16,4 +16,4 @@ spec:
       dashboards: grafana
   plugins:
     - name: grafana-clock-panel
-      version: 1.3.0
+      version: 1.3.0 # It can also be set to "latest"


### PR DESCRIPTION
- plugins:
  - features:
    - added support for "latest" version;
    - added `String()` method to `GrafanaPlugin` to simplify `PluginList` `String()` method;
  - fixes:
    - `Update` method (used in plugins reconciler to pick the newest plugin version) had no effect, because the update was done on a copy of `GrafanaPlugin`, not on a slice element. Fixed the behaviour and added a test for that;
  - tests:
    - added tests for `HasExactVersionOf`, `HasNewerVersionOf`, `SomeVersionOf`;
    - extended `Sanitize` tests to cover incorrect versions;
  - deprecations:
    - unused `PLUGINS_HASH` env (it became obsolete about ~3 years ago when we moved away from a custom plugin installer to `GF_INSTALL_PLUGINS`);
    - unused `GetInstalledVersionOf`, `Hash`, `VersionsOf` methods.

**NOTE:** I felt like it'd be better to cover the package functions with tests first (to document and test the current behavior) and only then implement the changes required for "latest", thus the size of the PR.

**NOTE:** I've found some more issues in the plugin logic, will fix them in a separate PR.

Fixes: #2153