### PR TITLE
chore(release): remove exclude rule for documentation label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,6 @@
 changelog:
   exclude:
     labels:
-      - documentation
       - chore
       - refactor
       - release-ignore
@@ -15,3 +14,6 @@ changelog:
     - title: Dependencies
       labels:
         - dependencies
+    - title: Documentation
+      labels:
+        - 'documentation'


### PR DESCRIPTION
- release (changelog):
  - removed exclude rule for `documentation` label;
  - added "Documentation" section.

**Context:** the issue with the current configuration of labeler & changelog is that any PR that has `documentation` label gets excluded from automated changelog even though it can contain features / fixes. To mitigate that, my suggestion would be to stop excluding `documentation`-labeled PRs.