### PR TITLE
chore(tk8s): switch testcontainers probes to /api/health endpoint

### DIFF
--- a/pkg/tk8s/containers.go
+++ b/pkg/tk8s/containers.go
@@ -17,7 +17,7 @@ func GetGrafanaTestContainer(t tHelper, ctx context.Context, image string) testc
 			"3000/tcp",
 		),
 		testcontainers.WithAdditionalWaitStrategy(
-			wait.ForHTTP("/").WithStartupTimeout(10*time.Second),
+			wait.ForHTTP("/api/health").WithStartupTimeout(10*time.Second),
 		),
 	)
 


### PR DESCRIPTION
- `tk8s`:
  - tiny change around `GetGrafanaTestContainer`:
    - it's better to use `/api/health` for startup checks as it validates DB availability. The same endpoint is used in readiness checks in various helm charts.