### PR TITLE
feat: added watchers for cm, secrets in datasource_controller

### DIFF
--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -372,6 +372,7 @@ func (r *GrafanaDatasourceReconciler) indexSecretSource() func(o client.Object) 
 		}
 
 		var secretRefs []string
+
 		for _, valueFrom := range datasource.Spec.ValuesFrom {
 			if valueFrom.ValueFrom.SecretKeyRef != nil {
 				secretRefs = append(secretRefs, fmt.Sprintf("%s/%s", datasource.Namespace, valueFrom.ValueFrom.SecretKeyRef.Name))
@@ -390,6 +391,7 @@ func (r *GrafanaDatasourceReconciler) indexConfigMapSource() func(o client.Objec
 		}
 
 		var configMapRefs []string
+
 		for _, valueFrom := range datasource.Spec.ValuesFrom {
 			if valueFrom.ValueFrom.ConfigMapKeyRef != nil {
 				configMapRefs = append(configMapRefs, fmt.Sprintf("%s/%s", datasource.Namespace, valueFrom.ValueFrom.ConfigMapKeyRef.Name))

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -30,13 +30,18 @@ import (
 
 	genapi "github.com/grafana/grafana-openapi-client-go/client"
 	client2 "github.com/grafana/grafana-operator/v5/controllers/client"
+	corev1 "k8s.io/api/core/v1"
 	kuberr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1beta1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 )
@@ -326,11 +331,95 @@ func (r *GrafanaDatasourceReconciler) Exists(client *genapi.GrafanaHTTPAPI, uid,
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *GrafanaDatasourceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	const (
+		secretIndexKey    string = ".metadata.secret"
+		configMapIndexKey string = ".metadata.configMap"
+	)
+
+	// Index the datasources by the Secret references they (may) point at.
+	if err := mgr.GetCache().IndexField(ctx, &v1beta1.GrafanaDatasource{}, secretIndexKey,
+		r.indexSecretSource()); err != nil {
+		return fmt.Errorf("failed setting secret index fields: %w", err)
+	}
+
+	// Index the datasources by the ConfigMap references they (may) point at.
+	if err := mgr.GetCache().IndexField(ctx, &v1beta1.GrafanaDatasource{}, configMapIndexKey,
+		r.indexConfigMapSource()); err != nil {
+		return fmt.Errorf("failed setting configmap index fields: %w", err)
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1beta1.GrafanaDatasource{}).
-		WithEventFilter(ignoreStatusUpdates()).
+		For(&v1beta1.GrafanaDatasource{}, builder.WithPredicates(
+			ignoreStatusUpdates(),
+		)).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForChangeByField(secretIndexKey)),
+		).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForChangeByField(configMapIndexKey)),
+		).
 		Complete(r)
+}
+
+func (r *GrafanaDatasourceReconciler) indexSecretSource() func(o client.Object) []string {
+	return func(o client.Object) []string {
+		datasource, ok := o.(*v1beta1.GrafanaDatasource)
+		if !ok {
+			panic(fmt.Sprintf("Expected a GrafanaDatasource, got %T", o))
+		}
+
+		var secretRefs []string
+		for _, valueFrom := range datasource.Spec.ValuesFrom {
+			if valueFrom.ValueFrom.SecretKeyRef != nil {
+				secretRefs = append(secretRefs, fmt.Sprintf("%s/%s", datasource.Namespace, valueFrom.ValueFrom.SecretKeyRef.Name))
+			}
+		}
+
+		return secretRefs
+	}
+}
+
+func (r *GrafanaDatasourceReconciler) indexConfigMapSource() func(o client.Object) []string {
+	return func(o client.Object) []string {
+		datasource, ok := o.(*v1beta1.GrafanaDatasource)
+		if !ok {
+			panic(fmt.Sprintf("Expected a GrafanaDatasource, got %T", o))
+		}
+
+		var configMapRefs []string
+		for _, valueFrom := range datasource.Spec.ValuesFrom {
+			if valueFrom.ValueFrom.ConfigMapKeyRef != nil {
+				configMapRefs = append(configMapRefs, fmt.Sprintf("%s/%s", datasource.Namespace, valueFrom.ValueFrom.ConfigMapKeyRef.Name))
+			}
+		}
+
+		return configMapRefs
+	}
+}
+
+func (r *GrafanaDatasourceReconciler) requestsForChangeByField(indexKey string) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		var list v1beta1.GrafanaDatasourceList
+		if err := r.List(ctx, &list, client.MatchingFields{
+			indexKey: fmt.Sprintf("%s/%s", o.GetNamespace(), o.GetName()),
+		}); err != nil {
+			logf.FromContext(ctx).Error(err, "failed to list datasources for watch mapping")
+			return nil
+		}
+
+		var reqs []reconcile.Request
+		for _, datasource := range list.Items {
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: datasource.Namespace,
+				Name:      datasource.Name,
+			}})
+		}
+
+		return reqs
+	}
 }
 
 func (r *GrafanaDatasourceReconciler) buildDatasourceModel(ctx context.Context, cr *v1beta1.GrafanaDatasource) (*models.UpdateDataSourceCommand, string, error) {

--- a/main.go
+++ b/main.go
@@ -289,7 +289,7 @@ func main() { // nolint:gocyclo
 	if err = (&controllers.GrafanaDatasourceReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrafanaDatasource")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Description

When a GrafanaDatasource CR references secrets or configmaps through the `valuesFrom` field, the operator will now automatically reconcile the datasource whenever those referenced resources change.

## Related Issue

Fixes [#2142](https://github.com/grafana/grafana-operator/issues/2142)

## What Changed

- Followed the same approach mentioned here - https://github.com/grafana/grafana-operator/issues/2142#issuecomment-3219444576
- Added unit tests for the indexing functionality

Note:
Should we add to add reconciler logic here too or in a separate PR? it says todo
https://github.com/grafana/grafana-operator/blob/37a6cfd761e358b3caef2706506fc3416e47acd6/controllers/serviceaccount_controller.go#L829

lemme know
