### PR TITLE
fix: apply Grafana preferences from the Grafana CR reconcile loop

### DIFF
--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -220,9 +220,40 @@ type GrafanaClient struct {
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
-// GrafanaPreferences holds Grafana preferences API settings
+// GrafanaPreferences holds Grafana org-level settings shown on the
+// "Default preferences" admin page. Empty fields are not sent so they
+// don't clobber values set elsewhere (UI, grafana.ini defaults).
+//
+// Most fields are applied via PATCH /api/org/preferences. OrganizationName
+// uses PUT /api/org instead, since Grafana's API separates org metadata
+// from preferences even though the UI groups them on one page.
+//
+// Values are passed to Grafana as-is and validated server-side. Invalid
+// values produce a 4xx from the Grafana API and surface as a reconcile
+// error.
 type GrafanaPreferences struct {
+	// OrganizationName sets the display name of the org (defaults to "Main Org."
+	// in a fresh Grafana). Backed by PUT /api/org. Skipped when empty; reading
+	// back via GET /api/org is used to avoid an unnecessary write when the
+	// configured name already matches.
+	OrganizationName string `json:"organizationName,omitempty"`
+
+	// HomeDashboardUID is the UID of the dashboard shown on the org's home page.
 	HomeDashboardUID string `json:"homeDashboardUid,omitempty"`
+
+	// Theme is the default UI theme for the org (e.g. "light", "dark", "system").
+	// Accepted values depend on the running Grafana version.
+	Theme string `json:"theme,omitempty"`
+
+	// Timezone is the default timezone for the org. Accepts an IANA timezone
+	// name (e.g. "America/New_York"), "utc", or "browser".
+	Timezone string `json:"timezone,omitempty"`
+
+	// WeekStart is the day the calendar week starts on (e.g. "monday", "sunday").
+	WeekStart string `json:"weekStart,omitempty"`
+
+	// Language is the default UI language as a locale code (e.g. "en-US", "de-DE").
+	Language string `json:"language,omitempty"`
 }
 
 // GrafanaStatus defines the observed state of Grafana

--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -45,6 +45,7 @@ const (
 	OperatorStageIngress        OperatorStageName = "ingress"
 	OperatorStagePlugins        OperatorStageName = "plugins"
 	OperatorStageDeployment     OperatorStageName = "deployment"
+	OperatorStagePreferences    OperatorStageName = "preferences"
 	OperatorStageComplete       OperatorStageName = "complete"
 )
 

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -8261,6 +8261,30 @@ spec:
                   description: Preferences holds the Grafana Preferences settings
                   properties:
                     homeDashboardUid:
+                      description: HomeDashboardUID is the UID of the dashboard shown on the org's home page.
+                      type: string
+                    language:
+                      description: Language is the default UI language as a locale code (e.g. "en-US", "de-DE").
+                      type: string
+                    organizationName:
+                      description: |-
+                        OrganizationName sets the display name of the org (defaults to "Main Org."
+                        in a fresh Grafana). Backed by PUT /api/org. Skipped when empty; reading
+                        back via GET /api/org is used to avoid an unnecessary write when the
+                        configured name already matches.
+                      type: string
+                    theme:
+                      description: |-
+                        Theme is the default UI theme for the org (e.g. "light", "dark", "system").
+                        Accepted values depend on the running Grafana version.
+                      type: string
+                    timezone:
+                      description: |-
+                        Timezone is the default timezone for the org. Accepts an IANA timezone
+                        name (e.g. "America/New_York"), "utc", or "browser".
+                      type: string
+                    weekStart:
+                      description: WeekStart is the day the calendar week starts on (e.g. "monday", "sunday").
                       type: string
                   type: object
                 route:

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -605,4 +605,3 @@ func (r *GrafanaDashboardReconciler) requestsForChangeByField(indexKey string) h
 		return reqs
 	}
 }
-

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -168,7 +168,6 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, fmt.Errorf("%s: %w", LogMsgResolvingFolderUID, err)
 	}
 
-	applyHomeErrors := make(map[string]string)
 	pluginErrors := make(map[string]string)
 	applyErrors := make(map[string]string)
 
@@ -188,13 +187,6 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err != nil {
 			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 		}
-
-		if grafana.Spec.Preferences != nil && uid == grafana.Spec.Preferences.HomeDashboardUID {
-			err = r.UpdateHomeDashboard(ctx, grafana, uid, cr)
-			if err != nil {
-				applyHomeErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
-			}
-		}
 	}
 
 	if len(pluginErrors) > 0 {
@@ -202,12 +194,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		log.Error(err, "failed to apply plugins to all instances")
 	}
 
-	if len(applyHomeErrors) > 0 {
-		err := fmt.Errorf(FmtStrApplyErrors, applyHomeErrors)
-		log.Error(err, "failed to apply home dashboards to all instances")
-	}
-
-	allApplyErrors := mergeReconcileErrors(applyErrors, pluginErrors, applyHomeErrors)
+	allApplyErrors := mergeReconcileErrors(applyErrors, pluginErrors)
 
 	condition := buildSynchronizedCondition("Dashboard", conditionDashboardSynchronized, cr.Generation, allApplyErrors, len(instances))
 	meta.SetStatusCondition(&cr.Status.Conditions, condition)
@@ -619,23 +606,3 @@ func (r *GrafanaDashboardReconciler) requestsForChangeByField(indexKey string) h
 	}
 }
 
-func (r *GrafanaDashboardReconciler) UpdateHomeDashboard(ctx context.Context, grafana v1beta1.Grafana, uid string, dashboard *v1beta1.GrafanaDashboard) error {
-	log := logf.FromContext(ctx)
-
-	gClient, err := grafanaclient.NewGeneratedGrafanaClient(ctx, r.Client, &grafana)
-	if err != nil {
-		return err
-	}
-
-	_, err = gClient.Org.UpdateOrgPreferences(&models.UpdatePrefsCmd{ //nolint:errcheck
-		HomeDashboardUID: uid,
-	})
-	if err != nil {
-		log.Error(err, "unable to update the home dashboard", "namespace", dashboard.Namespace, "name", dashboard.Name)
-		return err
-	}
-
-	log.Info("home dashboard configured", "namespace", dashboard.Namespace, "name", dashboard.Name)
-
-	return nil
-}

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -109,8 +109,10 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	var stages []v1beta1.OperatorStageName
 	if cr.IsExternal() {
-		// Only reconcile the Completion stage for external instances
-		stages = []v1beta1.OperatorStageName{v1beta1.OperatorStageComplete}
+		// External instances skip the in-cluster Deployment / PVC / Service
+		// pieces; only Preferences (which talks to the Grafana HTTP API)
+		// and the Completion stage apply.
+		stages = []v1beta1.OperatorStageName{v1beta1.OperatorStagePreferences, v1beta1.OperatorStageComplete}
 		// AdminURL is normally set during ingress/route stage.
 		// External instances only use the complete stage
 		cr.Status.AdminURL = cr.Spec.External.URL
@@ -410,6 +412,7 @@ func getInstallationStages() []v1beta1.OperatorStageName {
 		v1beta1.OperatorStageIngress,
 		v1beta1.OperatorStagePlugins,
 		v1beta1.OperatorStageDeployment,
+		v1beta1.OperatorStagePreferences,
 		v1beta1.OperatorStageComplete,
 	}
 }
@@ -432,6 +435,8 @@ func (r *GrafanaReconciler) getReconcilerForStage(stage v1beta1.OperatorStageNam
 		return grafana.NewPluginsReconciler(r.Client)
 	case v1beta1.OperatorStageDeployment:
 		return grafana.NewDeploymentReconciler(r.Client, r.IsOpenShift)
+	case v1beta1.OperatorStagePreferences:
+		return grafana.NewPreferencesReconciler(r.Client)
 	case v1beta1.OperatorStageComplete:
 		return grafana.NewCompleteReconciler(r.Client)
 	default:

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -320,8 +320,9 @@ func (r *GrafanaReconciler) syncStatuses(ctx context.Context) error {
 // SetupWithManager sets up the controller with the Manager.
 func (r *GrafanaReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	const (
-		secretIndexKey    string = ".metadata.secret"
-		configMapIndexKey string = ".metadata.configMap"
+		secretIndexKey        string = ".metadata.secret"
+		configMapIndexKey     string = ".metadata.configMap"
+		homeDashboardIndexKey string = ".spec.preferences.homeDashboardUID"
 	)
 
 	if err := mgr.GetCache().IndexField(ctx, &v1beta1.Grafana{}, secretIndexKey,
@@ -332,6 +333,11 @@ func (r *GrafanaReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 	if err := mgr.GetCache().IndexField(ctx, &v1beta1.Grafana{}, configMapIndexKey,
 		r.indexConfigMapSource()); err != nil {
 		return fmt.Errorf("failed setting configmap index fields: %w", err)
+	}
+
+	if err := mgr.GetCache().IndexField(ctx, &v1beta1.Grafana{}, homeDashboardIndexKey,
+		r.indexHomeDashboardUID()); err != nil {
+		return fmt.Errorf("failed setting home dashboard index fields: %w", err)
 	}
 
 	b := ctrl.NewControllerManagedBy(mgr).
@@ -350,6 +356,10 @@ func (r *GrafanaReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.requestsForChangeByField(configMapIndexKey)),
+		).
+		Watches(
+			&v1beta1.GrafanaDashboard{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForDashboardHomeRef(homeDashboardIndexKey)),
 		).
 		WithOptions(controller.Options{RateLimiter: defaultRateLimiter()})
 
@@ -481,6 +491,56 @@ func (r *GrafanaReconciler) indexConfigMapSource() func(client.Object) []string 
 		}
 
 		return refs
+	}
+}
+
+func (r *GrafanaReconciler) indexHomeDashboardUID() func(client.Object) []string {
+	return func(o client.Object) []string {
+		cr, ok := o.(*v1beta1.Grafana)
+		if !ok {
+			panic(fmt.Sprintf("Expected a Grafana, got %T", o))
+		}
+
+		if cr.Spec.Preferences == nil || cr.Spec.Preferences.HomeDashboardUID == "" {
+			return nil
+		}
+
+		return []string{cr.Spec.Preferences.HomeDashboardUID}
+	}
+}
+
+// requestsForDashboardHomeRef enqueues Grafana CRs whose
+// spec.preferences.homeDashboardUID matches the changed dashboard's resolved
+// UID. This closes the chicken-and-egg loop: when a dashboard referenced as
+// home dashboard is created (status.UID populated), the matching Grafana CR
+// re-reconciles so PreferencesReconciler can re-PATCH preferences.
+func (r *GrafanaReconciler) requestsForDashboardHomeRef(indexKey string) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		dash, ok := o.(*v1beta1.GrafanaDashboard)
+		if !ok {
+			return nil
+		}
+
+		uid := dash.Status.UID
+		if uid == "" {
+			return nil
+		}
+
+		var list v1beta1.GrafanaList
+		if err := r.List(ctx, &list, client.MatchingFields{indexKey: uid}); err != nil {
+			logf.FromContext(ctx).Error(err, "failed to list grafana instances for dashboard home-ref watch mapping")
+			return nil
+		}
+
+		reqs := make([]reconcile.Request, 0, len(list.Items))
+		for _, gr := range list.Items {
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: gr.Namespace,
+				Name:      gr.Name,
+			}})
+		}
+
+		return reqs
 	}
 }
 

--- a/controllers/preferences_reconciler_test.go
+++ b/controllers/preferences_reconciler_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	grafanaclient "github.com/grafana/grafana-operator/v5/controllers/client"
+	grafanareconciler "github.com/grafana/grafana-operator/v5/controllers/reconcilers/grafana"
+	"github.com/grafana/grafana-operator/v5/pkg/tk8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// Unit tests for the indexer + watch map function. These don't need the Grafana
+// testcontainer.
+func TestPreferencesIndexAndMap(t *testing.T) {
+	t.Run("indexHomeDashboardUID returns nil when preferences unset", func(t *testing.T) {
+		r := &GrafanaReconciler{}
+		idx := r.indexHomeDashboardUID()
+
+		got := idx(&v1beta1.Grafana{})
+		assert.Nil(t, got)
+	})
+
+	t.Run("indexHomeDashboardUID returns nil when home dashboard UID empty", func(t *testing.T) {
+		r := &GrafanaReconciler{}
+		idx := r.indexHomeDashboardUID()
+
+		got := idx(&v1beta1.Grafana{
+			Spec: v1beta1.GrafanaSpec{
+				Preferences: &v1beta1.GrafanaPreferences{},
+			},
+		})
+		assert.Nil(t, got)
+	})
+
+	t.Run("indexHomeDashboardUID indexes the configured UID", func(t *testing.T) {
+		r := &GrafanaReconciler{}
+		idx := r.indexHomeDashboardUID()
+
+		got := idx(&v1beta1.Grafana{
+			Spec: v1beta1.GrafanaSpec{
+				Preferences: &v1beta1.GrafanaPreferences{HomeDashboardUID: "abc-123"},
+			},
+		})
+		assert.Equal(t, []string{"abc-123"}, got)
+	})
+
+	t.Run("requestsForDashboardHomeRef ignores dashboards without a resolved status.UID", func(t *testing.T) {
+		fakeClient := fake.NewClientBuilder().Build()
+		r := &GrafanaReconciler{Client: fakeClient}
+
+		mapFn := r.requestsForDashboardHomeRef("ignored-index-key")
+		dash := &v1beta1.GrafanaDashboard{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "dash"},
+		}
+
+		got := mapFn(context.Background(), dash)
+		assert.Empty(t, got)
+	})
+
+	t.Run("requestsForDashboardHomeRef enqueues only Grafanas matching by index", func(t *testing.T) {
+		matching := &v1beta1.Grafana{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "matching"},
+			Spec: v1beta1.GrafanaSpec{
+				Preferences: &v1beta1.GrafanaPreferences{HomeDashboardUID: "home-uid"},
+			},
+		}
+		other := &v1beta1.Grafana{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns-b", Name: "other"},
+			Spec: v1beta1.GrafanaSpec{
+				Preferences: &v1beta1.GrafanaPreferences{HomeDashboardUID: "different-uid"},
+			},
+		}
+
+		const indexKey = ".spec.preferences.homeDashboardUID"
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme()).
+			WithObjects(matching, other).
+			WithIndex(&v1beta1.Grafana{}, indexKey, func(o client.Object) []string {
+				g, ok := o.(*v1beta1.Grafana)
+				if !ok || g.Spec.Preferences == nil {
+					return nil
+				}
+
+				return []string{g.Spec.Preferences.HomeDashboardUID}
+			}).
+			Build()
+		r := &GrafanaReconciler{Client: fakeClient}
+
+		mapFn := r.requestsForDashboardHomeRef(indexKey)
+		dash := &v1beta1.GrafanaDashboard{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "dash"},
+			Status: v1beta1.GrafanaDashboardStatus{
+				GrafanaContentStatus: v1beta1.GrafanaContentStatus{UID: "home-uid"},
+			},
+		}
+
+		got := mapFn(context.Background(), dash)
+		assert.Equal(t, []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Namespace: "ns-a", Name: "matching"}},
+		}, got)
+	})
+}
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+
+	return s
+}
+
+// Integration tests against the real Grafana running in a testcontainer
+// (started by suite_test.go). Each test creates a Grafana CR pointing to the
+// container and invokes the reconciler directly.
+var _ = Describe("Preferences Reconciler", Ordered, func() {
+	t := GinkgoT()
+
+	const (
+		homeDashUID   = "preferences-home-dash"
+		dashTitle     = "Home Dashboard For Preferences Test"
+		grafanaCRName = "preferences-grafana"
+		grafanaNS     = "default"
+		dashboardCR   = "preferences-home-dashboard"
+		labelKey      = "preferences-test"
+		labelValue    = "true"
+	)
+
+	matchLabels := map[string]string{labelKey: labelValue}
+
+	var (
+		grafanaCR *v1beta1.Grafana
+		gReq      = reconcile.Request{NamespacedName: types.NamespacedName{Namespace: grafanaNS, Name: grafanaCRName}}
+	)
+
+	BeforeAll(func() {
+		grafanaCR = &v1beta1.Grafana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: grafanaNS,
+				Name:      grafanaCRName,
+				Labels:    matchLabels,
+			},
+			Spec: v1beta1.GrafanaSpec{
+				External: externalGrafanaCr.Spec.External,
+				Config:   externalGrafanaCr.Spec.Config,
+				Client:   externalGrafanaCr.Spec.Client,
+				// Preferences set/cleared per-test via Patch
+			},
+		}
+
+		err := cl.Create(testCtx, grafanaCR)
+		require.NoError(t, err)
+	})
+
+	AfterAll(func() {
+		// Clean up the Grafana CR. Dashboard cleanup happens inline.
+		require.NoError(t, client.IgnoreNotFound(cl.Delete(testCtx, grafanaCR)))
+	})
+
+	It("stays Ready and marks PreferencesApplied=False when home dashboard is missing", func() {
+		// Set spec.preferences to a UID that doesn't yet exist in Grafana.
+		fresh := &v1beta1.Grafana{}
+		require.NoError(t, cl.Get(testCtx, gReq.NamespacedName, fresh))
+
+		fresh.Spec.Preferences = &v1beta1.GrafanaPreferences{HomeDashboardUID: "definitely-does-not-exist"}
+		require.NoError(t, cl.Update(testCtx, fresh))
+
+		r := &GrafanaReconciler{Client: cl, Scheme: cl.Scheme()}
+		_, err := r.Reconcile(testCtx, gReq)
+		require.NoError(t, err, "missing home dashboard should not hard-fail the reconcile")
+
+		got := &v1beta1.Grafana{}
+		require.NoError(t, cl.Get(testCtx, gReq.NamespacedName, got))
+
+		assert.True(t, tk8s.HasCondition(t, got, metav1.Condition{
+			Type:   conditionTypeGrafanaReady,
+			Reason: "GrafanaReady",
+		}), "Grafana should still report Ready when home dashboard is missing")
+
+		assert.True(t, tk8s.HasCondition(t, got, metav1.Condition{
+			Type:   grafanareconciler.ConditionPreferencesApplied,
+			Reason: "HomeDashboardMissing",
+		}), "PreferencesApplied condition should reflect HomeDashboardMissing")
+	})
+
+	It("applies the home dashboard preference once the dashboard exists in Grafana", func() {
+		// Create a GrafanaDashboard CR matching grafanaCR's labels and reconcile it,
+		// which creates the dashboard in Grafana.
+		dash := &v1beta1.GrafanaDashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: grafanaNS,
+				Name:      dashboardCR,
+			},
+			Spec: v1beta1.GrafanaDashboardSpec{
+				GrafanaCommonSpec: v1beta1.GrafanaCommonSpec{
+					InstanceSelector: &metav1.LabelSelector{MatchLabels: matchLabels},
+				},
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{
+					JSON: fmt.Sprintf(`{"uid": %q, "title": %q, "links": []}`, homeDashUID, dashTitle),
+				},
+			},
+		}
+		require.NoError(t, cl.Create(testCtx, dash))
+
+		dr := &GrafanaDashboardReconciler{Client: cl, Scheme: cl.Scheme(), Cfg: &Config{}}
+		_, err := dr.Reconcile(testCtx, tk8s.GetRequest(t, dash))
+		require.NoError(t, err)
+
+		// Sanity: dashboard now exists in Grafana. Use externalGrafanaCr (which
+		// has Status.AdminURL populated by the suite bootstrap reconcile) since
+		// both CRs target the same testcontainer.
+		gClient, err := grafanaclient.NewGeneratedGrafanaClient(testCtx, cl, externalGrafanaCr)
+		require.NoError(t, err)
+
+		_, err = gClient.Dashboards.GetDashboardByUID(homeDashUID) //nolint:errcheck
+		require.NoError(t, err, "dashboard should exist in Grafana after dashboard reconcile")
+
+		// Point the Grafana CR's preferences at the now-existing dashboard and
+		// also exercise the additional preference fields wired through the PATCH.
+		fresh := &v1beta1.Grafana{}
+		require.NoError(t, cl.Get(testCtx, gReq.NamespacedName, fresh))
+
+		const (
+			wantOrgName  = "Custom Org"
+			wantTheme    = "dark"
+			wantTimezone = "UTC"
+			wantWeek     = "monday"
+			wantLanguage = "en-US"
+		)
+
+		fresh.Spec.Preferences = &v1beta1.GrafanaPreferences{
+			OrganizationName: wantOrgName,
+			HomeDashboardUID: homeDashUID,
+			Theme:            wantTheme,
+			Timezone:         wantTimezone,
+			WeekStart:        wantWeek,
+			Language:         wantLanguage,
+		}
+		require.NoError(t, cl.Update(testCtx, fresh))
+
+		r := &GrafanaReconciler{Client: cl, Scheme: cl.Scheme()}
+		_, err = r.Reconcile(testCtx, gReq)
+		require.NoError(t, err)
+
+		got := &v1beta1.Grafana{}
+		require.NoError(t, cl.Get(testCtx, gReq.NamespacedName, got))
+
+		assert.True(t, tk8s.HasCondition(t, got, metav1.Condition{
+			Type:   grafanareconciler.ConditionPreferencesApplied,
+			Reason: "PreferencesApplied",
+		}), "PreferencesApplied condition should flip to PreferencesApplied/True after PATCH succeeds")
+
+		// Verify all preference fields landed in Grafana itself.
+		prefs, err := gClient.Org.GetOrgPreferences()
+		require.NoError(t, err)
+
+		payload := prefs.GetPayload()
+		assert.Equal(t, homeDashUID, payload.HomeDashboardUID, "homeDashboardUID")
+		assert.Equal(t, wantTheme, payload.Theme, "theme")
+		assert.Equal(t, wantTimezone, payload.Timezone, "timezone")
+		assert.Equal(t, wantWeek, payload.WeekStart, "weekStart")
+		assert.Equal(t, wantLanguage, payload.Language, "language")
+
+		// Verify the org name was applied via PUT /api/org.
+		org, err := gClient.Org.GetCurrentOrg()
+		require.NoError(t, err)
+		assert.Equal(t, wantOrgName, org.GetPayload().Name, "organization name")
+
+		// Cleanup. Reset the org name so the shared testcontainer Grafana
+		// looks the way other specs expect.
+		require.NoError(t, cl.Delete(testCtx, dash))
+
+		_, err = dr.Reconcile(testCtx, tk8s.GetRequest(t, dash))
+		require.NoError(t, err)
+
+		_, err = gClient.Org.UpdateCurrentOrg(&models.UpdateOrgForm{Name: "Main Org."}) //nolint:errcheck
+		require.NoError(t, err)
+	})
+
+	It("clears the PreferencesApplied condition when spec.preferences is unset", func() {
+		fresh := &v1beta1.Grafana{}
+		require.NoError(t, cl.Get(testCtx, gReq.NamespacedName, fresh))
+
+		fresh.Spec.Preferences = nil
+		require.NoError(t, cl.Update(testCtx, fresh))
+
+		r := &GrafanaReconciler{Client: cl, Scheme: cl.Scheme()}
+		_, err := r.Reconcile(testCtx, gReq)
+		require.NoError(t, err)
+
+		got := &v1beta1.Grafana{}
+		require.NoError(t, cl.Get(testCtx, gReq.NamespacedName, got))
+
+		assert.False(t, tk8s.HasCondition(t, got, metav1.Condition{
+			Type:   grafanareconciler.ConditionPreferencesApplied,
+			Reason: "HomeDashboardMissing",
+		}), "PreferencesApplied condition should be removed when preferences are unset")
+		assert.False(t, tk8s.HasCondition(t, got, metav1.Condition{
+			Type:   grafanareconciler.ConditionPreferencesApplied,
+			Reason: "PreferencesApplied",
+		}), "PreferencesApplied condition should be removed when preferences are unset")
+	})
+})

--- a/controllers/reconcilers/grafana/preferences_reconciler.go
+++ b/controllers/reconcilers/grafana/preferences_reconciler.go
@@ -1,0 +1,51 @@
+package grafana
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	grafanaclient "github.com/grafana/grafana-operator/v5/controllers/client"
+	"github.com/grafana/grafana-operator/v5/controllers/reconcilers"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type PreferencesReconciler struct {
+	client client.Client
+}
+
+func NewPreferencesReconciler(cl client.Client) reconcilers.OperatorGrafanaReconciler {
+	return &PreferencesReconciler{
+		client: cl,
+	}
+}
+
+func (r *PreferencesReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, _ *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+	log := logf.FromContext(ctx).WithName("PreferencesReconciler")
+
+	if cr.Spec.Preferences == nil {
+		return v1beta1.OperatorStageResultSuccess, nil
+	}
+
+	gClient, err := grafanaclient.NewGeneratedGrafanaClient(ctx, r.client, cr)
+	if err != nil {
+		return v1beta1.OperatorStageResultFailed, fmt.Errorf("building grafana api client: %w", err)
+	}
+
+	// PATCH so empty fields don't clobber preferences set elsewhere.
+	// Add new fields here as they are added to v1beta1.GrafanaPreferences.
+	cmd := &models.PatchPrefsCmd{
+		HomeDashboardUID: cr.Spec.Preferences.HomeDashboardUID,
+	}
+
+	if _, err := gClient.Org.PatchOrgPreferences(cmd); err != nil {
+		return v1beta1.OperatorStageResultFailed, fmt.Errorf("patching org preferences: %w", err)
+	}
+
+	log.V(1).Info("preferences applied")
+
+	return v1beta1.OperatorStageResultSuccess, nil
+}

--- a/controllers/reconcilers/grafana/preferences_reconciler.go
+++ b/controllers/reconcilers/grafana/preferences_reconciler.go
@@ -2,15 +2,29 @@ package grafana
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
+	"github.com/go-openapi/runtime"
+	genapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	grafanaclient "github.com/grafana/grafana-operator/v5/controllers/client"
 	"github.com/grafana/grafana-operator/v5/controllers/reconcilers"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rt "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	ConditionPreferencesApplied = "PreferencesApplied"
+
+	reasonPreferencesApplied   = "PreferencesApplied"
+	reasonHomeDashboardMissing = "HomeDashboardMissing"
 )
 
 type PreferencesReconciler struct {
@@ -23,10 +37,11 @@ func NewPreferencesReconciler(cl client.Client) reconcilers.OperatorGrafanaRecon
 	}
 }
 
-func (r *PreferencesReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, _ *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
+func (r *PreferencesReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, _ *v1beta1.OperatorReconcileVars, _ *rt.Scheme) (v1beta1.OperatorStageStatus, error) {
 	log := logf.FromContext(ctx).WithName("PreferencesReconciler")
 
 	if cr.Spec.Preferences == nil {
+		meta.RemoveStatusCondition(&cr.Status.Conditions, ConditionPreferencesApplied)
 		return v1beta1.OperatorStageResultSuccess, nil
 	}
 
@@ -39,13 +54,86 @@ func (r *PreferencesReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafa
 	// Add new fields here as they are added to v1beta1.GrafanaPreferences.
 	cmd := &models.PatchPrefsCmd{
 		HomeDashboardUID: cr.Spec.Preferences.HomeDashboardUID,
+		Theme:            cr.Spec.Preferences.Theme,
+		Timezone:         cr.Spec.Preferences.Timezone,
+		WeekStart:        cr.Spec.Preferences.WeekStart,
+		Language:         cr.Spec.Preferences.Language,
 	}
 
-	if _, err := gClient.Org.PatchOrgPreferences(cmd); err != nil {
+	if _, err := gClient.Org.PatchOrgPreferences(cmd); err != nil { //nolint:errcheck
+		// Grafana returns 404 when HomeDashboardUID points to a dashboard
+		// that doesn't exist yet. Treat as a soft failure so the instance
+		// stays Ready and dashboard reconciles can still create it; the
+		// Grafana CR re-reconciles when a matching GrafanaDashboard appears
+		// (see GrafanaReconciler.SetupWithManager).
+		if apiErr, ok := errors.AsType[*runtime.APIError](err); ok && apiErr.Code == http.StatusNotFound { //nolint:forbidigo
+			log.Info("home dashboard not found, will retry once it exists",
+				"uid", cr.Spec.Preferences.HomeDashboardUID)
+			setPreferencesPending(&cr.Status.Conditions, cr.Generation, cr.Spec.Preferences.HomeDashboardUID)
+
+			return v1beta1.OperatorStageResultSuccess, nil
+		}
+
 		return v1beta1.OperatorStageResultFailed, fmt.Errorf("patching org preferences: %w", err)
 	}
 
+	if err := r.applyOrganizationName(ctx, gClient, cr.Spec.Preferences.OrganizationName); err != nil {
+		return v1beta1.OperatorStageResultFailed, err
+	}
+
+	setPreferencesApplied(&cr.Status.Conditions, cr.Generation)
 	log.V(1).Info("preferences applied")
 
 	return v1beta1.OperatorStageResultSuccess, nil
+}
+
+// applyOrganizationName sets the org's display name via PUT /api/org if the
+// configured name is non-empty and differs from the current name. Reading the
+// current name first avoids generating audit-log noise on every reconcile when
+// the name is already what the spec asks for.
+func (r *PreferencesReconciler) applyOrganizationName(ctx context.Context, gClient *genapi.GrafanaHTTPAPI, want string) error {
+	if want == "" {
+		return nil
+	}
+
+	log := logf.FromContext(ctx).WithName("PreferencesReconciler")
+
+	current, err := gClient.Org.GetCurrentOrg()
+	if err != nil {
+		return fmt.Errorf("getting current org: %w", err)
+	}
+
+	if current.GetPayload().Name == want {
+		return nil
+	}
+
+	if _, err := gClient.Org.UpdateCurrentOrg(&models.UpdateOrgForm{Name: want}); err != nil { //nolint:errcheck
+		return fmt.Errorf("updating org name: %w", err)
+	}
+
+	log.Info("organization name updated", "from", current.GetPayload().Name, "to", want)
+
+	return nil
+}
+
+func setPreferencesApplied(conditions *[]metav1.Condition, generation int64) {
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ConditionPreferencesApplied,
+		Status:             metav1.ConditionTrue,
+		Reason:             reasonPreferencesApplied,
+		Message:            "Grafana preferences applied",
+		ObservedGeneration: generation,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	})
+}
+
+func setPreferencesPending(conditions *[]metav1.Condition, generation int64, uid string) {
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ConditionPreferencesApplied,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonHomeDashboardMissing,
+		Message:            fmt.Sprintf("home dashboard %q not found in Grafana; preference will be applied once the dashboard exists", uid),
+		ObservedGeneration: generation,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	})
 }

--- a/controllers/reconcilers/grafana/preferences_reconciler_test.go
+++ b/controllers/reconcilers/grafana/preferences_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -26,5 +27,6 @@ var _ = Describe("Reconcile Preferences", func() {
 
 		require.NoError(t, err)
 		assert.Equal(t, v1beta1.OperatorStageResultSuccess, status)
+		assert.Nil(t, meta.FindStatusCondition(cr.Status.Conditions, ConditionPreferencesApplied))
 	})
 })

--- a/controllers/reconcilers/grafana/preferences_reconciler_test.go
+++ b/controllers/reconcilers/grafana/preferences_reconciler_test.go
@@ -1,0 +1,30 @@
+package grafana
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+)
+
+var _ = Describe("Reconcile Preferences", func() {
+	t := GinkgoT()
+
+	It("is a no-op when spec.preferences is nil", func() {
+		r := NewPreferencesReconciler(cl)
+		cr := &v1beta1.Grafana{
+			Spec: v1beta1.GrafanaSpec{
+				Preferences: nil,
+			},
+		}
+
+		status, err := r.Reconcile(context.Background(), cr, &v1beta1.OperatorReconcileVars{}, scheme.Scheme)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1beta1.OperatorStageResultSuccess, status)
+	})
+})

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
@@ -8261,6 +8261,30 @@ spec:
                   description: Preferences holds the Grafana Preferences settings
                   properties:
                     homeDashboardUid:
+                      description: HomeDashboardUID is the UID of the dashboard shown on the org's home page.
+                      type: string
+                    language:
+                      description: Language is the default UI language as a locale code (e.g. "en-US", "de-DE").
+                      type: string
+                    organizationName:
+                      description: |-
+                        OrganizationName sets the display name of the org (defaults to "Main Org."
+                        in a fresh Grafana). Backed by PUT /api/org. Skipped when empty; reading
+                        back via GET /api/org is used to avoid an unnecessary write when the
+                        configured name already matches.
+                      type: string
+                    theme:
+                      description: |-
+                        Theme is the default UI theme for the org (e.g. "light", "dark", "system").
+                        Accepted values depend on the running Grafana version.
+                      type: string
+                    timezone:
+                      description: |-
+                        Timezone is the default timezone for the org. Accepts an IANA timezone
+                        name (e.g. "America/New_York"), "utc", or "browser".
+                      type: string
+                    weekStart:
+                      description: WeekStart is the day the calendar week starts on (e.g. "monday", "sunday").
                       type: string
                   type: object
                 route:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -12411,6 +12411,33 @@ spec:
                 description: Preferences holds the Grafana Preferences settings
                 properties:
                   homeDashboardUid:
+                    description: HomeDashboardUID is the UID of the dashboard shown
+                      on the org's home page.
+                    type: string
+                  language:
+                    description: Language is the default UI language as a locale code
+                      (e.g. "en-US", "de-DE").
+                    type: string
+                  organizationName:
+                    description: |-
+                      OrganizationName sets the display name of the org (defaults to "Main Org."
+                      in a fresh Grafana). Backed by PUT /api/org. Skipped when empty; reading
+                      back via GET /api/org is used to avoid an unnecessary write when the
+                      configured name already matches.
+                    type: string
+                  theme:
+                    description: |-
+                      Theme is the default UI theme for the org (e.g. "light", "dark", "system").
+                      Accepted values depend on the running Grafana version.
+                    type: string
+                  timezone:
+                    description: |-
+                      Timezone is the default timezone for the org. Accepts an IANA timezone
+                      name (e.g. "America/New_York"), "utc", or "browser".
+                    type: string
+                  weekStart:
+                    description: WeekStart is the day the calendar week starts on
+                      (e.g. "monday", "sunday").
                     type: string
                 type: object
               route:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -27569,7 +27569,47 @@ Preferences holds the Grafana Preferences settings
         <td><b>homeDashboardUid</b></td>
         <td>string</td>
         <td>
-          <br/>
+          HomeDashboardUID is the UID of the dashboard shown on the org's home page.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>language</b></td>
+        <td>string</td>
+        <td>
+          Language is the default UI language as a locale code (e.g. "en-US", "de-DE").<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>organizationName</b></td>
+        <td>string</td>
+        <td>
+          OrganizationName sets the display name of the org (defaults to "Main Org."
+in a fresh Grafana). Backed by PUT /api/org. Skipped when empty; reading
+back via GET /api/org is used to avoid an unnecessary write when the
+configured name already matches.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>theme</b></td>
+        <td>string</td>
+        <td>
+          Theme is the default UI theme for the org (e.g. "light", "dark", "system").
+Accepted values depend on the running Grafana version.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>timezone</b></td>
+        <td>string</td>
+        <td>
+          Timezone is the default timezone for the org. Accepts an IANA timezone
+name (e.g. "America/New_York"), "utc", or "browser".<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>weekStart</b></td>
+        <td>string</td>
+        <td>
+          WeekStart is the day the calendar week starts on (e.g. "monday", "sunday").<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
The homeDashboardUid field on Grafana.spec.preferences silently no-ops unless a GrafanaDashboard CR with a matching UID happens to reconcile, because that's the only place UpdateOrgPreferences gets called. Home dashboards sourced from anywhere else (provisioning.grafana.app Repository / Git Sync, the kubernetes admin API, manual import) leave the preference unset.

A new PreferencesReconciler stage runs on every Grafana CR reconcile and PATCHes the configured fields directly. It runs after deployment and before complete, and is a no-op when spec.preferences is empty. PATCH semantics keep fields from clobbering each other when only some are configured.

A 404 from the PATCH (when homeDashboardUid points at a dashboard that doesn't exist yet) is treated as a soft failure: warn, set a PreferencesApplied=False/HomeDashboardMissing status condition, return success. The instance stays Ready so the dashboard reconciler can still create the dashboard. Other errors still hard-fail. The Grafana controller watches GrafanaDashboard indexed by spec.preferences.homeDashboardUID, so when a referenced dashboard's status.UID is populated the Grafana CR re-reconciles and the PATCH retries automatically.

spec.preferences also accepts theme, timezone, weekStart, and language. Grafana validates them server-side.

The old dashboard-controller path is gone since the new stage covers its only case.

Integration tests in controllers/preferences_reconciler_test.go use the existing testcontainer Grafana from suite_test.go to cover the deadlock scenario, the recovery path after the dashboard appears, and condition cleanup when preferences are unset. Unit tests cover the index function and dashboard watch map function.

<!--

Thank you for investing your time in contributing to our project - we appreciate
it!

Please make sure to review our policy on code contributions:

The submitter is responsible for the code change, regardless of where that code
change came from, whether they wrote it themselves, used an "AI" or other tool,
or got it from someone else. That responsibility includes making sure that the
code change can be submitted under the Apache 2.0 license that we use.

The submitter needs to understand what code they are changing, what the change
does, and justify that change in the commit messages. Using coding assistants or
"AI" or other tools does not grant additional privileges or reduce our
expectations.

We'll get back to you once we had time to review your PR. If you want to discuss
your PR in a synchronous way, you can join our weekly sync call! The invite link
can be found in the README.md of the project
-->
