### PR TITLE
chore(e2e): bump kind to the latest supported k8s releases

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,10 +47,10 @@ jobs:
     strategy:
       matrix:
         version:
-          - v1.30.10
-          - v1.31.6
-          - v1.32.2
-          - v1.33.0
+          - v1.31.9
+          - v1.32.8
+          - v1.33.4
+          - v1.34.0
     steps:
       - name: Pre-pull kind image
         run: |

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ REGISTRY ?= ghcr.io
 ORG ?= grafana
 IMG ?= $(REGISTRY)/$(ORG)/grafana-operator:v$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.33.0
+ENVTEST_K8S_VERSION = 1.34.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/hack/kind/start-kind.sh
+++ b/hack/kind/start-kind.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 KIND=${KIND:-kind}
-KIND_NODE_VERSION=${KIND_NODE_VERSION:-v1.33.0}
+KIND_NODE_VERSION=${KIND_NODE_VERSION:-v1.34.0}
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kind-grafana}
 KUBECONFIG=${KUBECONFIG:-~/.kube/kind-grafana-operator}
 set -eu


### PR DESCRIPTION
- e2e:
  - bumped kind to the latest supported k8s releases;
  - bumped `envtest` to `1.34.0`.