### PR TITLE
chore(tests): add OpenShift Route CRD

### DIFF
--- a/controllers/reconcilers/grafana/ingress_reconciler_test.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	networkingv1 "k8s.io/api/networking/v1"
@@ -68,7 +69,14 @@ var _ = Describe("Allow use of Ingress on OpenShift", func() {
 		vars := &v1beta1.OperatorReconcileVars{}
 		status, err := r.Reconcile(ctx, cr, vars, scheme.Scheme)
 
-		Expect(err).To(HaveOccurred())
-		Expect(status).To(Equal(v1beta1.OperatorStageResultFailed), "Route does not exist in Scheme outside of OpenShift")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(status).To(Equal(v1beta1.OperatorStageResultSuccess))
+
+		route := &routev1.Route{}
+		err = k8sClient.Get(ctx, types.NamespacedName{
+			Name:      fmt.Sprintf("%s-route", cr.Name),
+			Namespace: "default",
+		}, route)
+		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/controllers/reconcilers/grafana/suite_test.go
+++ b/controllers/reconcilers/grafana/suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -55,7 +56,10 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "..", "tests", "fixtures"),
+		},
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -64,6 +68,9 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	err = grafanav1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = routev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/tests/fixtures/route_crd.yaml
+++ b/tests/fixtures/route_crd.yaml
@@ -1,0 +1,45 @@
+# https://raw.githubusercontent.com/openshift/router/refs/heads/release-4.21/deploy/route_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: routes.route.openshift.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: route.openshift.io
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Host
+          type: string
+          jsonPath: .status.ingress[0].host
+        - name: Admitted
+          type: string
+          jsonPath: .status.ingress[0].conditions[?(@.type=="Admitted")].status
+        - name: Service
+          type: string
+          jsonPath: .spec.to.name
+        - name: TLS
+          type: string
+          jsonPath: .spec.tls.type
+      subresources:
+        # enable spec/status
+        status: {}
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: routes
+    # singular name to be used as an alias on the CLI and for display
+    singular: route
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: Route


### PR DESCRIPTION
- tests:
  - added the OpenShift `Route` CRD;
  - we can now interact with `Routes` in the envtest environment, so I've adjusted the respective `Route` reconciliation test.