### PR TITLE
chore(golangci-lint): enforce custom error type helpers

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,6 +44,14 @@ linters:
     exhaustive:
       default-signifies-exhaustive: false
 
+    forbidigo:
+      forbid:
+        # Default pattern
+        - pattern: ^(fmt\.Print(|f|ln)|print|println)$
+        # Custom rules
+        - pattern: ^errors\.As(Type)?$
+          msg: Use IsErrorType or IsNotErrorType instead
+
     goconst:
       min-len: 3
       min-occurrences: 3

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -575,7 +575,7 @@ func UpdateStatus(ctx context.Context, cl client.Client, cr statusResource) {
 // IsErrorType finds the first error in err's tree that matches the type E, and
 // if one is found, returns true. Otherwise, false.
 func IsErrorType[E error](err error) bool {
-	if _, ok := errors.AsType[E](err); ok {
+	if _, ok := errors.AsType[E](err); ok { //nolint:forbidigo
 		return true
 	}
 


### PR DESCRIPTION
- `golangci-lint`:
  - extends the existing `forbidigo` configuration to enforce usage of the new `IsErrorType` / `IsNoErrorType` helpers.