### PR TITLE
chore(github): adjust list of ignored changes in release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,6 @@
 changelog:
   exclude:
     labels:
-      - chore
-      - refactor
       - release-ignore
   categories:
     - title: Breaking changes


### PR DESCRIPTION
- `github`:
  - reconfigured release template to exclude only PRs marked with `release-ignore` label. - `chore` is handy to be listed under "Other changes", `refactor` is unused.