### PR TITLE
chore(go): bump to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-operator/v5
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
- Go:
  - bumped version to 1.26.1.