### PR TITLE
fix(grafana): delete dangling route

### DIFF
--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -39,6 +39,13 @@ func NewIngressReconciler(client client.Client, isOpenShift bool) reconcilers.Op
 func (r *IngressReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("IngressReconciler")
 
+	if r.isOpenShift {
+		err := r.deleteRouteIfNil(ctx, cr, scheme)
+		if err != nil {
+			return v1beta1.OperatorStageResultFailed, err
+		}
+	}
+
 	err := r.deleteIngressIfNil(ctx, cr, scheme)
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
@@ -128,6 +135,32 @@ func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Gr
 	}
 
 	return v1beta1.OperatorStageResultSuccess, nil
+}
+
+func (r *IngressReconciler) deleteRouteIfNil(ctx context.Context, cr *v1beta1.Grafana, scheme *runtime.Scheme) error {
+	if cr.Spec.Route != nil {
+		return nil
+	}
+
+	route := model.GetGrafanaRoute(cr, scheme)
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      route.Name,
+			Namespace: route.Namespace,
+		},
+	}
+
+	err := r.client.Get(ctx, req.NamespacedName, route)
+	if err != nil {
+		if kuberr.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("error getting Route: %w", err)
+	}
+
+	return r.client.Delete(ctx, route)
 }
 
 func (r *IngressReconciler) reconcileRoute(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {


### PR DESCRIPTION
- grafana:
  - there's an old well-known issue in the grafana controller where it does not attempt to delete an `Route` when someone nullifies the `Route` spec in the `Grafana` CR (`.spec.route = {}` -> `.spec.route = nil`):
    - the PR implements the fix in the same way as in #2298;
    - it also contains tests based on `Route` CRD added in #2300. Lack of the CRD was the main reason why I did not include `Routes` in #2298.