### PR TITLE
fix(grafana): do not propagate applyset labels to child resources

### DIFF
--- a/controllers/resources/labels.go
+++ b/controllers/resources/labels.go
@@ -2,9 +2,12 @@ package resources
 
 import (
 	"maps"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const ignoredLabelsPrefix = "applyset.kubernetes.io/"
 
 func GetCommonLabels() map[string]string {
 	return map[string]string{
@@ -20,7 +23,15 @@ func SetInheritedLabels(obj metav1.ObjectMetaAccessor, inheritedLabels map[strin
 		labels = make(map[string]string)
 	}
 
-	maps.Copy(labels, inheritedLabels)
+	for k, v := range inheritedLabels {
+		// https://github.com/grafana/grafana-operator/issues/2642
+		if strings.HasPrefix(k, ignoredLabelsPrefix) {
+			continue
+		}
+
+		labels[k] = v
+	}
+
 	maps.Copy(labels, GetCommonLabels())
 
 	meta.SetLabels(labels)

--- a/controllers/resources/labels_test.go
+++ b/controllers/resources/labels_test.go
@@ -1,0 +1,73 @@
+package resources
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetInheritedLabels(t *testing.T) {
+	tests := []struct {
+		name            string
+		labels          map[string]string
+		inheritedLabels map[string]string
+		want            map[string]string // NOTE: will get merged with GetCommonLabels
+	}{
+		{
+			name:            "nil",
+			labels:          nil,
+			inheritedLabels: nil,
+			want:            map[string]string{},
+		},
+		{
+			name: "existing and inherited labels are merged",
+			labels: map[string]string{
+				"existing": "ex",
+			},
+			inheritedLabels: map[string]string{
+				"inherited": "in",
+			},
+			want: map[string]string{
+				"existing":  "ex",
+				"inherited": "in",
+			},
+		},
+		{
+			name: "applyset labels are ignored",
+			labels: map[string]string{
+				"existing": "ex",
+			},
+			inheritedLabels: map[string]string{
+				"inherited":                      "in",
+				"applyset.kubernetes.io/part-of": "applyset-abc",
+			},
+			want: map[string]string{
+				"existing":  "ex",
+				"inherited": "in",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// To replicate SetInheritedLabels() behavior
+			maps.Copy(tt.want, GetCommonLabels())
+
+			obj := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service",
+					Namespace: "default",
+					Labels:    tt.labels,
+				},
+			}
+
+			SetInheritedLabels(obj, tt.inheritedLabels)
+			got := obj.GetLabels()
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
- `controllers/resources`:
  - to improve compatibility with kubectl's [ApplySets](https://kubernetes.io/blog/2023/05/09/introducing-kubectl-applyset-pruning/), all parent labels prefixed with `applyset.kubernetes.io/` are ignored now.

**NOTE:** over 3 years ago, `kubectl` used `applyset.k8s.io/` as a prefix ([commit](https://github.com/kubernetes/kubectl/commit/03f092a1afae3ed4653512715e5a5377815faa28#diff-932935382ae79ec6eee821ad3e1f2fdb7a3a37f585d6a8fc35747ca1bce7ba74)), but I think it's not worth supporting. - It's far behind our EOL policies.

Fixes: #2642