### PR TITLE
docs: example for image rendering service

### DIFF
--- a/examples/grafana/image_renderer/README.md
+++ b/examples/grafana/image_renderer/README.md
@@ -1,0 +1,9 @@
+---
+title: "Image renderer via sidecar example"
+---
+
+This example configures the [Grafana image rendering service](https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/) for use in alerting & reporting.
+
+For production use, ensure that the image renderer has enough resources. Refer to the [recommendations in the official documentation](https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#memory-requirements) for more information.
+
+{{< readfile file="resources.yaml" code="true" lang="yaml" >}}

--- a/examples/grafana/image_renderer/resources.yaml
+++ b/examples/grafana/image_renderer/resources.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  labels:
+    instance: image-renderer
+  name: image-renderer
+  namespace: default
+spec:
+  # enterprise image if you need to enable the reporting functionality
+  version: docker.io/grafana/grafana-enterprise:12.2.0
+  config:
+    rendering:
+      server_url: http://localhost:8081/render
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: image-renderer
+            image: 'grafana/grafana-image-renderer:latest'
+            resources:
+              requests:
+                memory: '16Gi'


### PR DESCRIPTION
Adds an example for the image renderer deployment

closes #2160

(might be pulled into #2206)