### PR TITLE
chore(golangci-lint): block gomega imports

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ linters:
     - goconst
     - gocritic
     - gocyclo
+    - gomodguard
     - gosec
     - importas
     - makezero
@@ -70,6 +71,14 @@ linters:
 
     gocyclo:
       min-complexity: 25
+
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/onsi/gomega:
+              recommendations:
+                - github.com/stretchr/testify/assert
+                - github.com/stretchr/testify/require
 
     importas:
       no-unaliased: true


### PR DESCRIPTION
- `golangci-lint`:
  - added a rule to block `gomega` imports just in case someone tries to reintroduce it (I think we've had some PRs where that was the case).

Example of the generated output:

```shell
controllers/librarypanel_controller_test.go:16:2: import of package `github.com/onsi/gomega` is blocked because the module is in the blocked modules list. `github.com/stretchr/testify/assert` and `github.com/stretchr/testify/require` are recommended modules. (gomodguard)
        . "github.com/onsi/gomega"
        ^
1 issues:
* gomodguard: 1
make: *** [golangci-lint] Error 1
```