### PR TITLE
fix(e2e): Unstable assertion on serviceaccount status

### DIFF
--- a/tests/e2e/example-test/16-assert.yaml
+++ b/tests/e2e/example-test/16-assert.yaml
@@ -11,7 +11,7 @@ status:
     name: my-service-account
     role: Admin
     tokens:
-      - expires: "2099-12-31T11:59:59Z"
+      - (time_between(expires, '2099-12-31T11:59:58Z', '2099-12-31T12:00:10Z')): true
         name: my-token-a
         secret:
           name: thatsfine


### PR DESCRIPTION
Fix the flaky E2E test for serviceaccount when asserting the value of token expiration

```diff
    l.go:52: | 23:46:06 | example-test | step-16   | APPLY     | DONE  | grafana.integreatly.org/v1beta1/GrafanaServiceAccount @ grafana-operator-example-test/mysa
    l.go:52: | 23:46:06 | example-test | step-16   | ASSERT    | RUN   | grafana.integreatly.org/v1beta1/GrafanaServiceAccount @ grafana-operator-example-test/mysa
    l.go:52: | 23:48:06 | example-test | step-16   | ASSERT    | ERROR | grafana.integreatly.org/v1beta1/GrafanaServiceAccount @ grafana-operator-example-test/mysa
        === ERROR
        ----------------------------------------------------------------------------------------
        grafana.integreatly.org/v1beta1/GrafanaServiceAccount/grafana-operator-example-test/mysa
        ----------------------------------------------------------------------------------------
        * status.account.tokens[0].expires: Invalid value: "2099-12-31T12:00:00Z": Expected value: "2099-12-31T11:59:59Z"
        
        --- expected
        +++ actual
        @@ -12,13 +12,21 @@
             name: my-service-account
             role: Admin
             tokens:
        -    - expires: "2099-12-31T11:59:59Z" <-------- Expected
        +    - expires: "2099-12-31T12:00:00Z" <-------- Sometimes not a match due to timing
        +      id: 1
               name: my-token-a
               secret:
                 name: thatsfine
        -    - name: my-token-b
        +        namespace: grafana-operator-example-test
        +    - id: 2
        +      name: my-token-b
        +      secret:
        +        name: grafana-my-service-account-my-token-b-clzpw
        +        namespace: grafana-operator-example-test
           conditions:
        -  - message: ServiceAccount was successfully applied to 1 instances
        +  - lastTransitionTime: "2025-10-31T23:46:07Z"
        +    message: ServiceAccount was successfully applied to 1 instances
        +    observedGeneration: 1
             reason: ApplySuccessful
             status: "True"
             type: ServiceAccountSynchronized
    l.go:52: | 23:48:06 | example-test | step-16   | TRY       | END   |
    l.go:52: | 23:48:06 | example-test | step-16   | CATCH     | BEGIN |
    l.go:52: | 23:48:06 | example-test | step-16   | INTERNAL  | ERROR |
        === ERROR
        no matches for kind "grafana-operator" in version "grafana.integreatly.org/v1beta1"
    l.go:52: | 23:48:06 | example-test | step-16   | INTERNAL  | ERROR |
        === ERROR
        a name or selector must be specified
```