### PR TITLE
fix(controllers): incorrect matchExpressions (DoesNotExist / NotIn) handling for instances with no labels

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -200,24 +200,24 @@ func getFolderUID(ctx context.Context, cl client.Client, ref v1beta1.FolderRefer
 
 func labelsSatisfyMatchExpressions(labels map[string]string, matchExpressions []metav1.LabelSelectorRequirement) bool {
 	// To preserve support for scenario with instanceSelector: {}
-	if len(labels) == 0 {
+	if len(matchExpressions) == 0 {
 		return true
 	}
 
 	for _, matchExpression := range matchExpressions {
-		selected := false
+		label, exists := labels[matchExpression.Key]
 
-		if label, ok := labels[matchExpression.Key]; ok {
-			switch matchExpression.Operator {
-			case metav1.LabelSelectorOpDoesNotExist:
-				selected = false
-			case metav1.LabelSelectorOpExists:
-				selected = true
-			case metav1.LabelSelectorOpIn:
-				selected = slices.Contains(matchExpression.Values, label)
-			case metav1.LabelSelectorOpNotIn:
-				selected = !slices.Contains(matchExpression.Values, label)
-			}
+		var selected bool
+
+		switch matchExpression.Operator {
+		case metav1.LabelSelectorOpDoesNotExist:
+			selected = !exists
+		case metav1.LabelSelectorOpExists:
+			selected = exists
+		case metav1.LabelSelectorOpIn:
+			selected = exists && slices.Contains(matchExpression.Values, label)
+		case metav1.LabelSelectorOpNotIn:
+			selected = !exists || !slices.Contains(matchExpression.Values, label)
 		}
 
 		// All matchExpressions must evaluate to true in order to satisfy the conditions

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -199,21 +199,16 @@ func getFolderUID(ctx context.Context, cl client.Client, ref v1beta1.FolderRefer
 }
 
 func labelsSatisfyMatchExpressions(labels map[string]string, matchExpressions []metav1.LabelSelectorRequirement) bool {
-	// To preserve support for scenario with instanceSelector: {}
-	if len(matchExpressions) == 0 {
-		return true
-	}
-
 	for _, matchExpression := range matchExpressions {
+		selected := false
+
 		label, exists := labels[matchExpression.Key]
 
-		var selected bool
-
 		switch matchExpression.Operator {
-		case metav1.LabelSelectorOpDoesNotExist:
-			selected = !exists
 		case metav1.LabelSelectorOpExists:
 			selected = exists
+		case metav1.LabelSelectorOpDoesNotExist:
+			selected = !exists
 		case metav1.LabelSelectorOpIn:
 			selected = exists && slices.Contains(matchExpression.Values, label)
 		case metav1.LabelSelectorOpNotIn:

--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -97,12 +97,51 @@ func TestLabelsSatisfyMatchExpressions(t *testing.T) {
 			want:             true,
 		},
 		{
-			name:   "No labels",
+			name:   "No labels does not match Exists",
 			labels: map[string]string{},
 			matchExpressions: []metav1.LabelSelectorRequirement{
 				{
 					Operator: metav1.LabelSelectorOpExists,
 					Key:      "dashboards",
+				},
+			},
+			want: false,
+		},
+		{
+			name:   "No labels matches DoesNotExist",
+			labels: map[string]string{},
+			matchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+					Key:      "dashboards",
+				},
+			},
+			want: true,
+		},
+		{
+			name:   "No labels does not match In",
+			labels: map[string]string{},
+			matchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Operator: metav1.LabelSelectorOpIn,
+					Key:      "dashboards",
+					Values: []string{
+						"grafana",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:   "No labels matches NotIn",
+			labels: map[string]string{},
+			matchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Operator: metav1.LabelSelectorOpNotIn,
+					Key:      "dashboards",
+					Values: []string{
+						"grafana",
+					},
 				},
 			},
 			want: true,
@@ -276,6 +315,35 @@ func TestLabelsSatisfyMatchExpressions(t *testing.T) {
 				},
 			},
 			want: false,
+		},
+		{
+			name: "Missing label matches DoesNotExist",
+			labels: map[string]string{
+				"random-label": "random-value",
+			},
+			matchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+					Key:      "dashboards",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Missing label matches NotIn",
+			labels: map[string]string{
+				"random-label": "random-value",
+			},
+			matchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Operator: metav1.LabelSelectorOpNotIn,
+					Key:      "dashboards",
+					Values: []string{
+						"grafana",
+					},
+				},
+			},
+			want: true,
 		},
 	}
 


### PR DESCRIPTION
## What changing

Fixes `instanceSelector.matchExpressions` for Grafana instances that are missing the selected label entirely

`DoesNotExist` and `NotIn` werent working correctly when a label key was absent - selector check would skip evaluation rather then treating the missing key as matching those operators. 
Thats not how Kubernetes label selectors are supposed to work

## Reproducing bug

Apply a Grafana instance without `dashboards` label:

```yaml
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
metadata:
  name: grafana-a
spec:
  config:
    auth:
      disable_login_form: "false"
```

then add a resource with:

```yaml
spec:
  instanceSelector:
    matchExpressions:
      - key: dashboards
        operator: DoesNotExist
```

`grafana-a` should match, but before a fix, it didnt leaving resource with no matching instances

## Verification

```
go test ./controllers -run TestLabelsSatisfyMatchExpressions -count=1
make all
```

Labels in Kubernetes are optional and mutable, so `DoesNotExist` / `NotIn` against a missing key is a real and valid use case

This PR is related to selector support added in #1497. Not claiming this fixes #2132 - that ones about cleanup when labels change, which is a related but seperate issue
