### PR TITLE
chore(workflows): use different cache key for test jobs

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -76,7 +76,7 @@ jobs:
           make test-image-pre-pull
 
       # NOTE: use separate cache, so it doesn't clash with e2e builds
-      - uses: actions/cache@v5
+      - uses: actions/cache@b7e8d49f17405cc70c1c120101943203c98d3a4b # v5
         with:
           path: |
             ~/.cache/go-build


### PR DESCRIPTION
- `workflows`:
  - at the moment, there's a cache clash between `e2e` and `test` jobs, so, in case an `e2e` job manages to save cache first, `test` jobs would be a few times slower to execute due to missing test and linter cache files. To mitigate that, adjusted `test` jobs to use different cache keys:
    - disabled caching in `actions-setup-go`;
    - added `actions/cache`:
      - in addition to the standard Go locations, included `~/.cache/golangci-lint`, so `golangrun-ci` can run faster as well;
    - placed `actions/setup-go` before "Pre-pull Grafana test image", so the latter doesn't pollute cache with Golang's toolchain modules (previously, there was _"go: downloading go1.25.6 (linux/amd64)"_ in logs). 