### PR TITLE
fix(docs): unified_alerting.enabled type in multiple replicas example

### DIFF
--- a/examples/grafana/multiple_replicas/resources.yaml
+++ b/examples/grafana/multiple_replicas/resources.yaml
@@ -88,7 +88,7 @@ spec:
     # Configure HA for Grafana alerting
     # https://grafana.com/docs/grafana/latest/alerting/set-up/configure-high-availability/
     unified_alerting:
-      enabled: true
+      enabled: "true"
       ha_listen_address: "${POD_IP}:9094"
       ha_peers: "grafana-alerting:9094"
       ha_advertise_address: "${POD_IP}:9094"


### PR DESCRIPTION
* spec.config.unified_alerting.enabled: Invalid value: "boolean": spec.config.unified_alerting.enabled in body must be of type string: "boolean"

<!--

Thank you for investing your time in contributing to our project - we appreciate
it!

Please make sure to review our policy on code contributions:

The submitter is responsible for the code change, regardless of where that code
change came from, whether they wrote it themselves, used an "AI" or other tool,
or got it from someone else. That responsibility includes making sure that the
code change can be submitted under the Apache 2.0 license that we use.

The submitter needs to understand what code they are changing, what the change
does, and justify that change in the commit messages. Using coding assistants or
"AI" or other tools does not grant additional privileges or reduce our
expectations.

We'll get back to you once we had time to review your PR. If you want to discuss
your PR in a synchronous way, you can join our weekly sync call! The invite link
can be found in the README.md of the project
-->
