### PR TITLE
chore(labeler): add dependencies label for renovate PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,19 +1,19 @@
+bugfix:
+  - head-branch: ['^fix', 'fix', '^bugfix']
+
+chore:
+  - head-branch: ['^chore', '^ci', ^refactor]
+
+dependencies:
+  - head-branch: ['^renovate']
+
 documentation:
 - changed-files:
   - any-glob-to-any-file: docs/**
   - any-glob-to-any-file: examples/**
 
 feature:
- - head-branch: ['^feature', 'feature', '^feat']
-
-bugfix:
- - head-branch: ['^fix', 'fix', '^bugfix']
-
-chore:
- - head-branch: ['^chore', '^ci', ^refactor]
-
-dependencies:
-  - head-branch: ['^renovate']
+  - head-branch: ['^feature', 'feature', '^feat']
 
 test:
- - head-branch: ['^test']
+  - head-branch: ['^test']


### PR DESCRIPTION
- `labeler`:
  - reconfigured to add `dependencies` label for renovate PRs:
    - we have the `dependencies` section in the release template, but the label itself does not get automatically assigned, thus the PR;
  - reordered and reformatted config.