### PR TITLE
chore: prep release 5.21.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include Toolchain.mk
 .DEFAULT_GOAL := all
 
 # Current Operator version
-VERSION ?= 5.21.2
+VERSION ?= 5.21.3
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Whether you’re running one Grafana instance or many, the Grafana Operator simp
 Deploy the Grafana Operator easily in your cluster using Helm:
 
 ```bash
-helm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.21.2
+helm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.21.3
 ```
 
 **Option 2: Kustomize & More**

--- a/deploy/helm/grafana-operator/Chart.yaml
+++ b/deploy/helm/grafana-operator/Chart.yaml
@@ -12,8 +12,8 @@ description: Helm chart for the Grafana Operator
 type: application
 # We keep the version and appVersion in sync as most updates also include
 # changes to the CRDs which are bundled with the helm resources
-version: 5.21.2
-appVersion: "v5.21.2"
+version: 5.21.3
+appVersion: "v5.21.3"
 dependencies:
   - name: crds
     version: "0.0.*"

--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -7,14 +7,14 @@ linkTitle: "Helm installation"
 
 [grafana-operator](https://github.com/grafana/grafana-operator) for Kubernetes to manage Grafana instances and grafana resources.
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.21.2](https://img.shields.io/badge/AppVersion-v5.21.2-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v5.21.3](https://img.shields.io/badge/AppVersion-v5.21.3-informational?style=flat-square)
 
 ## Installation
 
 This is a OCI helm chart, helm started support OCI in version 3.8.0.
 
 ```shell
-helm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.21.2
+helm upgrade -i grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.21.3
 ```
 
 Sadly helm OCI charts currently don't support searching for available versions of a helm [oci registry](https://github.com/helm/helm/issues/11000).
@@ -30,7 +30,7 @@ resource "helm_release" "grafana_kubernetes_operator" {
   repository = "oci://ghcr.io/grafana/helm-charts"
   chart      = "grafana-operator"
   verify     = false
-  version    = "5.21.2"
+  version    = "5.21.3"
 }
 ```
 
@@ -43,7 +43,7 @@ This can result in the operator misbehaving when a release contains updates to t
 To avoid issues due to outdated or missing definitions, run the following command before updating an existing installation:
 
 ```shell
-kubectl apply --server-side --force-conflicts -f https://github.com/grafana/grafana-operator/releases/download/v5.21.2/crds.yaml
+kubectl apply --server-side --force-conflicts -f https://github.com/grafana/grafana-operator/releases/download/v5.21.3/crds.yaml
 ```
 
 The `--server-side` and `--force-conflict` flags are required to avoid running into issues with the `kubectl.kubernetes.io/last-applied-configuration` annotation.
@@ -56,7 +56,7 @@ without manual `kubectl apply` step required, `--set crds.immutable=false` on `h
 
 Use `helm upgrade -i --take-ownership` when switching to mutable CRDs for the first time only:
 ```shell
-helm upgrade -i --take-ownership --set crds.immutable=false grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.21.2
+helm upgrade -i --take-ownership --set crds.immutable=false grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.21.3
 ```
 
 Both types of CRDs are protected on the Helm chart uninstall to avoid cascading deletion.

--- a/deploy/kustomize/base/kustomization.yaml
+++ b/deploy/kustomize/base/kustomization.yaml
@@ -15,4 +15,4 @@ patches:
         value: grafana-operator-permissions
 images:
   - name: ghcr.io/grafana/grafana-operator
-    newTag: v5.21.2
+    newTag: v5.21.3

--- a/hugo/config.yaml
+++ b/hugo/config.yaml
@@ -24,7 +24,7 @@ params:
   copyright: Grafana Operator Team
   version_menu: Releases
   archived_version: false
-  version: v5.21.2
+  version: v5.21.3
   url_latest_version: https://example.com
   github_repo: https://github.com/grafana/grafana-operator
   github_branch: master


### PR DESCRIPTION
We should cut one more release after #2393 is merged to have valid image registry value.