### PR TITLE
fix: only cache contents on successful apply

### DIFF
--- a/controllers/content/cache/cache.go
+++ b/controllers/content/cache/cache.go
@@ -1,9 +1,13 @@
 package cache
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetContentCache(cr v1beta1.GrafanaContentResource) []byte {
@@ -37,4 +41,34 @@ func getContentCache(in *v1beta1.GrafanaContentStatus, url string, cacheDuration
 	}
 
 	return cache
+}
+
+func SetContentCache(cr v1beta1.GrafanaContentResource, data map[string]any) error {
+	spec := cr.GrafanaContentSpec()
+	status := cr.GrafanaContentStatus()
+
+	return setContentCache(status, spec.URL, data, spec.ContentCacheDuration.Duration)
+}
+
+func setContentCache(in *v1beta1.GrafanaContentStatus, url string, data map[string]any, cacheDuration time.Duration) error {
+	notExpired := cacheDuration <= 0 || in.ContentTimestamp.Add(cacheDuration).After(time.Now())
+	if notExpired && in.ContentURL == url {
+		return nil
+	}
+
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshaling content: %w", err)
+	}
+
+	gz, err := Gzip(encoded)
+	if err != nil {
+		return fmt.Errorf("compressing content: %w", err)
+	}
+
+	in.ContentCache = gz
+	in.ContentTimestamp = metav1.Time{Time: time.Now()}
+	in.ContentURL = url
+
+	return nil
 }

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -92,3 +92,79 @@ func TestGrafanaDashboardStatus_getContentCache(t *testing.T) {
 		})
 	}
 }
+
+func TestSetContentCache(t *testing.T) {
+	exampleURL := "http://localhost:8080/example.json"
+
+	t.Run("no cache: cache is populated", func(t *testing.T) {
+		status := v1beta1.GrafanaContentStatus{}
+		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, time.Hour)
+		require.NoError(t, err)
+
+		// content timestamp should be now
+		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
+
+		// url should be updated
+		assert.Equal(t, exampleURL, status.ContentURL)
+
+		// cached content should be retrievable
+		retrieved := getContentCache(&status, exampleURL, -1)
+		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
+	})
+
+	t.Run("existing valid cache: cache is not updated", func(t *testing.T) {
+		prevTime := time.Now().Add(-time.Minute * 5)
+		status := v1beta1.GrafanaContentStatus{
+			ContentURL:       exampleURL,
+			ContentCache:     []byte{1, 2, 3}, // sentinel value that should stay the same
+			ContentTimestamp: metav1.NewTime(prevTime),
+		}
+		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, time.Hour)
+		require.NoError(t, err)
+
+		// content timestamp should remain at prevTime
+		assert.Equal(t, prevTime, status.ContentTimestamp.Time)
+
+		// cached content should stay the same
+		assert.Equal(t, []byte{1, 2, 3}, status.ContentCache)
+	})
+
+	t.Run("existing old cache: cache is updated", func(t *testing.T) {
+		prevTime := time.Now().Add(-time.Hour * 5)
+		status := v1beta1.GrafanaContentStatus{
+			ContentURL:       exampleURL,
+			ContentCache:     []byte{1, 2, 3},
+			ContentTimestamp: metav1.NewTime(prevTime),
+		}
+		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, time.Hour)
+		require.NoError(t, err)
+
+		// content timestamp should be now
+		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
+
+		// cached content should be retrievable
+		retrieved := getContentCache(&status, exampleURL, -1)
+		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
+	})
+
+	t.Run("existing valid cache with wrong url: cache is updated", func(t *testing.T) {
+		prevTime := time.Now().Add(-time.Minute * 5)
+		status := v1beta1.GrafanaContentStatus{
+			ContentURL:       "http://localhost:8080/some-other.json",
+			ContentCache:     []byte{1, 2, 3},
+			ContentTimestamp: metav1.NewTime(prevTime),
+		}
+		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, time.Hour)
+		require.NoError(t, err)
+
+		// content timestamp should be now
+		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
+
+		// url should be updated
+		assert.Equal(t, exampleURL, status.ContentURL)
+
+		// cached content should be retrievable
+		retrieved := getContentCache(&status, exampleURL, -1)
+		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
+	})
+}

--- a/controllers/content/fetchers/grafana_com_fetcher_test.go
+++ b/controllers/content/fetchers/grafana_com_fetcher_test.go
@@ -28,7 +28,4 @@ func TestFetchDashboardFromGrafanaCom(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, fetchedDashboard, "Fetched dashboard shouldn't be empty")
 	assert.GreaterOrEqual(t, *dashboard.Spec.GrafanaCom.Revision, 42, "At least 42 revisions exist for dashboard 1860 as of 2024-12-22")
-
-	assert.False(t, dashboard.Status.ContentTimestamp.Time.IsZero(), "ContentTimestamp should have been set")
-	assert.NotEmpty(t, dashboard.Status.ContentURL, "ContentURL should have been set")
 }

--- a/controllers/content/fetchers/url_fetcher.go
+++ b/controllers/content/fetchers/url_fetcher.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -16,8 +15,6 @@ import (
 	"github.com/grafana/grafana-operator/v5/controllers/content/cache"
 	"github.com/grafana/grafana-operator/v5/controllers/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func FetchFromURL(ctx context.Context, cr v1beta1.GrafanaContentResource, cl client.Client, tlsConfig *tls.Config) ([]byte, error) {
@@ -89,16 +86,6 @@ func FetchFromURL(ctx context.Context, cr v1beta1.GrafanaContentResource, cl cli
 	if err != nil {
 		return []byte{}, err
 	}
-
-	gz, err := cache.Gzip(content)
-	if err != nil {
-		return []byte{}, fmt.Errorf("failed to gzip dashboard %v", cr.GetName())
-	}
-
-	status := cr.GrafanaContentStatus()
-	status.ContentCache = gz
-	status.ContentTimestamp = metav1.Time{Time: time.Now()}
-	status.ContentURL = spec.URL
 
 	return content, nil
 }

--- a/controllers/content/fetchers/url_fetcher_test.go
+++ b/controllers/content/fetchers/url_fetcher_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
-	"github.com/grafana/grafana-operator/v5/controllers/content/cache"
 	"github.com/grafana/grafana-operator/v5/pkg/tk8s"
 )
 
@@ -53,9 +52,6 @@ func getCredentials(t *testing.T, secretName string) (*corev1.Secret, *v1beta1.G
 
 func TestFetchFromURL(t *testing.T) {
 	want := []byte(`{"dummyField": "dummyData"}`)
-	wantCompressed, err := cache.Gzip(want)
-
-	require.NoError(t, err)
 
 	publicEndpoint := "/public"
 	privateEndpoint := "/private"
@@ -100,9 +96,6 @@ func TestFetchFromURL(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, want, got)
-		assert.Equal(t, wantCompressed, dashboard.Status.ContentCache)
-		assert.Equal(t, url, dashboard.Status.ContentURL)
-		assert.NotZero(t, dashboard.Status.ContentTimestamp.Time)
 	})
 
 	t.Run("using authentication", func(t *testing.T) {
@@ -124,15 +117,12 @@ func TestFetchFromURL(t *testing.T) {
 			Status: v1beta1.GrafanaDashboardStatus{},
 		}
 
-		err = cl.Create(context.Background(), credentialsSecret)
+		err := cl.Create(context.Background(), credentialsSecret)
 		require.NoError(t, err)
 
 		got, err := FetchFromURL(context.Background(), dashboard, cl, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, want, got)
-		assert.Equal(t, wantCompressed, dashboard.Status.ContentCache)
-		assert.Equal(t, url, dashboard.Status.ContentURL)
-		assert.NotZero(t, dashboard.Status.ContentTimestamp.Time)
 	})
 }

--- a/controllers/content/resolver.go
+++ b/controllers/content/resolver.go
@@ -220,3 +220,15 @@ func (h *Resolver) getContentModel(contentJSON []byte) (map[string]any, string, 
 
 	return contentModel, fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
+
+func (h *Resolver) UpdateCache(model map[string]any) error {
+	// GetSourceTypes needs to be of length 1 for this function to even be called
+	sourceType := GetSourceTypes(h.resource)[0]
+
+	// only cache remote resources
+	if sourceType != SourceTypeURL && sourceType != SourceTypeGrafanaCom {
+		return nil
+	}
+
+	return cache.SetContentCache(h.resource, model)
+}

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -65,6 +65,7 @@ const (
 	LogMsgRunningFinalizer    = "failed to finalize CR"
 	LogMsgRemoveFinalizer     = "failed to remove finalizer"
 	LogMsgApplyErrors         = "failed to sync CR to all Grafana instances"
+	LogMsgUpdateCache         = "failed to update cache for remote resource"
 
 	DbgMsgFoundMatchingInstances = "found matching Grafana instances"
 

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -104,22 +104,6 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	removeSuspended(&cr.Status.Conditions)
 
-	// Retrieving the model before the loop ensures to exit early in case of failure and not fail once per matching instance
-	resolver := content.NewResolver(cr, r.Client)
-
-	dashboardModel, hash, err := resolver.Resolve(ctx)
-	if err != nil {
-		// Resolve has a lot of failure cases.
-		// fetch content errors could be a temporary network issue but would result in an InvalidSpec condition
-		setInvalidSpec(&cr.Status.Conditions, cr.Generation, conditionReasonInvalidModelResolution, err.Error())
-		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDashboardSynchronized)
-		log.Error(err, LogMsgResolvingDashboardContents)
-
-		return ctrl.Result{}, fmt.Errorf("%s: %w", LogMsgResolvingDashboardContents, err)
-	}
-
-	removeInvalidSpec(&cr.Status.Conditions)
-
 	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
 	if err != nil {
 		cr.Status.NoMatchingInstances = true
@@ -142,6 +126,22 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	cr.Status.NoMatchingInstances = false
 	removeNoMatchingInstance(&cr.Status.Conditions)
 	log.V(1).Info(DbgMsgFoundMatchingInstances, "count", len(instances))
+
+	// Retrieving the model before the loop ensures to exit early in case of failure and not fail once per matching instance
+	resolver := content.NewResolver(cr, r.Client)
+
+	dashboardModel, hash, err := resolver.Resolve(ctx)
+	if err != nil {
+		// Resolve has a lot of failure cases.
+		// fetch content errors could be a temporary network issue but would result in an InvalidSpec condition
+		setInvalidSpec(&cr.Status.Conditions, cr.Generation, conditionReasonInvalidModelResolution, err.Error())
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionDashboardSynchronized)
+		log.Error(err, LogMsgResolvingDashboardContents)
+
+		return ctrl.Result{}, fmt.Errorf("%s: %w", LogMsgResolvingDashboardContents, err)
+	}
+
+	removeInvalidSpec(&cr.Status.Conditions)
 
 	uid := fmt.Sprintf("%s", dashboardModel["uid"])
 	log = log.WithValues("uid", uid)
@@ -221,6 +221,10 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	cr.Status.Hash = hash
 	cr.Status.UID = uid
+
+	if err := resolver.UpdateCache(dashboardModel); err != nil {
+		log.Error(err, LogMsgUpdateCache)
+	}
 
 	return ctrl.Result{RequeueAfter: r.Cfg.requeueAfter(cr.Spec.ResyncPeriod)}, nil
 }

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -103,6 +103,28 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	removeSuspended(&cr.Status.Conditions)
 
+	// begin instance selection and reconciliation
+
+	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
+	if err != nil {
+		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionLibraryPanelSynchronized)
+		log.Error(err, LogMsgGettingInstances)
+
+		return ctrl.Result{}, fmt.Errorf("%s: %w", LogMsgGettingInstances, err)
+	}
+
+	if len(instances) == 0 {
+		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionLibraryPanelSynchronized)
+		log.Error(ErrNoMatchingInstances, LogMsgNoMatchingInstances)
+
+		return ctrl.Result{}, fmt.Errorf("%s: %w", LogMsgNoMatchingInstances, ErrNoMatchingInstances)
+	}
+
+	removeNoMatchingInstance(&cr.Status.Conditions)
+	log.V(1).Info(DbgMsgFoundMatchingInstances, "count", len(instances))
+
 	resolver := content.NewResolver(cr, r.Client, content.WithDisabledSources([]content.SourceType{
 		// grafana.com does not currently support hosting library panels for distribution, but perhaps
 		// this will change in the future.
@@ -133,28 +155,6 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	removeInvalidSpec(&cr.Status.Conditions)
 
-	// begin instance selection and reconciliation
-
-	instances, err := GetScopedMatchingInstances(ctx, r.Client, cr)
-	if err != nil {
-		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
-		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionLibraryPanelSynchronized)
-		log.Error(err, LogMsgGettingInstances)
-
-		return ctrl.Result{}, fmt.Errorf("%s: %w", LogMsgGettingInstances, err)
-	}
-
-	if len(instances) == 0 {
-		setNoMatchingInstancesCondition(&cr.Status.Conditions, cr.Generation, err)
-		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionLibraryPanelSynchronized)
-		log.Error(ErrNoMatchingInstances, LogMsgNoMatchingInstances)
-
-		return ctrl.Result{}, fmt.Errorf("%s: %w", LogMsgNoMatchingInstances, ErrNoMatchingInstances)
-	}
-
-	removeNoMatchingInstance(&cr.Status.Conditions)
-	log.V(1).Info(DbgMsgFoundMatchingInstances, "count", len(instances))
-
 	folderUID, err := getFolderUID(ctx, r.Client, cr)
 	if err != nil {
 		log.Error(err, LogMsgResolvingFolderUID)
@@ -182,6 +182,10 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	cr.Status.Hash = hash
 	cr.Status.UID = content.GetGrafanaUID(cr, contentUID)
+
+	if err := resolver.UpdateCache(contentModel); err != nil {
+		log.Error(err, LogMsgUpdateCache)
+	}
 
 	return ctrl.Result{RequeueAfter: r.Cfg.requeueAfter(cr.Spec.ResyncPeriod)}, nil
 }


### PR DESCRIPTION
Resolves #2667 by only caching the content if it has been accepted by grafana as a valid dashboard