### PR TITLE
fix(AlertRuleGroup): `.spec.editable` cannot be be disabled

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -119,7 +119,8 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	var disableProvenance *string
-	if group.Spec.Editable == nil || *group.Spec.Editable {
+
+	if group.Spec.Editable != nil && *group.Spec.Editable {
 		trueStr := "true"
 		disableProvenance = &trueStr
 	}


### PR DESCRIPTION
## What does this PR do?

Restores correct behavior for the `editable` field in `GrafanaAlertRuleGroup` CRDs.  
With grafana-provider >= v5.19.0, all alert rule groups became editable in the Grafana UI, regardless of the `editable: false` field, due to always setting the `X-Disable-Provenance` header.

This PR ensures the header is only set when `editable` is `true`, restoring the intended restriction on editing these alerts via the UI.

## Background / Related Issue

Fixes: #2275

- See details and diagnosis in the linked issue.
- Regression introduced by v5.19.0, which always included the `X-Disable-Provenance` header (see: [Grafana code reference](https://github.com/grafana/grafana/blob/1d38cf7f0dfceb4e11b531c25097c42275592f4c/pkg/services/ngalert/api/api_provisioning.go#L520))

## How to test

1. Deploy `grafana-operator` with this change.
2. Create a `GrafanaAlertRuleGroup` with `editable: false`.
3. Check that the alert rule group is **not** editable in the Grafana UI and has `provenance: "api"`.

## Additional context

- In v5.18.0, the header was only set when `editable` was `true`.
- This restores v5.18.0 behavior and prevents accidental UI modifications of provisioned alert rules.