### PR TITLE
docs(quickstart): Undisturbed editing with `suspend=true` and link to Common Options

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -148,3 +148,6 @@ You will find the dashboard in a folder with the same name as your namespace.
 
 Always update a resource configurations, via the Custom Resources(CR) when the resource is created/managed by the operator.
 Any changes made directly in Grafana will be overwritten by the Grafana-operator as per the configuration defined in the CR.
+
+If the `resyncPeriod` is so short that it interferes with editing, suspend reconciliation by setting `.spec.suspend=true` on any Grafana CR in kubernetes.
+More about `suspend` and other common CR fields can be found under [Common Options](/docs/examples/common_options)


### PR DESCRIPTION
Not anything major, but it's also a problem with a *lot* of possible solutions.

At least mentioning `suspend` and guiding people to the bulkier examples might help.

closes: #1597 

<img width="1365" height="198" alt="image" src="https://github.com/user-attachments/assets/e3c2c861-9233-48ce-8267-dc45460af8d0" />
