### PR TITLE
fix(controllers): reflect changes in library panels

### DIFF
--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -125,8 +125,6 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	removeInvalidSpec(&libraryPanel.Status.Conditions)
-	libraryPanel.Status.Hash = hash
-	libraryPanel.Status.UID = content.CustomUIDOrUID(libraryPanel, contentUID)
 
 	// begin instance selection and reconciliation
 
@@ -168,6 +166,9 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
+
+	libraryPanel.Status.Hash = hash
+	libraryPanel.Status.UID = content.CustomUIDOrUID(libraryPanel, contentUID)
 
 	return ctrl.Result{RequeueAfter: r.Cfg.requeueAfter(libraryPanel.Spec.ResyncPeriod)}, nil
 }


### PR DESCRIPTION
- controllers:
  - moved the status updates for `hash` and `uid` to the end of the `Reconcile` function, so now the controller can properly detect changes in `LibraryPanel`'s contents:
    - the issue was that, previously, `content.HasChanged(cr, hash)` would always return `false`, because by the time the actual hash value comparison is done, the `uid` in CR object is already updated to the current value;
    - now it matches the placement of a similar update in the dashboard-controller ([source](https://github.com/grafana/grafana-operator/blob/690b7d60a7c1d89675a07e080f04025d55c5f91a/controllers/dashboard_controller.go#L212-213)).

**NOTE:** in future, ideally, we should extend our tests based on `testcontainers` to cover content update issues. For now, it's more important to have the fix in place before we cut a new release.

Fixes: #2316