### PR TITLE
fix(docs): prefix absolute links in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ hugo-dev: $(DART_SASS) $(HUGO) ## Start development server for hugo.
 	@echo -- Checking presence of dart-sass
 	@cd hugo && $(HUGO) env | grep dart-sass
 	@echo -- Starting dev server
-	@cd hugo && $(HUGO) env && $(HUGO) server --baseURL http://127.0.0.1/
+	@cd hugo && $(HUGO) env && $(HUGO) server --baseURL http://127.0.0.1/grafana-operator/
 
 .PHONY: kustomize-lint
 kustomize-lint: $(KUSTOMIZE) ## Lint kustomize overlays.
@@ -152,7 +152,7 @@ kustomize-github-assets: $(KUSTOMIZE) ## Generates GitHub assets.
 
 .PHONY:
 muffet-dev: $(MUFFET) ## Detect broken internal links in docs.
-	$(MUFFET) --include=http://localhost:1313 http://localhost:1313
+	$(MUFFET) --include=http://localhost:1313/grafana-operator http://localhost:1313/grafana-operator
 
 .PHONY:
 test-image-pre-pull: ## Pre-pulls Grafana image used in tests to speed up CI

--- a/hugo/layouts/_markup/render-link.html
+++ b/hugo/layouts/_markup/render-link.html
@@ -1,0 +1,26 @@
+{{- $u := urls.Parse .Destination -}}
+{{- $href := $u.String -}}
+{{- if strings.HasPrefix $u.String "#" -}}
+  {{- $href = printf "%s#%s" .PageInner.RelPermalink $u.Fragment -}}
+{{- else if and $href (not $u.IsAbs) -}}
+  {{- $path := strings.TrimPrefix "./" $u.Path -}}
+  {{- with or
+    ($.PageInner.GetPage $path)
+    ($.PageInner.Resources.Get $path)
+    (resources.Get $path)
+  -}}
+    {{- $href = .RelPermalink -}}
+    {{- with $u.RawQuery -}}
+      {{- $href = printf "%s?%s" $href . -}}
+    {{- end -}}
+    {{- with $u.Fragment -}}
+      {{- $href = printf "%s#%s" $href . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if strings.HasPrefix $href "gateway:experimental" -}}
+{{- /* Workaround for gateway api doc comments containing invalid markdown links */ -}}
+{{- else -}}
+<a href="{{ $href }}" {{- with .Title }} title="{{ . }}" {{- end }}>{{ .Text }}</a>
+{{ end }}
+{{- /**/ -}}


### PR DESCRIPTION
This fix adds a custom link renderer hook to correctly prefix absolute links with the base url.

To be honest: I don't know why this works. I wanted to add the prefix logic to `render-link.html` but just adding the [upstream template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_markup/render-link.html) seems to be enough :shrug:

Fixes: #2420 