### PR TITLE
chore(renovate): automatically add release-ignore label for certain deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,25 @@
     "ghcr.io/grafana/grafana-operator",
     "github.com/openshift/api"
   ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchDepNames": [
+        "fybrik/crdoc",
+        "golangci/golangci-lint",
+        "google/go-containerregistry",
+        "kyverno/chainsaw",
+        "mikefarah/yq",
+        "norwoodj/helm-docs"
+      ],
+      "addLabels": ["release-ignore"]
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
- `renovate`:
  - added a package rule that should make renovate automatically add `release-ignore` label to PRs for certain dependencies:
    - the exact list of deps to "ignore" is arguable, my suggestion would be to start with these as they should not impact any user-facing functionality: `fybrik/crdoc`, `golangci/golangci-lint`, `google/go-containerregistry`, `kyverno/chainsaw`, `mikefarah/yq`, `norwoodj/helm-docs`.

**NOTE:** I'm not sure how to locally test that, so it might not work :) (debug logs do not show which label a PR would be opened with)