### PR TITLE
chore(workflows): drop support for k8s v1.32

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -147,8 +147,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: v1.32.11
-            grafana_version: "10.4.5"
           - version: v1.33.7
             grafana_version: "10.4.5"
           - version: v1.34.3


### PR DESCRIPTION
- workflows:
  - dropped tests for k8s v1.32 as it reached its EOL on the 28th of February ([docs](https://kubernetes.io/releases/#release-v1-32)).