### PR TITLE
Add Uid to the error log when reconciling dashboards #2143

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -174,20 +174,20 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			err = ReconcilePlugins(ctx, r.Client, r.Scheme, &grafana, cr.Spec.Plugins, fmt.Sprintf("%v-dashboard", cr.Name))
 			if err != nil {
 				pluginErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
-				log.Error(err, "error reconciling plugins", "dashboard", cr.Name, "grafana", grafana.Name)
-			}
+				log.Error(err, "error reconciling plugins", "dashboard", cr.Name, "grafana", grafana.Name, "uid", uid)
+			  }
 		}
 
 		// then import the dashboard into the matching grafana instances
 		err = r.onDashboardCreated(ctx, &grafana, cr, dashboardModel, hash, folderUID)
 		if err != nil {
-			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
+		  applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Error())
 		}
 
 		if grafana.Spec.Preferences != nil && uid == grafana.Spec.Preferences.HomeDashboardUID {
 			err = r.UpdateHomeDashboard(ctx, grafana, uid, cr)
 			if err != nil {
-				applyHomeErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
+			  applyHomeErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Error())
 			}
 		}
 	}
@@ -208,7 +208,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	meta.SetStatusCondition(&cr.Status.Conditions, condition)
 
 	if len(allApplyErrors) > 0 {
-		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", allApplyErrors)
+		return ctrl.Result{}, fmt.Errorf("uid=%s: failed to apply to all instances: %v", uid, allApplyErrors)
 	}
 
 	cr.Status.Hash = hash

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -175,19 +175,19 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			if err != nil {
 				pluginErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 				log.Error(err, "error reconciling plugins", "dashboard", cr.Name, "grafana", grafana.Name, "uid", uid)
-			  }
+			}
 		}
 
 		// then import the dashboard into the matching grafana instances
 		err = r.onDashboardCreated(ctx, &grafana, cr, dashboardModel, hash, folderUID)
 		if err != nil {
-		  applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Error())
+			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Error())
 		}
 
 		if grafana.Spec.Preferences != nil && uid == grafana.Spec.Preferences.HomeDashboardUID {
 			err = r.UpdateHomeDashboard(ctx, grafana, uid, cr)
 			if err != nil {
-			  applyHomeErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Error())
+				applyHomeErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Error())
 			}
 		}
 	}

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -117,6 +117,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	log.Info("found matching Grafana instances for datasource", "count", len(instances))
 
+	uid := cr.CustomUIDOrUID()
 	if cr.IsUpdatedUID() {
 		log.Info("datasource uid got updated, deleting datasources with the old uid")
 
@@ -152,13 +153,14 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			err = ReconcilePlugins(ctx, r.Client, r.Scheme, &grafana, cr.Spec.Plugins, fmt.Sprintf("%v-datasource", cr.Name))
 			if err != nil {
 				pluginErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
+				log.Error(err, "error reconciling plugins", "datasource", cr.Name, "grafana", grafana.Name, "uid", uid)
 			}
 		}
 
 		// then import the datasource into the matching grafana instances
 		err = r.onDatasourceCreated(ctx, &grafana, cr, datasource, hash)
 		if err != nil {
-			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
+			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Errror())
 		}
 	}
 
@@ -173,7 +175,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	meta.SetStatusCondition(&cr.Status.Conditions, condition)
 
 	if len(allApplyErrors) > 0 {
-		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", allApplyErrors)
+		return ctrl.Result{}, fmt.Errorf("uid=%s: failed to apply to all instances: %v", uid, allApplyErrors)
 	}
 
 	cr.Status.Hash = hash

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -160,7 +160,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// then import the datasource into the matching grafana instances
 		err = r.onDatasourceCreated(ctx, &grafana, cr, datasource, hash)
 		if err != nil {
-			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Errror())
+			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = fmt.Sprintf("uid=%s: %s", uid, err.Error())
 		}
 	}
 


### PR DESCRIPTION
This is the issue that I worked for reviewers reference:https://github.com/grafana/grafana-operator/issues/2143

This PR adds the Grafana resource UID to reconciliation error logs to improve troubleshooting in environments with multiple dashboards/datasources.

Changes Made: 

Path: controllers/dashboard_controller.go:
- Added uid to plugin error logs.
- Prefixed applyErrors and applyHomeErrors with uid.
- Included uid in the final aggregated “failed to apply to all instances” error.

Path: controllers/datasource_controller.go:
- Compute uid via cr.CustomUIDOrUID().
- Added uid to plugin error logs.
- Prefixed applyErrors with uid.
- Included uid in the final aggregated “failed to apply to all instances” error.

Testing: make all (lint/build/tests) passed locally.


Thank you. Do let me know if I need to change else where or if I need to make any other improvements.
