### PR TITLE
fix(logging): `--zap-devel=true` does not enable debug logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,6 +147,10 @@ func configureZap() (zap.Options, error) {
 			return opts, fmt.Errorf("invalid log level: %w", err)
 		}
 
+		if opts.Development {
+			level = zapcore.DebugLevel
+		}
+
 		opts.Level = level
 	}
 


### PR DESCRIPTION
Minor oversight when we translated the Zap cli flags to Kong.
Now `make run` prints debug logs again!