### PR TITLE
fix(GrafanaManifest): consider forbidden error as success when deleting manifests

### DIFF
--- a/controllers/manifest_controller.go
+++ b/controllers/manifest_controller.go
@@ -174,7 +174,11 @@ func (r *GrafanaManifestReconciler) finalize(ctx context.Context, cr *v1beta1.Gr
 
 		err = cl.Resource(gvr).Namespace(ns).Delete(ctx, cr.Spec.Template.Metadata.Name, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete resource: %w", err)
+			if apierrors.IsForbidden(err) {
+				log.Info("treating forbidden as delete success in case of invalid namespaces")
+			} else {
+				return fmt.Errorf("failed to delete resource: %w", err)
+			}
 		}
 
 		if err := instance.RemoveNamespacedResource(ctx, r.Client, cr); err != nil {


### PR DESCRIPTION
This fixes an issue in the newly implemented Grafana Manifest controller in which it was impossible to delete resources that had an invalid namespace set.

To reproduce the issue, create a GrafanaManifest like this:
```
---
apiVersion: grafana.integreatly.org/v1beta1
kind: GrafanaManifest
metadata:
  name: local-manifest-test
spec:
  instanceSelector:
    matchLabels:
      instance: "local-instance"
  template:
    apiVersion: playlist.grafana.app/v0alpha1
    kind: Playlist
    metadata:
      name: manifest-test
      namespace: some-invalid-namespace
    spec:
      interval: 5m
      items:
        - type: dashboard_by_uid
          value: 19f285e5-c42d-4007-b671-31d493686316
 
```
which has its `spec.template.metadata.namespace` set to an invalid (e.g nonexistant) namespace.

The operator adds the finalzer but can't remove it as the `DELETE` request returns `403/Forbidden`.

An alternative solution would be to prevent creation of the finalizer if the resource hasn't actually been created or the namespace doesn't exist. This would involve a more complex refactoring though as the finalizer logic is shared across controllers