### PR TITLE
fix(Helm RBAC): Remove extra rolebinding when `namespaceScope=true` is set without `watchNamespaces`

### DIFF
--- a/deploy/helm/grafana-operator/templates/rbac.yaml
+++ b/deploy/helm/grafana-operator/templates/rbac.yaml
@@ -31,6 +31,7 @@ rules:
 {{- if .Values.namespaceScope }}
 {{- $watchNamespaces := append (splitList "," .Values.watchNamespaces) (include "grafana-operator.namespace" $) }}
 {{- range $watchNamespaces }}
+{{- if trim . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -48,6 +49,7 @@ roleRef:
   kind: ClusterRole
   name: {{ include "grafana-operator.fullname" $ }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}{{- /* range $watchNamespaces */}}
 
 {{- else }}{{- /* namespaceScope */}}


### PR DESCRIPTION
Found an edge case while testing #2565. When `namespaceScope: true` and watchNamespaces is not set, a rolebinding is created without namespace.

`helm template -n grafana grafana-operator deploy/helm/grafana-operator -s templates/rbac.yaml --set namespaceScope=true`

```yaml
# Output omitted for brevity
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: grafana-operator
  namespace:             # <-- This is empty?
  labels:
    helm.sh/chart: grafana-operator-5.22.0
    app.kubernetes.io/name: grafana-operator
    app.kubernetes.io/instance: grafana-operator
    app.kubernetes.io/version: "v5.22.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: grafana-operator
    app.kubernetes.io/component: operator
subjects:
  - kind: ServiceAccount
    name: grafana-operator
    namespace: grafana
roleRef:
  kind: ClusterRole
  name: grafana-operator
  apiGroup: rbac.authorization.k8s.io
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: grafana-operator
  namespace: grafana      # <-- Has a value
  labels:
    helm.sh/chart: grafana-operator-5.22.0
    app.kubernetes.io/name: grafana-operator
    app.kubernetes.io/instance: grafana-operator
    app.kubernetes.io/version: "v5.22.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: grafana-operator
    app.kubernetes.io/component: operator
subjects:
  - kind: ServiceAccount
    name: grafana-operator
    namespace: grafana
roleRef:
  kind: ClusterRole
  name: grafana-operator
  apiGroup: rbac.authorization.k8s.io
```

But the issue disappears when a set of `watchNamespaces` is also supplied:
`helm template -n grafana grafana-operator deploy/helm/grafana-operator -s templates/rbac.yaml --set namespaceScope=true --values - <<<'watchNamespaces: "one, two, three"'`

Helm does not handle array values as cli options well, hence the `herestring`.

It turns out that `splitList` is always an array of one item empty string, which the operators namespace is then appended to:
```
{{- $watchNamespaces := append (splitList "," .Values.watchNamespaces) (include "grafana-operator.namespace" $) }}
```

Which can be alternatively be fixed by splitting the line into:
```yaml
{{- $watchNamespaces := list }}
{{- if trim .Values.watchNamespaces }}
{{- $watchNamespaces = splitList "," .Values.watchNamespaces
{{- end }}
{{- $watchNamespaces := append $watchNamespaces (include "grafana-operator.namespace" $) }}
```