### PR TITLE
fix(cache): handle corrupted cache

### DIFF
--- a/controllers/content/cache/cache.go
+++ b/controllers/content/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -51,12 +52,7 @@ func SetContentCache(cr v1beta1.GrafanaContentResource, data map[string]any) err
 }
 
 func setContentCache(in *v1beta1.GrafanaContentStatus, url string, data map[string]any, cacheDuration time.Duration) error {
-	notExpired := cacheDuration <= 0 || in.ContentTimestamp.Add(cacheDuration).After(time.Now())
-
-	if len(in.ContentCache) > 0 && notExpired && in.ContentURL == url {
-		return nil
-	}
-
+	// NOTE: json.Marshal sorts map keys, so we should always get the same result
 	encoded, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("marshaling content: %w", err)
@@ -65,6 +61,13 @@ func setContentCache(in *v1beta1.GrafanaContentStatus, url string, data map[stri
 	gz, err := Gzip(encoded)
 	if err != nil {
 		return fmt.Errorf("compressing content: %w", err)
+	}
+
+	notExpired := cacheDuration <= 0 || in.ContentTimestamp.Add(cacheDuration).After(time.Now())
+
+	// NOTE: as encoded and compressed result should always be same, we can rely on bytes.Equal
+	if notExpired && bytes.Equal(in.ContentCache, gz) && in.ContentURL == url {
+		return nil
 	}
 
 	in.ContentCache = gz

--- a/controllers/content/cache/cache.go
+++ b/controllers/content/cache/cache.go
@@ -52,7 +52,8 @@ func SetContentCache(cr v1beta1.GrafanaContentResource, data map[string]any) err
 
 func setContentCache(in *v1beta1.GrafanaContentStatus, url string, data map[string]any, cacheDuration time.Duration) error {
 	notExpired := cacheDuration <= 0 || in.ContentTimestamp.Add(cacheDuration).After(time.Now())
-	if notExpired && in.ContentURL == url {
+
+	if len(in.ContentCache) > 0 && notExpired && in.ContentURL == url {
 		return nil
 	}
 

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -185,14 +185,14 @@ func TestSetContentCache(t *testing.T) {
 			},
 		},
 		{
-			name:            "corrupted cache (missing url): cache is updated",
+			name:            "corrupted cache (broken gzip): cache is updated",
 			url:             url1,
 			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				ContentCache:     []byte{},
+				ContentCache:     []byte{1, 2, 3},
 				ContentTimestamp: hourAgo,
-				// ContentURL:       url1,
+				ContentURL:       url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
 				ContentCache:     gz1,
@@ -233,14 +233,14 @@ func TestSetContentCache(t *testing.T) {
 			},
 		},
 		{
-			name:            "corrupted cache (broken gzip): cache is updated",
+			name:            "corrupted cache (missing url): cache is updated",
 			url:             url1,
 			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				ContentCache:     []byte{1, 2, 3},
+				ContentCache:     []byte{},
 				ContentTimestamp: hourAgo,
-				ContentURL:       url1,
+				// ContentURL:       url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
 				ContentCache:     gz1,

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -167,4 +167,25 @@ func TestSetContentCache(t *testing.T) {
 		retrieved := getContentCache(&status, exampleURL, -1)
 		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
 	})
+
+	t.Run("partially populated cache (valid URL, not expired): missing content is added", func(t *testing.T) {
+		prevTime := time.Now().Add(-time.Minute * 5)
+		status := v1beta1.GrafanaContentStatus{
+			ContentURL:       exampleURL,
+			ContentCache:     []byte{},
+			ContentTimestamp: metav1.NewTime(prevTime),
+		}
+		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, 0)
+		require.NoError(t, err)
+
+		// content timestamp should be now
+		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
+
+		// url should be the same
+		assert.Equal(t, exampleURL, status.ContentURL)
+
+		// cached content should be retrievable
+		retrieved := getContentCache(&status, exampleURL, -1)
+		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
+	})
 }

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -247,3 +247,22 @@ func TestSetContentCache(t *testing.T) {
 		})
 	}
 }
+
+func TestSetAndGetContent(t *testing.T) {
+	status := &v1beta1.GrafanaContentStatus{}
+
+	url := "http://localhost:8080/1.json"
+
+	data := map[string]any{"title": "Test1"}
+
+	j, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	err = setContentCache(status, url, data, 24*time.Hour)
+	require.NoError(t, err)
+
+	want := j
+	got := getContentCache(status, url, -1)
+
+	assert.Equal(t, want, got)
+}

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -242,7 +242,7 @@ func TestSetContentCache(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.want.ContentCache, status.ContentCache)
-			assert.WithinDuration(t, tt.want.ContentTimestamp.Time, status.ContentTimestamp.Time, time.Second)
+			assert.WithinDuration(t, tt.want.ContentTimestamp.Time, status.ContentTimestamp.Time, 5*time.Second)
 			assert.Equal(t, tt.want.ContentURL, status.ContentURL)
 		})
 	}

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -137,7 +137,7 @@ func TestSetContentCache(t *testing.T) {
 			},
 		},
 		{
-			name:            "existing valid cache: cache is not updated",
+			name:            "valid cache: timestamp is not updated",
 			url:             url1,
 			data:            data1,
 			contentDuration: 24 * time.Hour,
@@ -153,7 +153,7 @@ func TestSetContentCache(t *testing.T) {
 			},
 		},
 		{
-			name:            "existing valid cache with wrong url: cache is updated",
+			name:            "expired cache (old url): cache is updated",
 			url:             url2,
 			data:            data2,
 			contentDuration: 24 * time.Hour,
@@ -169,7 +169,7 @@ func TestSetContentCache(t *testing.T) {
 			},
 		},
 		{
-			name:            "partially populated cache (valid URL, not expired): missing content is added",
+			name:            "corrupted cache (missing content): cache is updated",
 			url:             url1,
 			data:            data1,
 			contentDuration: 24 * time.Hour,

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -216,6 +216,22 @@ func TestSetContentCache(t *testing.T) {
 				ContentTimestamp: now,
 			},
 		},
+		{
+			name:            "corrupted cache (broken gzip): cache is updated",
+			url:             url1,
+			data:            data1,
+			contentDuration: 24 * time.Hour,
+			status: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     []byte{1, 2, 3},
+				ContentTimestamp: hourAgo,
+			},
+			want: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     gz1,
+				ContentTimestamp: now,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -142,9 +142,9 @@ func TestSetContentCache(t *testing.T) {
 			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     gz1,
 				ContentTimestamp: hourAgo,
+				ContentURL:       url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
 				ContentCache:     gz1,
@@ -158,14 +158,14 @@ func TestSetContentCache(t *testing.T) {
 			data:            data2,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     gz1,
 				ContentTimestamp: hourAgo,
+				ContentURL:       url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
-				ContentURL:       url2,
 				ContentCache:     gz2,
 				ContentTimestamp: now,
+				ContentURL:       url2,
 			},
 		},
 		{
@@ -174,14 +174,14 @@ func TestSetContentCache(t *testing.T) {
 			data:            data1,
 			contentDuration: 5 * time.Minute,
 			status: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     gz1,
 				ContentTimestamp: hourAgo,
+				ContentURL:       url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     gz1,
 				ContentTimestamp: now,
+				ContentURL:       url1,
 			},
 		},
 		{
@@ -190,14 +190,14 @@ func TestSetContentCache(t *testing.T) {
 			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				// ContentURL:       url1,
 				ContentCache:     []byte{},
 				ContentTimestamp: hourAgo,
+				// ContentURL:       url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     gz1,
 				ContentTimestamp: now,
+				ContentURL:       url1,
 			},
 		},
 		{
@@ -206,14 +206,14 @@ func TestSetContentCache(t *testing.T) {
 			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				ContentURL: url1,
 				// ContentCache:     gz1,
 				ContentTimestamp: hourAgo,
+				ContentURL:       url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     gz1,
 				ContentTimestamp: now,
+				ContentURL:       url1,
 			},
 		},
 		{
@@ -222,14 +222,14 @@ func TestSetContentCache(t *testing.T) {
 			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				ContentURL:   url1,
 				ContentCache: gz1,
 				// ContentTimestamp: hourAgo,
+				ContentURL: url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     gz1,
 				ContentTimestamp: now,
+				ContentURL:       url1,
 			},
 		},
 		{
@@ -238,14 +238,14 @@ func TestSetContentCache(t *testing.T) {
 			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     []byte{1, 2, 3},
 				ContentTimestamp: hourAgo,
+				ContentURL:       url1,
 			},
 			want: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
 				ContentCache:     gz1,
 				ContentTimestamp: now,
+				ContentURL:       url1,
 			},
 		},
 	}

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -113,112 +113,89 @@ func TestSetContentCache(t *testing.T) {
 	gz2, err := Gzip(j2)
 	require.NoError(t, err)
 
-	t.Run("no cache: cache is populated", func(t *testing.T) {
-		status := v1beta1.GrafanaContentStatus{}
-		err := setContentCache(&status, url1, raw1, time.Hour)
-		require.NoError(t, err)
+	now := metav1.NewTime(time.Now())
+	hourAgo := metav1.NewTime(time.Now().Add(-time.Hour))
 
-		// content timestamp should be now
-		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
+	tests := []struct {
+		name            string
+		url             string
+		raw             map[string]any // TODO: rename
+		contentDuration time.Duration
+		status          v1beta1.GrafanaContentStatus
+		want            v1beta1.GrafanaContentStatus
+	}{
+		{
+			name:            "no cache: cache is populated",
+			url:             url1,
+			raw:             raw1,
+			contentDuration: time.Hour,
+			status:          v1beta1.GrafanaContentStatus{},
+			want: v1beta1.GrafanaContentStatus{
+				ContentCache:     gz1,
+				ContentTimestamp: now,
+				ContentURL:       url1,
+			},
+		},
+		{
+			name:            "existing valid cache: cache is not updated",
+			url:             url1,
+			raw:             raw1,
+			contentDuration: 24 * time.Hour,
+			status: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     gz1,
+				ContentTimestamp: hourAgo,
+			},
+			want: v1beta1.GrafanaContentStatus{
+				ContentCache:     gz1,
+				ContentTimestamp: hourAgo,
+				ContentURL:       url1,
+			},
+		},
+		{
+			name:            "existing valid cache with wrong url: cache is updated",
+			url:             url2,
+			raw:             raw2,
+			contentDuration: 24 * time.Hour,
+			status: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     gz1,
+				ContentTimestamp: hourAgo,
+			},
+			want: v1beta1.GrafanaContentStatus{
+				ContentURL:       url2,
+				ContentCache:     gz2,
+				ContentTimestamp: now,
+			},
+		},
+		{
+			name:            "partially populated cache (valid URL, not expired): missing content is added",
+			url:             url1,
+			raw:             raw1,
+			contentDuration: 24 * time.Hour,
+			status: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     []byte{},
+				ContentTimestamp: hourAgo,
+			},
+			want: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     gz1,
+				ContentTimestamp: now,
+			},
+		},
+	}
 
-		// url should be updated
-		assert.Equal(t, url1, status.ContentURL)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := tt.status.DeepCopy()
 
-		// content should be set to a correct value
-		assert.Equal(t, gz1, status.ContentCache)
+			err := setContentCache(status, tt.url, tt.raw, tt.contentDuration)
+			require.NoError(t, err)
 
-		// cached content should be retrievable
-		retrieved := getContentCache(&status, url1, -1)
-		assert.JSONEq(t, string(j1), string(retrieved))
-	})
-
-	t.Run("existing valid cache: cache is not updated", func(t *testing.T) {
-		prevTime := time.Now().Add(-time.Minute * 5)
-		status := v1beta1.GrafanaContentStatus{
-			ContentURL:       url1,
-			ContentCache:     gz1,
-			ContentTimestamp: metav1.NewTime(prevTime),
-		}
-		err := setContentCache(&status, url1, raw1, time.Hour)
-		require.NoError(t, err)
-
-		// content timestamp should remain at prevTime
-		assert.Equal(t, prevTime, status.ContentTimestamp.Time)
-
-		// content should be set to a correct value
-		assert.Equal(t, gz1, status.ContentCache)
-
-		// cached content should be retrievable
-		retrieved := getContentCache(&status, url1, -1)
-		assert.JSONEq(t, string(j1), string(retrieved))
-	})
-
-	t.Run("existing old cache: cache is updated", func(t *testing.T) {
-		prevTime := time.Now().Add(-time.Hour * 5)
-		status := v1beta1.GrafanaContentStatus{
-			ContentURL:       url1,
-			ContentCache:     gz1,
-			ContentTimestamp: metav1.NewTime(prevTime),
-		}
-		err := setContentCache(&status, url1, raw2, time.Hour)
-		require.NoError(t, err)
-
-		// content timestamp should be now
-		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
-
-		// content should be set to a correct value
-		assert.Equal(t, gz2, status.ContentCache)
-
-		// cached content should be retrievable
-		retrieved := getContentCache(&status, url1, -1)
-		assert.JSONEq(t, string(j2), string(retrieved))
-	})
-
-	t.Run("existing valid cache with wrong url: cache is updated", func(t *testing.T) {
-		prevTime := time.Now().Add(-time.Minute * 5)
-		status := v1beta1.GrafanaContentStatus{
-			ContentURL:       url1,
-			ContentCache:     gz1,
-			ContentTimestamp: metav1.NewTime(prevTime),
-		}
-		err := setContentCache(&status, url2, raw2, time.Hour)
-		require.NoError(t, err)
-
-		// content timestamp should be now
-		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
-
-		// url should be updated
-		assert.Equal(t, url2, status.ContentURL)
-
-		// content should be set to a correct value
-		assert.Equal(t, gz2, status.ContentCache)
-
-		// cached content should be retrievable
-		retrieved := getContentCache(&status, url2, -1)
-		assert.JSONEq(t, string(j2), string(retrieved))
-	})
-
-	t.Run("partially populated cache (valid URL, not expired): missing content is added", func(t *testing.T) {
-		prevTime := time.Now().Add(-time.Minute * 5)
-		status := v1beta1.GrafanaContentStatus{
-			ContentURL:       url1,
-			ContentCache:     []byte{},
-			ContentTimestamp: metav1.NewTime(prevTime),
-		}
-		err := setContentCache(&status, url1, raw1, 0)
-		require.NoError(t, err)
-
-		// content timestamp should be now
-		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
-
-		// url should be the same
-		assert.Equal(t, url1, status.ContentURL)
-
-		// content should be set to a correct value
-		assert.Equal(t, gz1, status.ContentCache)
-
-		// cached content should be retrievable
-		retrieved := getContentCache(&status, url1, -1)
-		assert.JSONEq(t, string(j1), string(retrieved))
-	})
+			assert.Equal(t, tt.want.ContentCache, status.ContentCache)
+			assert.WithinDuration(t, tt.want.ContentTimestamp.Time, status.ContentTimestamp.Time, time.Second)
+			assert.Equal(t, tt.want.ContentURL, status.ContentURL)
+		})
+	}
 }

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -98,13 +98,13 @@ func TestSetContentCache(t *testing.T) {
 	url1 := "http://localhost:8080/1.json"
 	url2 := "http://localhost:8080/2.json"
 
-	raw1 := map[string]any{"title": "Test1"}
-	raw2 := map[string]any{"title": "Test2"}
+	data1 := map[string]any{"title": "Test1"}
+	data2 := map[string]any{"title": "Test2"}
 
-	j1, err := json.Marshal(raw1)
+	j1, err := json.Marshal(data1)
 	require.NoError(t, err)
 
-	j2, err := json.Marshal(raw2)
+	j2, err := json.Marshal(data2)
 	require.NoError(t, err)
 
 	gz1, err := Gzip(j1)
@@ -119,7 +119,7 @@ func TestSetContentCache(t *testing.T) {
 	tests := []struct {
 		name            string
 		url             string
-		raw             map[string]any // TODO: rename
+		data            map[string]any
 		contentDuration time.Duration
 		status          v1beta1.GrafanaContentStatus
 		want            v1beta1.GrafanaContentStatus
@@ -127,7 +127,7 @@ func TestSetContentCache(t *testing.T) {
 		{
 			name:            "no cache: cache is populated",
 			url:             url1,
-			raw:             raw1,
+			data:            data1,
 			contentDuration: time.Hour,
 			status:          v1beta1.GrafanaContentStatus{},
 			want: v1beta1.GrafanaContentStatus{
@@ -139,7 +139,7 @@ func TestSetContentCache(t *testing.T) {
 		{
 			name:            "existing valid cache: cache is not updated",
 			url:             url1,
-			raw:             raw1,
+			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
 				ContentURL:       url1,
@@ -155,7 +155,7 @@ func TestSetContentCache(t *testing.T) {
 		{
 			name:            "existing valid cache with wrong url: cache is updated",
 			url:             url2,
-			raw:             raw2,
+			data:            data2,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
 				ContentURL:       url1,
@@ -171,7 +171,7 @@ func TestSetContentCache(t *testing.T) {
 		{
 			name:            "partially populated cache (valid URL, not expired): missing content is added",
 			url:             url1,
-			raw:             raw1,
+			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
 				ContentURL:       url1,
@@ -190,7 +190,7 @@ func TestSetContentCache(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			status := tt.status.DeepCopy()
 
-			err := setContentCache(status, tt.url, tt.raw, tt.contentDuration)
+			err := setContentCache(status, tt.url, tt.data, tt.contentDuration)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.want.ContentCache, status.ContentCache)

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -128,7 +128,7 @@ func TestSetContentCache(t *testing.T) {
 			name:            "no cache: cache is populated",
 			url:             url1,
 			data:            data1,
-			contentDuration: time.Hour,
+			contentDuration: 24 * time.Hour,
 			status:          v1beta1.GrafanaContentStatus{},
 			want: v1beta1.GrafanaContentStatus{
 				ContentCache:     gz1,

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGrafanaDashboardStatus_getContentCache(t *testing.T) {
+func TestGetContentCache(t *testing.T) {
 	timestamp := metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
 	infinite := 0 * time.Second
 	dashboardJSON := []byte(`{"dummyField": "dummyData"}`)

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -94,98 +95,114 @@ func TestGrafanaDashboardStatus_getContentCache(t *testing.T) {
 }
 
 func TestSetContentCache(t *testing.T) {
-	exampleURL := "http://localhost:8080/example.json"
+	url1 := "http://localhost:8080/1.json"
+	url2 := "http://localhost:8080/2.json"
+
+	raw1 := map[string]any{"title": "Test1"}
+	raw2 := map[string]any{"title": "Test2"}
+
+	j1, err := json.Marshal(raw1)
+	require.NoError(t, err)
+
+	j2, err := json.Marshal(raw2)
+	require.NoError(t, err)
+
+	gz1, err := Gzip(j1)
+	require.NoError(t, err)
+
+	// gz2, err := Gzip(j2)
+	// require.NoError(t, err)
 
 	t.Run("no cache: cache is populated", func(t *testing.T) {
 		status := v1beta1.GrafanaContentStatus{}
-		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, time.Hour)
+		err := setContentCache(&status, url1, raw1, time.Hour)
 		require.NoError(t, err)
 
 		// content timestamp should be now
 		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
 
 		// url should be updated
-		assert.Equal(t, exampleURL, status.ContentURL)
+		assert.Equal(t, url1, status.ContentURL)
 
 		// cached content should be retrievable
-		retrieved := getContentCache(&status, exampleURL, -1)
-		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
+		retrieved := getContentCache(&status, url1, -1)
+		assert.JSONEq(t, string(j1), string(retrieved))
 	})
 
 	t.Run("existing valid cache: cache is not updated", func(t *testing.T) {
 		prevTime := time.Now().Add(-time.Minute * 5)
 		status := v1beta1.GrafanaContentStatus{
-			ContentURL:       exampleURL,
-			ContentCache:     []byte{1, 2, 3}, // sentinel value that should stay the same
+			ContentURL:       url1,
+			ContentCache:     gz1,
 			ContentTimestamp: metav1.NewTime(prevTime),
 		}
-		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, time.Hour)
+		err := setContentCache(&status, url1, raw1, time.Hour)
 		require.NoError(t, err)
 
 		// content timestamp should remain at prevTime
 		assert.Equal(t, prevTime, status.ContentTimestamp.Time)
 
 		// cached content should stay the same
-		assert.Equal(t, []byte{1, 2, 3}, status.ContentCache)
+		assert.Equal(t, gz1, status.ContentCache)
 	})
 
 	t.Run("existing old cache: cache is updated", func(t *testing.T) {
 		prevTime := time.Now().Add(-time.Hour * 5)
 		status := v1beta1.GrafanaContentStatus{
-			ContentURL:       exampleURL,
-			ContentCache:     []byte{1, 2, 3},
+			ContentURL:       url1,
+			ContentCache:     gz1,
 			ContentTimestamp: metav1.NewTime(prevTime),
 		}
-		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, time.Hour)
+		err := setContentCache(&status, url1, raw2, time.Hour)
 		require.NoError(t, err)
 
 		// content timestamp should be now
 		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
 
 		// cached content should be retrievable
-		retrieved := getContentCache(&status, exampleURL, -1)
-		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
+		retrieved := getContentCache(&status, url1, -1)
+		assert.JSONEq(t, string(j2), string(retrieved))
 	})
 
 	t.Run("existing valid cache with wrong url: cache is updated", func(t *testing.T) {
 		prevTime := time.Now().Add(-time.Minute * 5)
 		status := v1beta1.GrafanaContentStatus{
-			ContentURL:       "http://localhost:8080/some-other.json",
-			ContentCache:     []byte{1, 2, 3},
+			ContentURL:       url1,
+			ContentCache:     gz1,
 			ContentTimestamp: metav1.NewTime(prevTime),
 		}
-		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, time.Hour)
+		err := setContentCache(&status, url2, raw2, time.Hour)
 		require.NoError(t, err)
 
 		// content timestamp should be now
 		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
 
 		// url should be updated
-		assert.Equal(t, exampleURL, status.ContentURL)
+		assert.Equal(t, url2, status.ContentURL)
 
 		// cached content should be retrievable
-		retrieved := getContentCache(&status, exampleURL, -1)
-		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
+		retrieved := getContentCache(&status, url2, -1)
+		assert.JSONEq(t, string(j2), string(retrieved))
 	})
 
 	t.Run("partially populated cache (valid URL, not expired): missing content is added", func(t *testing.T) {
 		prevTime := time.Now().Add(-time.Minute * 5)
 		status := v1beta1.GrafanaContentStatus{
-			ContentURL:       exampleURL,
+			ContentURL:       url1,
 			ContentCache:     []byte{},
 			ContentTimestamp: metav1.NewTime(prevTime),
 		}
-		err := setContentCache(&status, exampleURL, map[string]any{"title": "Test"}, 0)
+		err := setContentCache(&status, url1, raw1, 0)
 		require.NoError(t, err)
 
 		// content timestamp should be now
 		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
 
 		// url should be the same
-		assert.Equal(t, exampleURL, status.ContentURL)
+		assert.Equal(t, url1, status.ContentURL)
 
 		// cached content should be retrievable
-		retrieved := getContentCache(&status, exampleURL, -1)
-		assert.JSONEq(t, `{"title":"Test"}`, string(retrieved))
+		retrieved := getContentCache(&status, url1, -1)
+		assert.JSONEq(t, string(j1), string(retrieved))
 	})
 }

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -169,14 +169,46 @@ func TestSetContentCache(t *testing.T) {
 			},
 		},
 		{
+			name:            "corrupted cache (missing url): cache is updated",
+			url:             url1,
+			data:            data1,
+			contentDuration: 24 * time.Hour,
+			status: v1beta1.GrafanaContentStatus{
+				// ContentURL:       url1,
+				ContentCache:     []byte{},
+				ContentTimestamp: hourAgo,
+			},
+			want: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     gz1,
+				ContentTimestamp: now,
+			},
+		},
+		{
 			name:            "corrupted cache (missing content): cache is updated",
 			url:             url1,
 			data:            data1,
 			contentDuration: 24 * time.Hour,
 			status: v1beta1.GrafanaContentStatus{
-				ContentURL:       url1,
-				ContentCache:     []byte{},
+				ContentURL: url1,
+				// ContentCache:     gz1,
 				ContentTimestamp: hourAgo,
+			},
+			want: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     gz1,
+				ContentTimestamp: now,
+			},
+		},
+		{
+			name:            "corrupted cache (missing timestamp): cache is updated",
+			url:             url1,
+			data:            data1,
+			contentDuration: 24 * time.Hour,
+			status: v1beta1.GrafanaContentStatus{
+				ContentURL:   url1,
+				ContentCache: gz1,
+				// ContentTimestamp: hourAgo,
 			},
 			want: v1beta1.GrafanaContentStatus{
 				ContentURL:       url1,

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -110,8 +110,8 @@ func TestSetContentCache(t *testing.T) {
 	gz1, err := Gzip(j1)
 	require.NoError(t, err)
 
-	// gz2, err := Gzip(j2)
-	// require.NoError(t, err)
+	gz2, err := Gzip(j2)
+	require.NoError(t, err)
 
 	t.Run("no cache: cache is populated", func(t *testing.T) {
 		status := v1beta1.GrafanaContentStatus{}
@@ -123,6 +123,9 @@ func TestSetContentCache(t *testing.T) {
 
 		// url should be updated
 		assert.Equal(t, url1, status.ContentURL)
+
+		// content should be set to a correct value
+		assert.Equal(t, gz1, status.ContentCache)
 
 		// cached content should be retrievable
 		retrieved := getContentCache(&status, url1, -1)
@@ -142,8 +145,12 @@ func TestSetContentCache(t *testing.T) {
 		// content timestamp should remain at prevTime
 		assert.Equal(t, prevTime, status.ContentTimestamp.Time)
 
-		// cached content should stay the same
+		// content should be set to a correct value
 		assert.Equal(t, gz1, status.ContentCache)
+
+		// cached content should be retrievable
+		retrieved := getContentCache(&status, url1, -1)
+		assert.JSONEq(t, string(j1), string(retrieved))
 	})
 
 	t.Run("existing old cache: cache is updated", func(t *testing.T) {
@@ -158,6 +165,9 @@ func TestSetContentCache(t *testing.T) {
 
 		// content timestamp should be now
 		assert.WithinDuration(t, time.Now(), status.ContentTimestamp.Time, time.Second)
+
+		// content should be set to a correct value
+		assert.Equal(t, gz2, status.ContentCache)
 
 		// cached content should be retrievable
 		retrieved := getContentCache(&status, url1, -1)
@@ -180,6 +190,9 @@ func TestSetContentCache(t *testing.T) {
 		// url should be updated
 		assert.Equal(t, url2, status.ContentURL)
 
+		// content should be set to a correct value
+		assert.Equal(t, gz2, status.ContentCache)
+
 		// cached content should be retrievable
 		retrieved := getContentCache(&status, url2, -1)
 		assert.JSONEq(t, string(j2), string(retrieved))
@@ -200,6 +213,9 @@ func TestSetContentCache(t *testing.T) {
 
 		// url should be the same
 		assert.Equal(t, url1, status.ContentURL)
+
+		// content should be set to a correct value
+		assert.Equal(t, gz1, status.ContentCache)
 
 		// cached content should be retrievable
 		retrieved := getContentCache(&status, url1, -1)

--- a/controllers/content/cache/cache_test.go
+++ b/controllers/content/cache/cache_test.go
@@ -169,6 +169,22 @@ func TestSetContentCache(t *testing.T) {
 			},
 		},
 		{
+			name:            "expired cache (old timestamp): cache is updated",
+			url:             url1,
+			data:            data1,
+			contentDuration: 5 * time.Minute,
+			status: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     gz1,
+				ContentTimestamp: hourAgo,
+			},
+			want: v1beta1.GrafanaContentStatus{
+				ContentURL:       url1,
+				ContentCache:     gz1,
+				ContentTimestamp: now,
+			},
+		},
+		{
 			name:            "corrupted cache (missing url): cache is updated",
 			url:             url1,
 			data:            data1,


### PR DESCRIPTION
- `cache`:
  - in #2668, we changed how caching is handled (only content validated against Grafana gets stored). That introduces some potential edge cases around corrupted cache that I think are worth handling. E.g. if URL is up-to-date and timestamp satisfies cache duration, `setContentCache` will not replace missing or broken content:
    - to mitigate that, added byte comparison to `setContentCache`;
    - just in case, added extra test cases that validate that a missing timestamp or a missing URL will also be handled. Technically, those intersect with other test cases, but I think it's worth having something explicit;
    - as part of the change:
      - converted existing tests into table-tests. - It's easier to check which of the cases are covered when test behaviour is the same everywhere (previously, there were some small differences amongst the tests);
      - moved integration test for set & get content to `TestSetAndGetContent`.
