### PR TITLE
chore: customize renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>grafana/grafana-renovate-config//presets/base"],
+  "ignoreDeps": ["ghcr.io/grafana/grafana-operator"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["operator_constants.go"],
+      "datasourceTemplate": "docker",
+      "matchStrings": [
+        "\\s*GrafanaImage\\s*=\\s*\"(?<depName>[^\\s]+?)\"\\s*\\n\\s*GrafanaVersion\\s*=\\s*\"(?<currentValue>[\\w+\\.\\-]*)\""
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This customization ignores our own package (as it's only referenced in bundles) and adds a custom manager for updating the default grafana version automatically