### PR TITLE
fix(kustomize): remove stale image override from cluster_scoped overlay

### DIFF
--- a/deploy/kustomize/overlays/cluster_scoped/kustomization.yaml
+++ b/deploy/kustomize/overlays/cluster_scoped/kustomization.yaml
@@ -1,29 +1,6 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
 namespace: grafana
 
 resources:
   - ../../base
-
-# Example customizations (uncomment and modify as needed):
-#
-# Override the operator image:
-# images:
-#   - name: ghcr.io/grafana/grafana-operator
-#     newName: my-registry.example.com/grafana-operator
-#     newTag: v5.21.3
-#
-# Add labels to all resources:
-# commonLabels:
-#   environment: production
-#
-# Adjust resource limits via a patch:
-# patches:
-#   - target:
-#       kind: Deployment
-#       name: grafana-operator-controller-manager
-#     patch: |
-#       - op: replace
-#         path: /spec/template/spec/containers/0/resources/limits/memory
-#         value: 512Mi
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
The cluster_scoped overlay had a hardcoded images section with v5.18.0 that was overriding the base kustomization. This caused release artifacts to contain the wrong operator image version.

The overlay now inherits the image from base (which is correctly updated during releases), matching how namespace_scoped already works.

Also added commented examples showing common customizations.

fixes #2412 