### PR TITLE
chore(renovate): add config for Makefile toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ REGISTRY ?= ghcr.io
 ORG ?= grafana
 IMG ?= $(REGISTRY)/$(ORG)/grafana-operator:v$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+# renovate: datasource=github-tags depName=kubernetes-sigs/controller-tools extractVersion=^envtest-(?<version>v\d+\.\d+\.\d+)$
 ENVTEST_K8S_VERSION = 1.34.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -4,21 +4,31 @@ $(BIN):
 
 M = $(shell printf "\033[34;1m▶\033[0m")
 
+# renovate: datasource=github-tags depName=kyverno/chainsaw
 CHAINSAW_VERSION = v0.2.12
+# renovate: datasource=github-tags depName=kubernetes-sigs/controller-tools versioning=semver
 CONTROLLER_GEN_VERSION = v0.17.3
+# renovate: datasource=github-tags depName=fybrik/crdoc
 CRDOC_VERSION = v0.6.4
 DART_SASS_VERSION = 1.86.0
+# renovate: datasource=github-tags depName=kubernetes-sigs/controller-runtime
 ENVTEST_VERSION = v0.21.0
+# renovate: datasource=github-tags depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION = v2.4.0
+# renovate: datasource=github-tags depName=norwoodj/helm-docs
 HELM_DOCS_VERSION = 1.14.2
 HELM_VERSION = v3.17.3
 HUGO_VERSION = 0.151.0
+# renovate: datasource=github-tags depName=kubernetes-sigs/kind
 KIND_VERSION = v0.29.0
+# renovate: datasource=github-tags depName=ko-build/ko
 KO_VERSION = 0.18.0
+# renovate: datasource=github-tags depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>.*)$
 KUSTOMIZE_VERSION = v5.6.0
 MUFFET_VERSION = v2.10.9
 OPERATOR_SDK_VERSION = v1.32.0
 OPM_VERSION = v1.23.2
+# renovate: datasource=github-tags depName=mikefarah/yq
 YQ_VERSION = v4.45.4
 
 ifdef GITHUB_TOKEN

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,16 @@
         "\\s*value:\\s*\"?[^\\s]+?:(?<currentValue>[\\w+\\.\\-]*)\"?",
         "\\s*version:\\s*\"?(?<currentValue>[\\w+\\.\\-]*)\"?"
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Makefile$/",
+        "/\\.mk$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:*\\??=\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- renovate:
  - added a custom regex manager to handle deps in `Makefile` / `Toolchain.mk`;
  - enabled updates for:
    - `chainsaw`;
    - `controller-runtime`;
    - `controller-tools`;
    - `crdoc`;
    - `envtest` & `setup-envtest`;
    - `golangci-lint`;
    - `helm-docs`;
    - `kind`;
    - `ko`;
    - `kustomize`;
    - `yq`.

**NOTE:** Those instructions require a GitHub token to be present, which is, presumably, the case in our setup (I have no visibility over enterprise settings). For local tests, I used: `docker run --rm -v "${PWD}:/repo" -w /repo -e LOG_LEVEL=debug -e RENOVATE_GITHUB_COM_TOKEN=REDACTED renovate/renovate --platform=local --repository-cache=reset --enabled-managers regex` (+ had to disable `extends` section inside `renovate.json`).