### PR TITLE
chore: Fix hugo github_subdir setting

### DIFF
--- a/hugo/config.yaml
+++ b/hugo/config.yaml
@@ -29,8 +29,8 @@ params:
   github_repo: https://github.com/grafana/grafana-operator
   github_branch: master
   path_base_for_github_subdir:
-    from: ^.*?/grafana-operator/(?:docs/(examples/.*)|(docs/docs/.*)|(examples/.*))$
-    to: $1$2$3
+    from: .*?/grafana-operator/(.*)
+    to: $1
   offlineSearch: true
   prism_syntax_highlighting: false
   ui:


### PR DESCRIPTION
Fixed the "View Page Source / Edit this page" link generation in hugo by correcting the `path_base_for_github_subdir` configuration

Before this change, it was redirecting to an incorrect path.

After this change paths under `/docs/examples/...` are redirected to `examples/...` , while other `/docs/...` paths are redirected to `docs/docs/...`, as follows:
  - https://grafana.github.io/grafana-operator/docs/examples/serviceaccounts/ →
  https://github.com/grafana/grafana-operator/edit/master/examples/serviceaccounts/_index.md ✓
  - https://grafana.github.io/grafana-operator/docs/ →
  https://github.com/grafana/grafana-operator/edit/master/docs/docs/_index.md

Verified the fix locally using `make hugo-dev`
I haven’t confirmed it after the CI ran, so I’m sorry if it turns out to be wrong.

