### PR TITLE
chore(Grafana): Validate credentials before getting Grafana version

### DIFF
--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -25,6 +25,14 @@ func NewCompleteReconciler(client client.Client) reconcilers.OperatorGrafanaReco
 func (r *CompleteReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, _ *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("CompleteReconciler")
 
+	log.V(1).Info("attempting to authenticate with instance")
+
+	_, err := grafanaclient.GetAuthenticationStatus(ctx, r.client, cr)
+	if err != nil {
+		cr.Status.Version = ""
+		return v1beta1.OperatorStageResultFailed, fmt.Errorf("failed to authenticate with instance: %w", err)
+	}
+
 	log.V(1).Info("fetching Grafana version from instance")
 
 	version, err := grafanaclient.GetGrafanaVersion(ctx, r.client, cr)


### PR DESCRIPTION
The Complete reconciler now evaluates the given credentials before attempting to get the Version from the Grafana instance.

The goal is to make authentication issues easier to spot for users.

Changes:
Implements an explicit login check (`GetAuthenticationStatus`) to validate credentials separately from getting the instance version.

A successful response is and always has been `200 OK {"Message": "Logged in"}`.
This is explicitly checked to ensure an invalid endpoint returning `200 OK` for any GET request does not evaluate a Grafana instance to healthy