### PR TITLE
chore(metrics): remove unused metrics

### DIFF
--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -6,7 +6,6 @@ import (
 )
 
 const (
-	initialSyncDuration = "initial_sync_duration"
 	instanceName        = "instance_name"
 	instanceNamespace   = "instance_namespace"
 	method              = "method"
@@ -64,7 +63,7 @@ var (
 	InitialStatusSyncDuration = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Subsystem: subsystemReconciler,
-		Name:      initialSyncDuration,
+		Name:      "initial_sync_duration",
 		Help:      "time in ms to sync statuses after operator restart",
 	})
 )

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -67,46 +67,6 @@ var (
 		Name:      initialSyncDuration,
 		Help:      "time in ms to sync statuses after operator restart",
 	})
-
-	// Deprecated: All Initial Sync Duration metrics have merged into a single metric
-	InitialContactPointSyncDuration = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: "contactpoints",
-		Name:      initialSyncDuration,
-		Help:      "time in ms to sync contact-points after operator restart",
-	})
-
-	// Deprecated: All Initial Sync Duration metrics have merged into a single metric
-	InitialDashboardSyncDuration = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: "dashboards",
-		Name:      initialSyncDuration,
-		Help:      "time in ms to sync dashboards after operator restart",
-	})
-
-	// Deprecated: All Initial Sync Duration metrics have merged into a single metric
-	InitialLibraryPanelSyncDuration = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: "librarypanels",
-		Name:      initialSyncDuration,
-		Help:      "time in ms to sync library panels after operator restart",
-	})
-
-	// Deprecated: All Initial Sync Duration metrics have merged into a single metric
-	InitialDatasourceSyncDuration = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: "datasources",
-		Name:      initialSyncDuration,
-		Help:      "time in ms to sync datasources after operator restart",
-	})
-
-	// Deprecated: All Initial Sync Duration metrics have merged into a single metric
-	InitialFoldersSyncDuration = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: "folders",
-		Name:      initialSyncDuration,
-		Help:      "time in ms to sync folders after operator restart",
-	})
 )
 
 func init() {
@@ -117,10 +77,4 @@ func init() {
 	metrics.Registry.MustRegister(DashboardURLRequests)
 	metrics.Registry.MustRegister(ContentURLRequests)
 	metrics.Registry.MustRegister(InitialStatusSyncDuration)
-	// TODO Remvoe below registrations
-	metrics.Registry.MustRegister(InitialContactPointSyncDuration)
-	metrics.Registry.MustRegister(InitialDashboardSyncDuration)
-	metrics.Registry.MustRegister(InitialLibraryPanelSyncDuration)
-	metrics.Registry.MustRegister(InitialDatasourceSyncDuration)
-	metrics.Registry.MustRegister(InitialFoldersSyncDuration)
 }


### PR DESCRIPTION
- `metrics`:
  - removed several metrics that have been marked as deprecated about a year ago. There were no calls to them from any of the controllers, so they've been used.