### PR TITLE
chore(client): add more tests

### DIFF
--- a/controllers/client/auth.go
+++ b/controllers/client/auth.go
@@ -144,6 +144,7 @@ func getContainerEnvCredentials(ctx context.Context, c client.Client, cr *v1beta
 	}
 
 	for _, container := range deployment.Spec.Template.Spec.Containers {
+		// TODO: refactor to pick only the relevant container
 		for _, env := range container.Env {
 			if env.Name == config.GrafanaAdminUserEnvVar {
 				if env.Value != "" {

--- a/controllers/client/auth_test.go
+++ b/controllers/client/auth_test.go
@@ -157,7 +157,7 @@ func TestGetContainerEnvCredentials(t *testing.T) {
 		usernameKey = "user"
 		password    = "secret"
 		passwordKey = "password"
-		secretName  = "grafana-credentials"
+		secretName  = "grafana-credentials" //nolint:gosec
 		nonExistent = "non-existent"
 	)
 
@@ -240,11 +240,11 @@ func TestGetContainerEnvCredentials(t *testing.T) {
 			envs: []corev1.EnvVar{
 				{
 					Name:      config.GrafanaAdminUserEnvVar,
-					ValueFrom: getEnvValueFrom(t, secretName, usernameKey),
+					ValueFrom: getEnvVarSecretSource(t, secretName, usernameKey),
 				},
 				{
 					Name:      config.GrafanaAdminPasswordEnvVar,
-					ValueFrom: getEnvValueFrom(t, secretName, passwordKey),
+					ValueFrom: getEnvVarSecretSource(t, secretName, passwordKey),
 				},
 			},
 			want: &grafanaAdminCredentials{
@@ -258,11 +258,11 @@ func TestGetContainerEnvCredentials(t *testing.T) {
 			envs: []corev1.EnvVar{
 				{
 					Name:      config.GrafanaAdminUserEnvVar,
-					ValueFrom: getEnvValueFrom(t, nonExistent, usernameKey),
+					ValueFrom: getEnvVarSecretSource(t, nonExistent, usernameKey),
 				},
 				{
 					Name:      config.GrafanaAdminPasswordEnvVar,
-					ValueFrom: getEnvValueFrom(t, nonExistent, passwordKey),
+					ValueFrom: getEnvVarSecretSource(t, nonExistent, passwordKey),
 				},
 			},
 			want:        nil,
@@ -273,11 +273,11 @@ func TestGetContainerEnvCredentials(t *testing.T) {
 			envs: []corev1.EnvVar{
 				{
 					Name:      config.GrafanaAdminUserEnvVar,
-					ValueFrom: getEnvValueFrom(t, secretName, nonExistent),
+					ValueFrom: getEnvVarSecretSource(t, secretName, nonExistent),
 				},
 				{
 					Name:      config.GrafanaAdminPasswordEnvVar,
-					ValueFrom: getEnvValueFrom(t, secretName, passwordKey),
+					ValueFrom: getEnvVarSecretSource(t, secretName, passwordKey),
 				},
 			},
 			want:        nil,
@@ -288,11 +288,11 @@ func TestGetContainerEnvCredentials(t *testing.T) {
 			envs: []corev1.EnvVar{
 				{
 					Name:      config.GrafanaAdminUserEnvVar,
-					ValueFrom: getEnvValueFrom(t, secretName, usernameKey),
+					ValueFrom: getEnvVarSecretSource(t, secretName, usernameKey),
 				},
 				{
 					Name:      config.GrafanaAdminPasswordEnvVar,
-					ValueFrom: getEnvValueFrom(t, secretName, nonExistent),
+					ValueFrom: getEnvVarSecretSource(t, secretName, nonExistent),
 				},
 			},
 			want:        nil,
@@ -312,7 +312,7 @@ func TestGetContainerEnvCredentials(t *testing.T) {
 			deployment := resources.GetGrafanaDeployment(cr, nil)
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name: "grafana", // TODO: switch to const
+					Name: "grafana", // TODO: switch to const once it's done inside getContainerEnvCredentials
 					Env:  tt.envs,
 				},
 			}
@@ -333,7 +333,7 @@ func TestGetContainerEnvCredentials(t *testing.T) {
 	}
 }
 
-func getEnvValueFrom(t *testing.T, secretName, key string) *corev1.EnvVarSource {
+func getEnvVarSecretSource(t *testing.T, secretName, key string) *corev1.EnvVarSource {
 	t.Helper()
 
 	v := &corev1.EnvVarSource{
@@ -356,7 +356,7 @@ func createAndCleanupResources(t *testing.T, ctx context.Context, c client.WithW
 		require.NoError(t, err)
 
 		t.Cleanup(func() {
-			c.Delete(ctx, obj)
+			c.Delete(ctx, obj) //nolint:errcheck
 		})
 	}
 }


### PR DESCRIPTION
- `client`:
  - extracted logic around fetching admin credentials from environment variables from `getAdminCredentials` into `getContainerEnvCredentials` to simplify testing and improve readability;
  - added tests cases covering `getContainerEnvCredentials`;
  - added a `t.Cleanup` call to `createFileWithContent`, so we don't have to explicitly remove the files inside tests anymore.