### PR TITLE
chore(github): add catch-all category to release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -20,3 +20,6 @@ changelog:
     - title: Documentation
       labels:
         - documentation
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
- `github`:
  - added catch-all category to the release template:
    - I think it's useful to have a catch-all category to highlight changes from PRs that didn't match any other category:
      - some PRs don't get labelled because of a non-standard branch name;
      - some of our internal changes might have user while being hidden from the release changelog;
      - at the moment, it's not that easy to track which changes are part of which release.