### PR TITLE
Align helm values for registry with other grafana charts

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -92,9 +92,11 @@ It's easier to just manage this configuration outside of the operator.
 | extraVolumeMounts | list | `[]` | extra container volume mounts |
 | extraVolumes | list | `[]` | extra pod volumes |
 | fullnameOverride | string | `""` | Overrides the fully qualified app name. |
+| global.imageRegistry | string | `nil` | Overrides the Docker registry globally for all images |
 | hostUsers | bool | `true` | Set to false to opt-in to use user namespaces |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in grafana operator container |
-| image.repository | string | `"ghcr.io/grafana/grafana-operator"` | grafana operator image repository |
+| image.registry | string | `"ghcr.io"` | grafana operator image registry |
+| image.repository | string | `"grafana/grafana-operator"` | grafana operator image repository |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | image pull secrets |
 | isOpenShift | bool | `false` | Determines if the target cluster is OpenShift. Additional rbac permissions for routes will be added on OpenShift |

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.global.imageRegistry | default .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -1,3 +1,7 @@
+global:
+  # -- Overrides the Docker registry globally for all images
+  imageRegistry: null
+
 # -- If the operator should run in namespace-scope or not,
 # if true the operator will only be able to manage instances in the same namespace
 namespaceScope: false
@@ -64,8 +68,7 @@ logging:
   time: rfc3339
 
 # -- Additional environment variables
-env:
-  []
+env: []
   # -- grafana image, e.g. docker.io/grafana/grafana:9.1.6, overwrites the default grafana image defined in the operator
   # - name: RELATED_IMAGE_GRAFANA
   #   value: "docker.io/grafana/grafana:9.1.6"
@@ -73,8 +76,10 @@ env:
   #   value: "myvalue"
 
 image:
+  # -- grafana operator image registry
+  registry: ghcr.io
   # -- grafana operator image repository
-  repository: ghcr.io/grafana/grafana-operator
+  repository: grafana/grafana-operator
   # -- The image pull policy to use in grafana operator container
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
Bringing the helm chart closer inline with the rest of the grafana helm charts for registry overrides