### PR TITLE
feat: added watchers for cm, secrets in contactpoint_controller

### DIFF
--- a/controllers/contactpoint_controller_test.go
+++ b/controllers/contactpoint_controller_test.go
@@ -1,12 +1,15 @@
 package controllers
 
 import (
+	"testing"
+
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
 )
 
 var _ = Describe("ContactPoint Reconciler: Provoke Conditions", func() {
@@ -114,3 +117,163 @@ var _ = Describe("ContactPoint Reconciler: Provoke Conditions", func() {
 		})
 	}
 })
+
+func TestContactPointIndexing(t *testing.T) {
+	reconciler := &GrafanaContactPointReconciler{
+		Client: k8sClient,
+	}
+
+	t.Run("indexSecretSource returns correct secret references", func(t *testing.T) {
+		cp := &v1beta1.GrafanaContactPoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-contactpoint",
+			},
+			Spec: v1beta1.GrafanaContactPointSpec{
+				ValuesFrom: []v1beta1.ValueFrom{
+					{
+						ValueFrom: v1beta1.ValueFromSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "secret1",
+								},
+								Key: "key1",
+							},
+						},
+					},
+					{
+						ValueFrom: v1beta1.ValueFromSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "secret2",
+								},
+								Key: "key2",
+							},
+						},
+					},
+					{
+						ValueFrom: v1beta1.ValueFromSource{
+							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "configmap1",
+								},
+								Key: "key1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		indexFunc := reconciler.indexSecretSource()
+		result := indexFunc(cp)
+
+		expected := []string{"test-namespace/secret1", "test-namespace/secret2"}
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("indexConfigMapSource returns correct configmap references", func(t *testing.T) {
+		cp := &v1beta1.GrafanaContactPoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-contactpoint",
+			},
+			Spec: v1beta1.GrafanaContactPointSpec{
+				ValuesFrom: []v1beta1.ValueFrom{
+					{
+						ValueFrom: v1beta1.ValueFromSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "secret1",
+								},
+								Key: "key1",
+							},
+						},
+					},
+					{
+						ValueFrom: v1beta1.ValueFromSource{
+							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "configmap1",
+								},
+								Key: "key1",
+							},
+						},
+					},
+					{
+						ValueFrom: v1beta1.ValueFromSource{
+							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "configmap2",
+								},
+								Key: "key2",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		indexFunc := reconciler.indexConfigMapSource()
+		result := indexFunc(cp)
+
+		expected := []string{"test-namespace/configmap1", "test-namespace/configmap2"}
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("indexSecretSource returns empty slice when no secret references", func(t *testing.T) {
+		cp := &v1beta1.GrafanaContactPoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-contactpoint",
+			},
+			Spec: v1beta1.GrafanaContactPointSpec{
+				ValuesFrom: []v1beta1.ValueFrom{
+					{
+						ValueFrom: v1beta1.ValueFromSource{
+							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "configmap1",
+								},
+								Key: "key1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		indexFunc := reconciler.indexSecretSource()
+		result := indexFunc(cp)
+
+		require.Empty(t, result)
+	})
+
+	t.Run("indexConfigMapSource returns empty slice when no configmap references", func(t *testing.T) {
+		cp := &v1beta1.GrafanaContactPoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-contactpoint",
+			},
+			Spec: v1beta1.GrafanaContactPointSpec{
+				ValuesFrom: []v1beta1.ValueFrom{
+					{
+						ValueFrom: v1beta1.ValueFromSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "secret1",
+								},
+								Key: "key1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		indexFunc := reconciler.indexConfigMapSource()
+		result := indexFunc(cp)
+
+		require.Empty(t, result)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -329,7 +329,7 @@ func main() { // nolint:gocyclo
 	if err = (&controllers.GrafanaContactPointReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GrafanaContactPoint")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Description
When a GrafanaContactPoint CR references secrets or configmaps through the valuesFrom field, the operator will now automatically reconcile the contactpoint whenever those referenced resources change.

Related Issue
https://github.com/grafana/grafana-operator/pull/2178#issuecomment-3317764400

What Changed
Added unit tests for the indexing functionality