### PR TITLE
fix(plugins): remove ConfigMap key if no plugins left

### DIFF
--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -373,6 +373,36 @@ func TestUpdatePluginConfigMap(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "removed plugin (nil)",
+			cm: &corev1.ConfigMap{
+				BinaryData: map[string][]byte{
+					"a": []byte("1"),
+				},
+			},
+			value:         nil,
+			key:           "a",
+			deprecatedKey: "b",
+			want:          true,
+			wantCM: &corev1.ConfigMap{
+				BinaryData: map[string][]byte{},
+			},
+		},
+		{
+			name: "removed plugin (empty slice)",
+			cm: &corev1.ConfigMap{
+				BinaryData: map[string][]byte{
+					"a": []byte("1"),
+				},
+			},
+			value:         []byte{},
+			key:           "a",
+			deprecatedKey: "b",
+			want:          true,
+			wantCM: &corev1.ConfigMap{
+				BinaryData: map[string][]byte{},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes a defect that was introduced during the recent plugin data types refactoring. - Instead of removing a ConfigMap key when no plugins are left or when a CR is removed, the operator updates the key with null-value.

To mitigate the behaviour, added a length check, so now the keys will get properly garbage collected.

**NOTE:** no releases got affected, only the code in master branch.
