### PR TITLE
fix(logs): Leader election log format

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/go-logr/logr"
 	uberzap "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/klog/v2"
 
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -284,6 +285,7 @@ func main() { //nolint:gocyclo
 	}
 
 	ctx := ctrl.SetupSignalHandler()
+	ctx = klog.NewContext(ctx, setupLog) // Leader election logger is set through the ctx
 
 	// Determine Operator scope
 	switch {


### PR DESCRIPTION
This has personally bugged me for the better part of a year 😅 

Old:
```
...
2026-01-26T20:38:44.179Z        info    starting server {"name": "health probe", "addr": "[::]:8081"}
I0126 20:38:44.281068       1 leaderelection.go:258] "Attempting to acquire leader lease..." lock="grafana/grafana-operator-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
I0126 20:39:12.887899       1 leaderelection.go:272] "Successfully acquired lease" lock="grafana/grafana-operator-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
2026-01-26T20:39:12.888Z        info    Starting EventSource    {"controller": "grafana", "controllerGroup": "grafana.integreatly.org", "controllerKind": "Grafana", "source": "kind source: *v1.Ingress"}
```

New:
```
...
2026-01-26T20:35:53.617Z        info    starting server {"name": "health probe", "addr": "[::]:8081"}
2026-01-26T20:35:53.617Z        info    controller-runtime.metrics      Serving metrics server  {"bindAddress": "0.0.0.0:9090", "secure": false}
2026-01-26T20:35:53.718Z        info    setup   Attempting to acquire leader lease...   {"version": "v5.21.4", "lock": "grafana/grafana-operator-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
2026-01-26T20:36:06.830Z        info    setup   Successfully acquired lease     {"version": "v5.21.4", "lock": "grafana/grafana-operator-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
2026-01-26T20:36:06.831Z        info    Starting EventSource    {"controller": "grafana", "controllerGroup": "grafana.integreatly.org", "controllerKind": "Grafana", "source": "kind source: *v1.Ingress"}
```

For now, this is the minimally necessary code to correctly format leader election logs.
But it could make sense to create an additional logger from the same options with a new name.
`controller-runtime.leases`