### PR TITLE
Add 'jira' to Grafana contact points

### DIFF
--- a/bundle/manifests/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/bundle/manifests/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -110,6 +110,7 @@ spec:
                 - discord
                 - email
                 - googlechat
+                - jira
                 - kafka
                 - line
                 - opsgenie


### PR DESCRIPTION
This should add Jira as an option for GrafanaContactPoints, as it has been supported in Grafana since March 2025.

I could find no other references to the Contact Point types in the code base since the move to Receivers. Please let me know if I've missed anything.