### PR TITLE
feat: expose leader election timing configuration via env vars and CLI flags

### DIFF
--- a/examples/common_options/_index.md
+++ b/examples/common_options/_index.md
@@ -157,6 +157,54 @@ status:
 
 When `.spec.suspend` is `true` The Operator will ignore any changes where they are normally synchronized immediately.
 
+## Leader election tuning
+
+When leader election is enabled (`--leader-elect` / `ENABLE_LEADER_ELECTION=true`), the operator uses controller-runtime's default timing of 15s lease / 10s renew / 2s retry. These defaults assume low-latency API server access and may be unsuitable for environments with elevated API server or etcd latency.
+
+The following options allow tuning the leader election timing parameters via CLI flags or environment variables:
+
+| CLI Flag | Environment Variable | Default | Description |
+|----------|---------------------|---------|-------------|
+| `--leader-election-lease-duration` | `LEADER_ELECTION_LEASE_DURATION` | 15s (controller-runtime) | Duration that non-leader candidates wait before force-acquiring leadership |
+| `--leader-election-renew-deadline` | `LEADER_ELECTION_RENEW_DEADLINE` | 10s (controller-runtime) | Duration that the leader retries refreshing before giving up |
+| `--leader-election-retry-period` | `LEADER_ELECTION_RETRY_PERIOD` | 2s (controller-runtime) | Duration between each leadership acquisition/renewal attempt |
+
+Setting any value to `0s` (or omitting it) leaves the controller-runtime default in place.
+
+**Constraints:**
+- `lease-duration` must be greater than `renew-deadline`
+- `renew-deadline` must be greater than `retry-period`
+
+### Example: Environment variables (OLM / Subscription)
+
+For OLM-managed deployments, timing can be configured via `Subscription.spec.config.env` without modifying the Deployment or CSV directly:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: grafana-operator
+spec:
+  config:
+    env:
+      - name: LEADER_ELECTION_LEASE_DURATION
+        value: "60s"
+      - name: LEADER_ELECTION_RENEW_DEADLINE
+        value: "40s"
+      - name: LEADER_ELECTION_RETRY_PERIOD
+        value: "10s"
+```
+
+### Example: CLI flags
+
+```bash
+grafana-operator \
+  --leader-elect \
+  --leader-election-lease-duration=60s \
+  --leader-election-renew-deadline=40s \
+  --leader-election-retry-period=10s
+```
+
 ## Using a proxy server
 
 The Operator can use a proxy server when fetching URL-based / Grafana.com dashboards or making requests to external Grafana instances.

--- a/main.go
+++ b/main.go
@@ -86,12 +86,15 @@ var operatorConfig struct {
 	WatchLabelSelectors    string `env:"WATCH_LABEL_SELECTORS"                                       help:"The resources to watch according to their labels. e.g. 'partition in (customerA, customerB),environment!=qa'. If empty of undefined, the operator will watch all CRs."`
 	CachingLevel           string `env:"ENFORCE_CACHE_LABELS"     default:"safe" enum:"all,safe,off" help:"Configure cache limits. Valid values are 'off', 'safe' and 'all'"`
 
-	MetricsAddr             string        `name:"metrics-bind-address"      default:":8080"                                 help:"The address the metric endpoint binds to."`
-	ProbeAddr               string        `name:"health-probe-bind-address" default:":8081"                                 help:"The address the probe endpoint binds to."`
-	PprofAddr               string        `name:"pprof-addr"                                                                help:"The address to expose the pprof server. Empty string disables the pprof server."`
-	EnableLeaderElection    bool          `name:"leader-elect"              default:"false" env:"ENABLE_LEADER_ELECTION"    help:"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager."`
-	MaxConcurrentReconciles int           `name:"max-concurrent-reconciles" default:"1"     env:"MAX_CONCURRENT_RECONCILES" help:"Maximum number of concurrent reconciles for dashboard, datasource, folder controllers."`
-	ResyncPeriod            time.Duration `name:"default-resync-period"     default:"10m"   env:"DEFAULT_RESYNC_PERIOD"     help:"Controls the default .spec.resyncPeriod when undefined on CRs."`
+	MetricsAddr                 string        `name:"metrics-bind-address"      default:":8080"                                 help:"The address the metric endpoint binds to."`
+	ProbeAddr                   string        `name:"health-probe-bind-address" default:":8081"                                 help:"The address the probe endpoint binds to."`
+	PprofAddr                   string        `name:"pprof-addr"                                                                help:"The address to expose the pprof server. Empty string disables the pprof server."`
+	EnableLeaderElection        bool          `name:"leader-elect"                      default:"false" env:"ENABLE_LEADER_ELECTION"              help:"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager."`
+	LeaderElectionLeaseDuration time.Duration `name:"leader-election-lease-duration"     default:"0s"    env:"LEADER_ELECTION_LEASE_DURATION"      help:"Duration that non-leader candidates will wait to force acquire leadership. Defaults to 15s from controller-runtime when unset (0s)."`
+	LeaderElectionRenewDeadline time.Duration `name:"leader-election-renew-deadline"     default:"0s"    env:"LEADER_ELECTION_RENEW_DEADLINE"      help:"Duration that the acting leader will retry refreshing leadership before giving up. Defaults to 10s from controller-runtime when unset (0s)."`
+	LeaderElectionRetryPeriod   time.Duration `name:"leader-election-retry-period"       default:"0s"    env:"LEADER_ELECTION_RETRY_PERIOD"        help:"Duration between each leadership acquisition/renewal attempt. Defaults to 2s from controller-runtime when unset (0s)."`
+	MaxConcurrentReconciles     int           `name:"max-concurrent-reconciles"          default:"1"     env:"MAX_CONCURRENT_RECONCILES"           help:"Maximum number of concurrent reconciles for dashboard, datasource, folder controllers."`
+	ResyncPeriod                time.Duration `name:"default-resync-period"              default:"10m"   env:"DEFAULT_RESYNC_PERIOD"               help:"Controls the default .spec.resyncPeriod when undefined on CRs."`
 
 	ZapDevel           bool   `name:"zap-devel"            default:"false"                                                         help:"Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn)"`
 	ZapEncoder         string `name:"zap-encoder"          default:"console" enum:"console,json"                                   help:"Zap log encoding ('json' or 'console')"`
@@ -234,6 +237,11 @@ func main() { //nolint:gocyclo
 		Controller: config.Controller{
 			MaxConcurrentReconciles: operatorConfig.MaxConcurrentReconciles,
 		},
+	}
+
+	if err := applyLeaderElectionTiming(&mgrOptions); err != nil {
+		setupLog.Error(err, "invalid leader election timing configuration")
+		os.Exit(1)
 	}
 
 	// A non-empty watchLabelSelector will attempt to enable sharding of the operator.
@@ -514,6 +522,45 @@ func getNamespaceConfigSelector(ctx context.Context, restConfig *rest.Config, se
 	}
 
 	return defaultNamespaces
+}
+
+func applyLeaderElectionTiming(opts *ctrl.Options) error {
+	lease := operatorConfig.LeaderElectionLeaseDuration
+	renew := operatorConfig.LeaderElectionRenewDeadline
+	retry := operatorConfig.LeaderElectionRetryPeriod
+
+	if lease == 0 && renew == 0 && retry == 0 {
+		return nil
+	}
+
+	if lease < 0 || renew < 0 || retry < 0 {
+		return fmt.Errorf("leader election durations must be positive: lease=%v, renew=%v, retry=%v", lease, renew, retry)
+	}
+
+	if lease > 0 && renew > 0 && lease <= renew {
+		return fmt.Errorf("lease duration (%v) must be greater than renew deadline (%v)", lease, renew)
+	}
+
+	if renew > 0 && retry > 0 && renew <= retry {
+		return fmt.Errorf("renew deadline (%v) must be greater than retry period (%v)", renew, retry)
+	}
+
+	if lease > 0 {
+		opts.LeaseDuration = &lease
+		setupLog.Info("overriding leader election lease duration", "leaseDuration", lease)
+	}
+
+	if renew > 0 {
+		opts.RenewDeadline = &renew
+		setupLog.Info("overriding leader election renew deadline", "renewDeadline", renew)
+	}
+
+	if retry > 0 {
+		opts.RetryPeriod = &retry
+		setupLog.Info("overriding leader election retry period", "retryPeriod", retry)
+	}
+
+	return nil
 }
 
 func getLabelSelectors(watchLabelSelectors string) (labels.Selector, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func TestApplyLeaderElectionTiming_AllZero(t *testing.T) {
+	operatorConfig.LeaderElectionLeaseDuration = 0
+	operatorConfig.LeaderElectionRenewDeadline = 0
+	operatorConfig.LeaderElectionRetryPeriod = 0
+
+	opts := ctrl.Options{}
+	if err := applyLeaderElectionTiming(&opts); err != nil {
+		t.Fatalf("expected no error for all-zero (unset) values, got: %v", err)
+	}
+	if opts.LeaseDuration != nil || opts.RenewDeadline != nil || opts.RetryPeriod != nil {
+		t.Fatal("expected nil pointers when no overrides are set")
+	}
+}
+
+func TestApplyLeaderElectionTiming_AllSet(t *testing.T) {
+	operatorConfig.LeaderElectionLeaseDuration = 60 * time.Second
+	operatorConfig.LeaderElectionRenewDeadline = 40 * time.Second
+	operatorConfig.LeaderElectionRetryPeriod = 10 * time.Second
+
+	opts := ctrl.Options{}
+	if err := applyLeaderElectionTiming(&opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.LeaseDuration == nil || *opts.LeaseDuration != 60*time.Second {
+		t.Fatalf("expected LeaseDuration=60s, got %v", opts.LeaseDuration)
+	}
+	if opts.RenewDeadline == nil || *opts.RenewDeadline != 40*time.Second {
+		t.Fatalf("expected RenewDeadline=40s, got %v", opts.RenewDeadline)
+	}
+	if opts.RetryPeriod == nil || *opts.RetryPeriod != 10*time.Second {
+		t.Fatalf("expected RetryPeriod=10s, got %v", opts.RetryPeriod)
+	}
+}
+
+func TestApplyLeaderElectionTiming_PartialOverride(t *testing.T) {
+	operatorConfig.LeaderElectionLeaseDuration = 30 * time.Second
+	operatorConfig.LeaderElectionRenewDeadline = 0
+	operatorConfig.LeaderElectionRetryPeriod = 0
+
+	opts := ctrl.Options{}
+	if err := applyLeaderElectionTiming(&opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.LeaseDuration == nil || *opts.LeaseDuration != 30*time.Second {
+		t.Fatalf("expected LeaseDuration=30s, got %v", opts.LeaseDuration)
+	}
+	if opts.RenewDeadline != nil {
+		t.Fatal("expected RenewDeadline to remain nil for partial override")
+	}
+	if opts.RetryPeriod != nil {
+		t.Fatal("expected RetryPeriod to remain nil for partial override")
+	}
+}
+
+func TestApplyLeaderElectionTiming_NegativeValue(t *testing.T) {
+	operatorConfig.LeaderElectionLeaseDuration = -5 * time.Second
+	operatorConfig.LeaderElectionRenewDeadline = 0
+	operatorConfig.LeaderElectionRetryPeriod = 0
+
+	opts := ctrl.Options{}
+	if err := applyLeaderElectionTiming(&opts); err == nil {
+		t.Fatal("expected error for negative lease duration")
+	}
+}
+
+func TestApplyLeaderElectionTiming_LeaseNotGreaterThanRenew(t *testing.T) {
+	operatorConfig.LeaderElectionLeaseDuration = 10 * time.Second
+	operatorConfig.LeaderElectionRenewDeadline = 10 * time.Second
+	operatorConfig.LeaderElectionRetryPeriod = 2 * time.Second
+
+	opts := ctrl.Options{}
+	if err := applyLeaderElectionTiming(&opts); err == nil {
+		t.Fatal("expected error when lease duration equals renew deadline")
+	}
+}
+
+func TestApplyLeaderElectionTiming_RenewNotGreaterThanRetry(t *testing.T) {
+	operatorConfig.LeaderElectionLeaseDuration = 30 * time.Second
+	operatorConfig.LeaderElectionRenewDeadline = 5 * time.Second
+	operatorConfig.LeaderElectionRetryPeriod = 5 * time.Second
+
+	opts := ctrl.Options{}
+	if err := applyLeaderElectionTiming(&opts); err == nil {
+		t.Fatal("expected error when renew deadline equals retry period")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `LEADER_ELECTION_LEASE_DURATION`, `LEADER_ELECTION_RENEW_DEADLINE`, and `LEADER_ELECTION_RETRY_PERIOD` environment variables (and corresponding `--leader-election-*` CLI flags) to allow tuning controller-runtime leader election timing
- Validate constraints at startup (lease > renew > retry, all positive) with clear error messages
- When unset (`0s`), controller-runtime defaults (15s / 10s / 2s) are preserved — fully backwards compatible

## Motivation

In OLM-managed deployments on OpenShift, the operator runs as a single replica with leader election enabled (via CSV). Under cluster pressure conditions (elevated API server latency, etcd storage pressure), the default 15s/10s/2s leader election timing causes:

- Lease renewal failures: `failed to renew lease: context deadline exceeded`
- Leadership loss and operator restarts
- Reconciliation interruptions across all managed resources

Since OLM controls the Deployment, users cannot easily tune these parameters without patching the CSV or Deployment directly — changes that are not durable across OLM reconciliation or upgrades.

This PR exposes the timing parameters through environment variables that can be set via `Subscription.spec.config.env`, which is the OLM-supported mechanism for operator configuration:

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: grafana-operator
spec:
  config:
    env:
      - name: LEADER_ELECTION_LEASE_DURATION
        value: "60s"
      - name: LEADER_ELECTION_RENEW_DEADLINE
        value: "40s"
      - name: LEADER_ELECTION_RETRY_PERIOD
        value: "10s"
```

## Changes

| File | Change |
|------|--------|
| `main.go` | Add 3 config fields to `operatorConfig` struct; add `applyLeaderElectionTiming()` with validation and logging |
| `main_test.go` | 6 unit tests covering: all-zero (no-op), all-set, partial override, negative values, lease≤renew, renew≤retry |
| `examples/common_options/_index.md` | Document new options with constraint rules, OLM Subscription example, and CLI example |

## Design decisions

1. **Zero-value sentinel** — `0s` means "not configured", leaving the controller-runtime default in place. This is safe because a 0-duration lease/renew/retry is never valid.
2. **Partial overrides allowed** — Users can tune just one parameter (e.g. only increase lease duration) while leaving others at defaults.
3. **Validation at startup** — Invalid combinations (lease ≤ renew, renew ≤ retry, negative values) cause a clear error and exit rather than cryptic runtime failures.
4. **Kong tags** — Follow the existing pattern (`name`, `default`, `env`, `help`) used by `EnableLeaderElection`, `ResyncPeriod`, etc.

## Test plan

- [x] `go vet .` passes
- [x] `go fmt` clean
- [x] All 6 unit tests pass:
  - `TestApplyLeaderElectionTiming_AllZero` — no-op when unset
  - `TestApplyLeaderElectionTiming_AllSet` — all three overrides applied
  - `TestApplyLeaderElectionTiming_PartialOverride` — only lease set, others nil
  - `TestApplyLeaderElectionTiming_NegativeValue` — rejects negative durations
  - `TestApplyLeaderElectionTiming_LeaseNotGreaterThanRenew` — rejects lease ≤ renew
  - `TestApplyLeaderElectionTiming_RenewNotGreaterThanRetry` — rejects renew ≤ retry
- [ ] Verify `--help` output shows new flags with descriptions
- [ ] E2E: deploy with env vars set, confirm operator starts with overridden timing in logs

Closes #2651

Made with [Cursor](https://cursor.com)