### PR TITLE
feat(Controllers): Track previously matched instances for cleanup

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -91,7 +91,7 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 
 	removeSuspended(&group.Status.Conditions)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, group)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, group)
 	if err != nil {
 		setNoMatchingInstancesCondition(&group.Status.Conditions, group.Generation, err)
 		meta.RemoveStatusCondition(&group.Status.Conditions, conditionAlertGroupSynchronized)
@@ -299,7 +299,7 @@ func (r *GrafanaAlertRuleGroupReconciler) finalize(ctx context.Context, group *g
 		isCleanupInGrafanaRequired = false
 	}
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, group)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, group)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}

--- a/controllers/contactpoint_controller_test.go
+++ b/controllers/contactpoint_controller_test.go
@@ -59,7 +59,7 @@ var _ = Describe("ContactPoint Reconciler: Provoke Conditions", func() {
 				Type:   conditionContactPointSynchronized,
 				Reason: conditionReasonApplyFailed,
 			},
-			wantErr: "failed to apply to all instances",
+			wantErr: "syncing all instances:",
 		},
 		{
 			name: "Referenced secret does not exist",

--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -533,18 +533,18 @@ var _ = Describe("GetMatchingInstances functions", Ordered, func() {
 
 	Context("Ensure AllowCrossNamespaceImport is upheld by GetScopedMatchingInstances", func() {
 		It("Finds all ready instances when instanceSelector is empty", func() {
-			instances, err := GetScopedMatchingInstances(testCtx, k8sClient, matchAllFolder)
+			instances, _, err := GetScopedMatchingInstances(testCtx, k8sClient, matchAllFolder)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(instances).To(HaveLen(2 + 2)) // +2 To account for instances created in controllers/suite_test.go to provoke conditions
 		})
 		It("Finds all ready and Matching instances", func() {
-			instances, err := GetScopedMatchingInstances(testCtx, k8sClient, &allowFolder)
+			instances, _, err := GetScopedMatchingInstances(testCtx, k8sClient, &allowFolder)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(instances).ToNot(BeEmpty())
 			Expect(instances).To(HaveLen(2))
 		})
 		It("Finds matching and ready and matching instance in namespace", func() {
-			instances, err := GetScopedMatchingInstances(testCtx, k8sClient, denyFolder)
+			instances, _, err := GetScopedMatchingInstances(testCtx, k8sClient, denyFolder)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(instances).ToNot(BeEmpty())
 			Expect(instances).To(HaveLen(1))

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -115,7 +115,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	removeInvalidSpec(&cr.Status.Conditions)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
 		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDashboardSynchronized)
@@ -221,7 +221,7 @@ func (r *GrafanaDashboardReconciler) finalize(ctx context.Context, cr *v1beta1.G
 
 	uid := content.CustomUIDOrUID(cr, cr.Status.UID)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -97,7 +97,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	removeSuspended(&cr.Status.Conditions)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
 		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDatasourceSynchronized)
@@ -190,7 +190,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 }
 
 func (r *GrafanaDatasourceReconciler) deleteOldDatasource(ctx context.Context, cr *v1beta1.GrafanaDatasource) error {
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}
@@ -223,7 +223,7 @@ func (r *GrafanaDatasourceReconciler) finalize(ctx context.Context, cr *v1beta1.
 	log := logf.FromContext(ctx)
 	log.Info("Finalizing GrafanaDatasource")
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -100,7 +100,7 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	removeInvalidSpec(&folder.Status.Conditions)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, folder)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, folder)
 	if err != nil {
 		setNoMatchingInstancesCondition(&folder.Status.Conditions, folder.Generation, err)
 		meta.RemoveStatusCondition(&folder.Status.Conditions, conditionFolderSynchronized)
@@ -154,7 +154,7 @@ func (r *GrafanaFolderReconciler) finalize(ctx context.Context, folder *grafanav
 
 	uid := folder.CustomUIDOrUID()
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, folder)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, folder)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -130,7 +130,7 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	// begin instance selection and reconciliation
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, libraryPanel)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, libraryPanel)
 	if err != nil {
 		setNoMatchingInstancesCondition(&libraryPanel.Status.Conditions, libraryPanel.Generation, err)
 		meta.RemoveStatusCondition(&libraryPanel.Status.Conditions, conditionLibraryPanelSynchronized)
@@ -238,7 +238,7 @@ func (r *GrafanaLibraryPanelReconciler) finalize(ctx context.Context, cr *v1beta
 
 	uid := content.CustomUIDOrUID(cr, cr.Status.UID)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}

--- a/controllers/mutetiming_controller.go
+++ b/controllers/mutetiming_controller.go
@@ -85,7 +85,7 @@ func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	removeSuspended(&muteTiming.Status.Conditions)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, muteTiming)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, muteTiming)
 	if err != nil {
 		setNoMatchingInstancesCondition(&muteTiming.Status.Conditions, muteTiming.Generation, err)
 		meta.RemoveStatusCondition(&muteTiming.Status.Conditions, conditionMuteTimingSynchronized)
@@ -207,7 +207,7 @@ func (r *GrafanaMuteTimingReconciler) finalize(ctx context.Context, muteTiming *
 	log := logf.FromContext(ctx)
 	log.Info("Finalizing GrafanaMuteTiming")
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, muteTiming)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, muteTiming)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -134,7 +134,7 @@ func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req
 
 	meta.RemoveStatusCondition(&notificationPolicy.Status.Conditions, conditionNotificationPolicyLoopDetected)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, notificationPolicy)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, notificationPolicy)
 	if err != nil {
 		setNoMatchingInstancesCondition(&notificationPolicy.Status.Conditions, notificationPolicy.Generation, err)
 		meta.RemoveStatusCondition(&notificationPolicy.Status.Conditions, conditionNotificationPolicySynchronized)
@@ -304,7 +304,7 @@ func (r *GrafanaNotificationPolicyReconciler) finalize(ctx context.Context, noti
 	log := logf.FromContext(ctx)
 	log.Info("Finalizing GrafanaNotificationPolicy")
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, notificationPolicy)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, notificationPolicy)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}

--- a/controllers/notificationtemplate_controller.go
+++ b/controllers/notificationtemplate_controller.go
@@ -84,7 +84,7 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 
 	removeSuspended(&notificationTemplate.Status.Conditions)
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, notificationTemplate)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, notificationTemplate)
 	if err != nil {
 		setNoMatchingInstancesCondition(&notificationTemplate.Status.Conditions, notificationTemplate.Generation, err)
 		meta.RemoveStatusCondition(&notificationTemplate.Status.Conditions, conditionNotificationTemplateSynchronized)
@@ -156,7 +156,7 @@ func (r *GrafanaNotificationTemplateReconciler) finalize(ctx context.Context, no
 	log := logf.FromContext(ctx)
 	log.Info("Finalizing GrafanaNotificationTemplate")
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, notificationTemplate)
+	instances, _, err := GetScopedMatchingInstances(ctx, r.Client, notificationTemplate)
 	if err != nil {
 		return fmt.Errorf("fetching instances: %w", err)
 	}


### PR DESCRIPTION
Managed to get a PoC up and running.
The code still needs a fair bit of cleanup and some helper functions to simplify things a bit.

In theory, this should allow making the `instanceSelector` and `allowCrossNamespaceImport` mutable.

<details>
<summary><b>setup.yml</b></summary>

```yaml
---    
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
metadata:
  labels:
    dashboards: grafana
  name: grafana1
  namespace: default
spec:
  client:
    preferIngress: true
  config:
    security:
      admin_password: secret
      admin_user: root
  ingress:
    spec:
      ingressClassName: nginx
      rules:
      - host: grafana1.127.0.0.1.nip.io
        http:
          paths:
          - backend:
              service:
                name: grafana1-service
                port:
                  number: 3000
            path: /
            pathType: Prefix
---              
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
metadata:
  labels:
    dashboards: grafana
  name: grafana2
  namespace: default
spec:
  client:
    preferIngress: true
  config:
    security:
      admin_password: secret
      admin_user: root
  ingress:
    spec:
      ingressClassName: nginx
      rules:
      - host: grafana2.127.0.0.1.nip.io
        http:
          paths:
          - backend:
              service:
                name: grafana2-service
                port:
                  number: 3000
            path: /
            pathType: Prefix
---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaContactPoint
metadata:
  name: grafanacontactpoint-sample
  namespace: default
spec:
  instanceSelector:
    matchLabels:
      dashboards: grafana
  receivers:
  - settings:
      addresses: email1@email.com
    type: email
  - settings:
      addresses: email2@email.com
    type: email
  resyncPeriod: 10s
```

</details>

```bash
make start-kind
kubectl apply --serverside -f setup.yml

# Start the operator in a separate terminal 
make run

# Wait for both Grafanas to be ready
kubectl get grafanas

# ContactPoint matched both instances 
kubectl get grafanas -o yaml | yq '.items[].status.contactPoints'
# - default/grafanacontactpoint-sample/grafanacontactpoint-sample
# - default/grafanacontactpoint-sample/grafanacontactpoint-sample

kubectl get grafanacontactpoints grafanacontactpoint-sample -o yaml | yq '.metadata.annotations'
# annotations:
#   operator.grafana.com/matched-instances: default/grafana1,default/grafana2

# Remove label from an instance
kubectl label grafana grafana2 dashboards-

# Verify it was removed from Grafana status and ContactPoint annotations
kubectl get grafanas -o yaml | yq '.items[].status.contactPoints'
# - default/grafanacontactpoint-sample/grafanacontactpoint-sample
# []
kubectl get grafanacontactpoints grafanacontactpoint-sample -o yaml | yq '.metadata.annotations'
# annotations:
#   operator.grafana.com/matched-instances: default/grafana1

# Label the instance again and see it's matched again.
kubectl label grafana grafana2 dashboards=grafana
```
