### PR TITLE
fix(GrafanaDashboard): update Grafana status even when remote state matches

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -354,7 +354,7 @@ func (r *GrafanaDashboardReconciler) onDashboardCreated(ctx context.Context, gra
 
 	if matchesStateInGrafana {
 		log.V(1).Info("dashboard hasn't changed, skipping update")
-		return nil
+		return grafana.AddNamespacedResource(ctx, r.Client, cr, cr.NamespacedResource(uid))
 	}
 
 	resp, err := gClient.Dashboards.PostDashboard(&models.SaveDashboardCommand{


### PR DESCRIPTION
- dashboard-controller:
  - As discussed with @Baarsgaard in another PR, to make sure status always contains all related resources, we should call `AddNamespacedResource` inside `if matchesStateInGrafana` block as well.