### PR TITLE
chore(renovate): ungroup gomod updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,11 +14,6 @@
       "groupName": "github-actions (non-major)"
     },
     {
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "groupName": "go-dependencies (non-major)"
-    },
-    {
       "matchManagers": [
         "custom.regex"
       ],


### PR DESCRIPTION
- renovate:
  - I think it's clear at this point that grouping gomod updates overcomplicates reviews and delays merging of individual package upgrades. E.g. #2660 has been open 2 weeks ago and contains changes to 9 packages, some of those updates require code changes (as the code can't get complited atm). So, let's remove the grouping.