### PR TITLE
chore(release): add label for breaking changes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,13 +10,13 @@ changelog:
         - release-note-action-required
     - title: Features
       labels:
-        - 'feature'
+        - feature
     - title: Fixes
       labels:
-        - 'bugfix'
+        - bugfix
     - title: Dependencies
       labels:
         - dependencies
     - title: Documentation
       labels:
-        - 'documentation'
+        - documentation


### PR DESCRIPTION
- `release.yml`:
  - to remind us of the need to mention that particular changes are breaking / require manual actions, added a dedicated label `release-note-action-required`;
  - removed double-quotes for labels as it messes with automated YAML formatting, and they're not needed anyway.
