### PR TITLE
chore(test): Extend Grafana testcontainer wait time

### DIFF
--- a/pkg/tk8s/containers.go
+++ b/pkg/tk8s/containers.go
@@ -17,7 +17,7 @@ func GetGrafanaTestContainer(t tHelper, ctx context.Context, image string) testc
 			"3000/tcp",
 		),
 		testcontainers.WithAdditionalWaitStrategy(
-			wait.ForHTTP("/api/health").WithStartupTimeout(10*time.Second),
+			wait.ForHTTP("/api/health").WithStartupTimeout(15*time.Second),
 		),
 	)
 


### PR DESCRIPTION
With the recent versions of Grafana being slightly slower, I'm starting to see some flaky test runs locally due to the timeout.