### PR TITLE
chore(Controllers): Align Reconcile functions to use similar variable names

### DIFF
--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -63,9 +63,9 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 	log := logf.FromContext(ctx).WithName("GrafanaLibraryPanelReconciler")
 	ctx = logf.IntoContext(ctx, log)
 
-	libraryPanel := &v1beta1.GrafanaLibraryPanel{}
+	cr := &v1beta1.GrafanaLibraryPanel{}
 
-	err := r.Get(ctx, req.NamespacedName, libraryPanel)
+	err := r.Get(ctx, req.NamespacedName, cr)
 	if err != nil {
 		if kuberr.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -74,14 +74,14 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, fmt.Errorf("failed to get GrafanaLibraryPanel: %w", err)
 	}
 
-	if libraryPanel.GetDeletionTimestamp() != nil {
+	if cr.GetDeletionTimestamp() != nil {
 		// Check if resource needs clean up
-		if controllerutil.ContainsFinalizer(libraryPanel, grafanaFinalizer) {
-			if err := r.finalize(ctx, libraryPanel); err != nil {
+		if controllerutil.ContainsFinalizer(cr, grafanaFinalizer) {
+			if err := r.finalize(ctx, cr); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to finalize GrafanaLibraryPanel: %w", err)
 			}
 
-			if err := removeFinalizer(ctx, r.Client, libraryPanel); err != nil {
+			if err := removeFinalizer(ctx, r.Client, cr); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 			}
 		}
@@ -89,16 +89,16 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, libraryPanel)
+	defer UpdateStatus(ctx, r.Client, cr)
 
-	if libraryPanel.Spec.Suspend {
-		setSuspended(&libraryPanel.Status.Conditions, libraryPanel.Generation, conditionReasonApplySuspended)
+	if cr.Spec.Suspend {
+		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)
 		return ctrl.Result{}, nil
 	}
 
-	removeSuspended(&libraryPanel.Status.Conditions)
+	removeSuspended(&cr.Status.Conditions)
 
-	resolver := content.NewContentResolver(libraryPanel, r.Client, content.WithDisabledSources([]content.ContentSourceType{
+	resolver := content.NewContentResolver(cr, r.Client, content.WithDisabledSources([]content.ContentSourceType{
 		// grafana.com does not currently support hosting library panels for distribution, but perhaps
 		// this will change in the future.
 		content.ContentSourceTypeGrafanaCom,
@@ -107,8 +107,8 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 	// Retrieving the model before the loop ensures to exit early in case of failure and not fail once per matching instance
 	contentModel, hash, err := resolver.Resolve(ctx)
 	if err != nil {
-		setInvalidSpec(&libraryPanel.Status.Conditions, libraryPanel.Generation, "InvalidModelResolution", err.Error())
-		meta.RemoveStatusCondition(&libraryPanel.Status.Conditions, conditionLibraryPanelSynchronized)
+		setInvalidSpec(&cr.Status.Conditions, cr.Generation, "InvalidModelResolution", err.Error())
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionLibraryPanelSynchronized)
 
 		return ctrl.Result{}, fmt.Errorf("error resolving library panel contents: %w", err)
 	}
@@ -117,36 +117,36 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 	// it can happen that the user does not utilize `.spec.uid` but updates
 	// the UID within the content model itself. this will create a conflict b/c
 	// we are effectively requesting a change to the uid, which is immutable.
-	if content.IsUpdatedUID(libraryPanel, contentUID) {
-		setInvalidSpec(&libraryPanel.Status.Conditions, libraryPanel.Generation, "InvalidModel", errLibraryPanelContentUIDImmutable.Error())
-		meta.RemoveStatusCondition(&libraryPanel.Status.Conditions, conditionLibraryPanelSynchronized)
+	if content.IsUpdatedUID(cr, contentUID) {
+		setInvalidSpec(&cr.Status.Conditions, cr.Generation, "InvalidModel", errLibraryPanelContentUIDImmutable.Error())
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionLibraryPanelSynchronized)
 
 		return ctrl.Result{}, errLibraryPanelContentUIDImmutable
 	}
 
-	removeInvalidSpec(&libraryPanel.Status.Conditions)
+	removeInvalidSpec(&cr.Status.Conditions)
 
 	// begin instance selection and reconciliation
 
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, libraryPanel)
+	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
-		setNoMatchingInstancesCondition(&libraryPanel.Status.Conditions, libraryPanel.Generation, err)
-		meta.RemoveStatusCondition(&libraryPanel.Status.Conditions, conditionLibraryPanelSynchronized)
+		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionLibraryPanelSynchronized)
 
 		return ctrl.Result{}, fmt.Errorf("could not find matching instances: %w", err)
 	}
 
 	if len(instances) == 0 {
-		setNoMatchingInstancesCondition(&libraryPanel.Status.Conditions, libraryPanel.Generation, err)
-		meta.RemoveStatusCondition(&libraryPanel.Status.Conditions, conditionLibraryPanelSynchronized)
+		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionLibraryPanelSynchronized)
 
 		return ctrl.Result{}, ErrNoMatchingInstances
 	}
 
-	removeNoMatchingInstance(&libraryPanel.Status.Conditions)
+	removeNoMatchingInstance(&cr.Status.Conditions)
 	log.Info("found matching Grafana instances for library panel", "count", len(instances))
 
-	folderUID, err := getFolderUID(ctx, r.Client, libraryPanel)
+	folderUID, err := getFolderUID(ctx, r.Client, cr)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf(ErrFetchingFolder, err)
 	}
@@ -154,23 +154,23 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 	applyErrors := make(map[string]string)
 
 	for _, grafana := range instances {
-		err := r.reconcileWithInstance(ctx, &grafana, libraryPanel, contentModel, hash, folderUID)
+		err := r.reconcileWithInstance(ctx, &grafana, cr, contentModel, hash, folderUID)
 		if err != nil {
 			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 		}
 	}
 
-	condition := buildSynchronizedCondition("Library panel", conditionLibraryPanelSynchronized, libraryPanel.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&libraryPanel.Status.Conditions, condition)
+	condition := buildSynchronizedCondition("Library panel", conditionLibraryPanelSynchronized, cr.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&cr.Status.Conditions, condition)
 
 	if len(applyErrors) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to apply to all instances: %v", applyErrors)
 	}
 
-	libraryPanel.Status.Hash = hash
-	libraryPanel.Status.UID = content.CustomUIDOrUID(libraryPanel, contentUID)
+	cr.Status.Hash = hash
+	cr.Status.UID = content.CustomUIDOrUID(cr, contentUID)
 
-	return ctrl.Result{RequeueAfter: r.Cfg.requeueAfter(libraryPanel.Spec.ResyncPeriod)}, nil
+	return ctrl.Result{RequeueAfter: r.Cfg.requeueAfter(cr.Spec.ResyncPeriod)}, nil
 }
 
 func (r *GrafanaLibraryPanelReconciler) reconcileWithInstance(ctx context.Context, instance *v1beta1.Grafana, cr *v1beta1.GrafanaLibraryPanel, model map[string]any, hash, folderUID string) error {
@@ -319,13 +319,13 @@ func (r *GrafanaLibraryPanelReconciler) SetupWithManager(ctx context.Context, mg
 
 func (r *GrafanaLibraryPanelReconciler) indexConfigMapSource() func(o client.Object) []string {
 	return func(o client.Object) []string {
-		libraryPanel, ok := o.(*v1beta1.GrafanaLibraryPanel)
+		cr, ok := o.(*v1beta1.GrafanaLibraryPanel)
 		if !ok {
 			panic(fmt.Sprintf("Expected a GrafanaLibraryPanel, got %T", o))
 		}
 
-		if libraryPanel.Spec.ConfigMapRef != nil {
-			return []string{fmt.Sprintf("%s/%s", libraryPanel.Namespace, libraryPanel.Spec.ConfigMapRef.Name)}
+		if cr.Spec.ConfigMapRef != nil {
+			return []string{fmt.Sprintf("%s/%s", cr.Namespace, cr.Spec.ConfigMapRef.Name)}
 		}
 
 		return nil
@@ -342,10 +342,10 @@ func (r *GrafanaLibraryPanelReconciler) requestsForChangeByField(indexKey string
 		}
 
 		var reqs []reconcile.Request
-		for _, libraryPanel := range list.Items {
+		for _, cr := range list.Items {
 			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
-				Namespace: libraryPanel.Namespace,
-				Name:      libraryPanel.Name,
+				Namespace: cr.Namespace,
+				Name:      cr.Name,
 			}})
 		}
 


### PR DESCRIPTION
It's already quite easy to make changes across multiple controllers, but there are instances where copying code across controllers is a bigger hassle than necessary.
This is one of the last changes to fully align all Reconcile functions!