### PR TITLE
fix(docs): git URLs

### DIFF
--- a/hugo/config.yaml
+++ b/hugo/config.yaml
@@ -29,7 +29,7 @@ params:
   github_repo: https://github.com/grafana/grafana-operator
   github_branch: master
   path_base_for_github_subdir:
-    from: .*?/grafana-operator/(.*)
+    from: .*/grafana-operator/(.*)
     to: $1
   offlineSearch: true
   prism_syntax_highlighting: false


### PR DESCRIPTION
As it was highlighted in #2420, "View page source" / "Edit this page" buttons contain broken links. - There's `/grafana-operator` prefix there. Somehow, it surfaces only in builds, not it local dev environment.

In any case, it's sufficient to simply switch from a lazy to a greedy regex in `path_base_for_github_subdir` (part of `hugo/config`) to fix the issue.

To test:
- `make hugo`
- open `hugo/public/docs/index.html` in a browser
- check "View page source" / "Edit this page" links.