### PR TITLE
fix(RBAC): Missing `*/finalizers` patch;update perms for OpenShift

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -78,6 +78,13 @@ rules:
 - apiGroups:
   - grafana.integreatly.org
   resources:
+  - '*/finalizers'
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - grafana.integreatly.org
+  resources:
   - '*/status'
   verbs:
   - get

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -29,6 +29,7 @@ import (
 
 // +kubebuilder:rbac:groups=grafana.integreatly.org,resources=*,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=grafana.integreatly.org,resources=*/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=grafana.integreatly.org,resources=*/finalizers,verbs=update;patch
 
 const (
 	// Synchronization size and timeout values

--- a/deploy/helm/grafana-operator/files/rbac.yaml
+++ b/deploy/helm/grafana-operator/files/rbac.yaml
@@ -78,6 +78,13 @@ rules:
   - apiGroups:
       - grafana.integreatly.org
     resources:
+      - '*/finalizers'
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - grafana.integreatly.org
+    resources:
       - '*/status'
     verbs:
       - get

--- a/deploy/kustomize/base/role.yaml
+++ b/deploy/kustomize/base/role.yaml
@@ -78,6 +78,13 @@ rules:
 - apiGroups:
   - grafana.integreatly.org
   resources:
+  - '*/finalizers'
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - grafana.integreatly.org
+  resources:
   - '*/status'
   verbs:
   - get


### PR DESCRIPTION
Fixes a regression on OpenShift from #2268 

`ownerReferences` cannot be set when the role is not allowed to `update` `*/finalizers` on the targetted resource, in this case `Grafana` CRs.

`patch` is included in the permissions as that is the primary method used by the Operator to set finalizers.

fixes: #2390