### PR TITLE
chore(github): exclude github-actions label in release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,7 @@
 changelog:
   exclude:
     labels:
+      - github-actions
       - release-ignore
   categories:
     - title: Breaking changes


### PR DESCRIPTION
- `github`:
  - reconfigured release template to exclude PRs marked with `github-actions` label. - Unlike with toolchain, it's not easy to extend renovate configuration to add `release-ignore` label (#2518), because the configuration itself is not visible to us (inherited from Grafana). So, the easiest solution is to simply rely on the `github-actions` label that renovate already assigns. 