### PR TITLE
feat(Helm): Allow enabling/disabling user namespaces

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -91,6 +91,7 @@ It's easier to just manage this configuration outside of the operator.
 | extraVolumeMounts | list | `[]` | extra container volume mounts |
 | extraVolumes | list | `[]` | extra pod volumes |
 | fullnameOverride | string | `""` | Overrides the fully qualified app name. |
+| hostUsers | bool | `true` | Set to false to opt-in to use user namespaces |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in grafana operator container |
 | image.repository | string | `"ghcr.io/grafana/grafana-operator"` | grafana operator image repository |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version }}
+      hostUsers: {{ .Values.hostUsers }}
+      {{- end}}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -149,6 +149,9 @@ securityContext:
   # -- Whether to require a container to run as a non-root user
   runAsNonRoot: true
 
+# -- Set to false to opt-in to use user namespaces
+hostUsers: true
+
 # -- grafana operator container resources
 resources: {}
 


### PR DESCRIPTION
Versions earlier than 1.33 shows nothing
```bash
kind create cluster --image=kindest/node:v1.31.12
helm upgrade -i grafana-operator deploy/helm/grafana-operator --set hostUsers=false
kubectl get deployments.apps grafana-operator -o yaml | grep hostUsers
helm upgrade -i grafana-operator deploy/helm/grafana-operator --set hostUsers=true
kubectl get deployments.apps grafana-operator -o yaml | grep hostUsers
kind delete cluster
```

Versions 1.33 and later shows `hostUsers: <bool>`
```bash
kind create cluster --image=kindest/node:v1.33.4
# Shows field for both
helm upgrade -i grafana-operator deploy/helm/grafana-operator --set hostUsers=false
kubectl get deployments.apps grafana-operator -o yaml | grep hostUsers
helm upgrade -i grafana-operator deploy/helm/grafana-operator --set hostUsers=true
kubectl get deployments.apps grafana-operator -o yaml | grep hostUsers
kind delete cluster
```

closes: #2116

