### PR TITLE
fix(Annotations): Panic when applying annotations and map is nil

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -479,12 +479,12 @@ func patchFinalizers(ctx context.Context, cl client.Client, cr client.Object) er
 func addAnnotation(ctx context.Context, cl client.Client, cr client.Object, key string, value string) error {
 	crAnnotations := cr.GetAnnotations()
 
-	if crAnnotations[key] == value {
-		return nil
-	}
-
 	if crAnnotations == nil {
 		crAnnotations = make(map[string]string, 0)
+	}
+
+	if crAnnotations[key] == value {
+		return nil
 	}
 
 	// Add key to map and create patch


### PR DESCRIPTION
When there's absolutely no annotations on a CR and we attempt to patch on an annotation, the modification of the annotation fails before the patch is applied due to a nil map..