### PR TITLE
chore(renovate): disable npm manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
     "ghcr.io/grafana/grafana-operator",
     "github.com/openshift/api"
   ],
+  "npm": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
- renovate:
  - disabled `npm` manager:
    - as discussed over Slack, it's worth disabling the `npm` manager for these reasons:
      - we use NPM deps only to build docs, so the deps don’t necessarily have to be up-to-date;
      - we don’t have much testing on the results, so something breaking might go unnoticed;
      - there are simply way too many irrelevant updates;
      - given the history of malicious code published to NPM, it creates risks.