### PR TITLE
chore(e2e): test in quiet mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ e2e-local-gh-actions: e2e-kind ko-build-kind e2e
 .PHONY: e2e
 e2e: $(CHAINSAW) install deploy-chainsaw ## Run e2e tests using chainsaw.
 	$(info $(M) running $@)
-	$(CHAINSAW) test --test-dir ./tests/e2e/$(TESTS)
+	$(CHAINSAW) test --quiet --test-dir ./tests/e2e/$(TESTS)
 
 export KO_DOCKER_REPO ?= ko.local/grafana/grafana-operator
 export KIND_CLUSTER_NAME ?= kind-grafana


### PR DESCRIPTION
- `e2e`:
  - enabled the recently introduced `--quiet` mode to reduce noise in logs.
    > Added quiet mode with --quiet (suppresses verbose output and only shows errors, test failures, and the final test summary)

<img width="854" height="266" alt="image" src="https://github.com/user-attachments/assets/f7ae54df-bb5d-44fe-9880-41e850ad1d2f" />
