### PR TITLE
feat: added reconcile logic for secrets in serviceaccount_controller

### DIFF
--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -835,11 +835,9 @@ func renewSecret(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *GrafanaServiceAccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// TODO: Consider watching token Secrets for reactive reconciles.
-	// It'll requeue on Secret create/update/delete, reducing reliance on ResyncPeriod.
-	// Example: Owns(&corev1.Secret{}, builder.WithPredicates(...))
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.GrafanaServiceAccount{}).
+		Owns(&corev1.Secret{}).
 		WithEventFilter(predicate.Or(
 			ignoreStatusUpdates(),
 			predicate.AnnotationChangedPredicate{},


### PR DESCRIPTION
Description
Added reconcile logic for secrets using .Owns in serviceaccount_controller

Related Issue
https://github.com/grafana/grafana-operator/pull/2178#issuecomment-3317764400

What Changed
