### PR TITLE
chore(Config): Migrate ENV vars to kong

### DIFF
--- a/main.go
+++ b/main.go
@@ -470,7 +470,7 @@ func getNamespaceConfigSelector(restConfig *rest.Config, selector string, labelS
 
 	cl, err := client.New(restConfig, client.Options{})
 	if err != nil {
-		setupLog.Error(err, "failed to get watch namespaces")
+		setupLog.Error(err, "failed to create a kubernetes client")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Changes:
- All environment variables are now read by Kong
- `WATCH_LABEL_SELECTOR` Will now exit if the selector cannot be parsed
- `ENFORCE_CACHE_LABELS` is now validated by a Kong enum.
  Removed the switch that effectively set a bool to `true` to enable caching
- Added validation for `WATCH_NAMESPACE_SELECTOR`, now returns an error when invalid

For now the changes have been tested manually, but further refactoring is planned.
Specifically to move logic out of main and into functions to allow for testing, maybe even with `envtest`