### PR TITLE
chore(CI): Include E2E/Integration test updates in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,12 +9,17 @@
   "customManagers": [
     {
       "customType": "regex",
+      "packageNameTemplate": "docker.io/grafana/grafana",
       "managerFilePatterns": [
-        "/operator_constants.go/"
+        "/controllers\/config\/operator_constants.go/",
+        "/config\/manager\/manager.yaml/",
+        "/tests\/e2e\/example-test\/00-assert.yaml/"
       ],
       "datasourceTemplate": "docker",
       "matchStrings": [
-        "\\s*GrafanaImage\\s*=\\s*\"(?<depName>[^\\s]+?)\"\\s*\\n\\s*GrafanaVersion\\s*=\\s*\"(?<currentValue>[\\w+\\.\\-]*)\""
+        "\\s*GrafanaVersion\\s*=\\s*\"(?<currentValue>[\\w+\\.\\-]*)\"",
+        "\\s*value:\\s*\"?[^\\s]+?:(?<currentValue>[\\w+\\.\\-]*)\"?",
+        "\\s*version:\\s*\"?(?<currentValue>[\\w+\\.\\-]*)\"?"
       ]
     }
   ]


### PR DESCRIPTION
Decided to see if I could fully automate the Grafana Image update PRs.

Playing around with this, I used the following to test:
```bash
docker run --rm -v "${PWD}:/repo" -w /repo -e LOG_LEVEL=debug renovate/renovate --platform=local --repository-cache=reset --enabled-managers regex
```
Which we could add as a make target eventually.

I ran into some problems while testing due to `grafana/grafana-renovate-config` from the `extends` section not being publicly accessible?
Removing the section during tests worked well but is a bit annoying.

Hopefully merging this should make the tests on #2242 run successfully after renovate rebases the branch.