### PR TITLE
fix(librarypanel): finalize plugins, mitigate HTTP errors for non-existent panels

### DIFF
--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -279,6 +279,13 @@ func (r *GrafanaLibraryPanelReconciler) finalize(ctx context.Context, cr *v1beta
 			}
 		}
 
+		if grafana.IsInternal() {
+			err = ReconcilePlugins(ctx, r.Client, r.Scheme, &grafana, nil, cr.GetPluginConfigMapKey(), cr.GetPluginConfigMapDeprecatedKey())
+			if err != nil {
+				return fmt.Errorf("reconciling plugins: %w", err)
+			}
+		}
+
 		// Update grafana instance Status
 		err = grafana.RemoveNamespacedResource(ctx, r.Client, cr)
 		if err != nil {

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -254,9 +254,9 @@ func (r *GrafanaLibraryPanelReconciler) finalize(ctx context.Context, cr *v1beta
 
 		isCleanupInGrafanaRequired := true
 
-		resp, err := grafanaClient.LibraryElements.GetLibraryElementConnections(uid)
+		resp, err := grafanaClient.LibraryElements.GetLibraryElementByUID(uid)
 		if err != nil {
-			var notFound *library_elements.GetLibraryElementConnectionsNotFound
+			var notFound *library_elements.GetLibraryElementByUIDNotFound
 			if !errors.As(err, &notFound) {
 				return fmt.Errorf("fetching library panel from instance %s/%s: %w", grafana.Namespace, grafana.Name, err)
 			}
@@ -266,7 +266,7 @@ func (r *GrafanaLibraryPanelReconciler) finalize(ctx context.Context, cr *v1beta
 
 		// Skip cleanup in instances
 		if isCleanupInGrafanaRequired {
-			if len(resp.Payload.Result) > 0 {
+			if resp.Payload.Result.Meta.ConnectedDashboards > 0 {
 				return fmt.Errorf("library panel %s/%s/%s on instance %s/%s has existing connections", cr.Namespace, cr.Name, uid, grafana.Namespace, grafana.Name) //nolint
 			}
 


### PR DESCRIPTION
- `LibraryPanel`:
  - fixes:
    - finalize plugins (#2172);
    - mitigate HTTP errors for non-existent panels (finalize stage):
      - current Grafana API behaviour is a bit weird in a sense that it responds with an HTTP 403 when the operator tries to fetch the number of linked dashboards for a non-existent library panel (`GetLibraryElementConnections`). To mitigate the error, switched the operator to another API endpoint;
  - chores:
    - unified variable naming in finalize.

Fixes: #2172

Depends on: #2179

#### Example of the error mesage (finalize stage for non-existent GrafanaLibraryPanel)

`grafana-operator-controller-manager-6cbfb78484-899f8 manager 2025-09-01T14:42:53.646Z error Reconciler error {"controller": "grafanalibrarypanel", "controllerGroup": "grafana.integreatly.org", "controllerKind": "GrafanaLibraryPanel", "GrafanaLibraryPanel": {"name":"grafana-library-panel","namespace":"default"}, "namespace": "default", "name": "grafana-library-panel", "reconcileID": "edc1ef84-4fc8-49dc-9f6e-b21267c5c053", "error": "failed to finalize GrafanaLibraryPanel: fetching library panel from instance default/grafana: [GET /library-elements/{library_element_uid}/connections/][403] getLibraryElementConnectionsForbidden {\"message\":\"You'll need additional permissions to perform this action. Permissions needed: library.panels:read\"}"}`