### PR TITLE
grouping renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,16 @@
   ],
   "packageRules": [
     {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "github-actions (non-major)"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "go-dependencies (non-major)"
+    },
+    {
       "matchManagers": [
         "custom.regex"
       ],


### PR DESCRIPTION
This should lower the amount of noice for the maintainers. Major versions will still get it's own PR.
The bad thing with this is that 0-ver apps will still show as minor.