### PR TITLE
feat(featureflags): extend FeatureFlag type

### DIFF
--- a/controllers/config/feature_flags.go
+++ b/controllers/config/feature_flags.go
@@ -1,0 +1,14 @@
+package config
+
+import "github.com/grafana/grafana-operator/v5/pkg/featureflags"
+
+// var FoldersUseNewAPI = featureflags.FeatureFlag{
+// 	Name:         "FoldersUseNewAPI",
+// 	IsActive:     false,
+// 	IsDeprecated: false,
+// 	Description:  "Use Grafana 13+ API-server style APIs for the folder controller",
+// }
+
+var FeatureFlags = featureflags.FeatureFlags{
+	// FoldersUseNewAPI.Name: &FoldersUseNewAPI,
+}

--- a/controllers/config/feature_flags.go
+++ b/controllers/config/feature_flags.go
@@ -9,6 +9,6 @@ import "github.com/grafana/grafana-operator/v5/pkg/featureflags"
 // 	Description:  "Use Grafana 13+ API-server style APIs for the folder controller",
 // }
 
-var FeatureFlags = featureflags.FeatureFlags{
-	// FoldersUseNewAPI.Name: &FoldersUseNewAPI,
-}
+var FeatureFlags = featureflags.NewFeatureFlags(
+// FoldersUseNewAPI,
+)

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/config"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -61,10 +61,10 @@ import (
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers"
+	"github.com/grafana/grafana-operator/v5/controllers/config"
 	"github.com/grafana/grafana-operator/v5/controllers/resources"
 	"github.com/grafana/grafana-operator/v5/embeds"
 	"github.com/grafana/grafana-operator/v5/pkg/autodetect"
-	"github.com/grafana/grafana-operator/v5/pkg/featureflags"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -196,10 +196,12 @@ func main() { //nolint:gocyclo
 	slogger := slog.New(logr.ToSlogHandler(setupLog))
 	slog.SetDefault(slogger)
 
-	if err := featureflags.SetActiveFromArg(operatorConfig.FeatureFlags); err != nil {
+	if err := config.FeatureFlags.SetActiveFromArg(operatorConfig.FeatureFlags); err != nil {
 		setupLog.Error(err, "failed to parse feature flags")
 		os.Exit(1)
 	}
+
+	slog.Info("activation status of the feature flags", "flags", fmt.Sprint(config.FeatureFlags))
 
 	// Optimize Go runtime based on CGroup limits (GOMEMLIMIT, sets a soft memory limit for the runtime)
 	memlimit.SetGoMemLimitWithOpts(memlimit.WithLogger(slogger)) //nolint:errcheck
@@ -239,7 +241,7 @@ func main() { //nolint:gocyclo
 		LeaderElection:         operatorConfig.EnableLeaderElection,
 		LeaderElectionID:       fmt.Sprintf("grafana-operator-%x", leHash.Sum(nil)),
 		PprofBindAddress:       operatorConfig.PprofAddr,
-		Controller: config.Controller{
+		Controller: ctrlconfig.Controller{
 			MaxConcurrentReconciles: operatorConfig.MaxConcurrentReconciles,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func main() { //nolint:gocyclo
 		os.Exit(1)
 	}
 
-	slog.Info("activation status of the feature flags", "flags", fmt.Sprint(config.FeatureFlags))
+	setupLog.Info("activation status of the feature flags", "flags", fmt.Sprint(config.FeatureFlags))
 
 	// Optimize Go runtime based on CGroup limits (GOMEMLIMIT, sets a soft memory limit for the runtime)
 	memlimit.SetGoMemLimitWithOpts(memlimit.WithLogger(slogger)) //nolint:errcheck

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -74,3 +74,13 @@ func (ffs FeatureFlags) String() string {
 
 	return strings.Join(withStatus, ", ")
 }
+
+func NewFeatureFlags(flags ...FeatureFlag) FeatureFlags {
+	ffs := FeatureFlags{}
+
+	for _, ff := range flags {
+		ffs[ff.Name] = &ff
+	}
+
+	return ffs
+}

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -3,75 +3,58 @@ package featureflags
 import (
 	"errors"
 	"fmt"
-	"maps"
-	"slices"
+	"sort"
 	"strings"
 )
 
-type FeatureFlag string
+var ErrUknownFeatureFlag = errors.New("unknown feature flag")
 
-var (
-	ErrActiveNotInitialized = errors.New("field with active flags is not initialized")
-	ErrUknownFeatureFlag    = errors.New("unknown feature flag")
-)
-
-type FeatureFlags struct {
-	// available is the source of truth of flags available to the user. The value in the map should contain documentation for the feature flag
-	available map[FeatureFlag]string
-	active    map[FeatureFlag]bool
+type FeatureFlag struct {
+	Name         string
+	IsActive     bool
+	IsDeprecated bool
+	Description  string
 }
 
-func (ffs *FeatureFlags) IsActive(ff FeatureFlag) bool {
-	// TODO: handle not available
-	return ffs.active[ff]
+func (ff FeatureFlag) String() string {
+	return fmt.Sprintf("%s: %t", ff.Name, ff.IsActive)
 }
 
-func (ffs *FeatureFlags) IsAvailable(ff FeatureFlag) bool {
-	// TODO: handle not available
-	_, isAvailable := ffs.available[ff]
+type FeatureFlags map[string]*FeatureFlag
 
-	return isAvailable
-}
-
-func (ffs *FeatureFlags) SetActive(ff FeatureFlag) error {
-	if ffs.active == nil {
-		return ErrActiveNotInitialized
+func (ffs FeatureFlags) SetActive(name string) error {
+	if _, ok := ffs[name]; !ok {
+		return ErrUknownFeatureFlag
 	}
 
-	if ffs.IsAvailable(ff) {
-		// TODO: add safety?
-		ffs.active[ff] = true
+	ffs[name].IsActive = true
 
-		return nil
-	}
-
-	return ErrUknownFeatureFlag
+	return nil
 }
 
-func (ffs *FeatureFlags) SetActiveFromArg(arg string) error {
-	toActivate := []FeatureFlag{}
+func (ffs FeatureFlags) SetActiveFromArg(arg string) error {
+	toActivate := []string{}
 	unknown := []string{}
 
-	for f := range strings.SplitSeq(arg, ",") {
-		if f == "" {
+	for name := range strings.SplitSeq(arg, ",") {
+		if name == "" {
 			continue
 		}
 
-		ff := FeatureFlag(f)
-
-		if ffs.IsAvailable(ff) {
-			toActivate = append(toActivate, ff)
-		} else {
-			unknown = append(unknown, f)
+		if _, ok := ffs[name]; !ok {
+			unknown = append(unknown, name)
+			continue
 		}
+
+		toActivate = append(toActivate, name)
 	}
 
 	if len(unknown) > 0 {
 		return fmt.Errorf("unknown feature flags: %s", strings.Join(unknown, ","))
 	}
 
-	for _, ff := range toActivate {
-		err := ffs.SetActive(ff)
+	for _, name := range toActivate {
+		err := ffs.SetActive(name)
 		if err != nil {
 			return err
 		}
@@ -80,29 +63,14 @@ func (ffs *FeatureFlags) SetActiveFromArg(arg string) error {
 	return nil
 }
 
-func (ffs *FeatureFlags) String() string {
-	available := slices.Sorted(maps.Keys(ffs.available))
+func (ffs FeatureFlags) String() string {
+	withStatus := make([]string, 0, len(ffs))
 
-	withStatus := make([]string, 0, len(available))
-
-	for _, ff := range available {
-		withStatus = append(
-			withStatus, fmt.Sprintf("%s: %t", ff, ffs.IsActive(ff)),
-		)
+	for _, v := range ffs {
+		withStatus = append(withStatus, v.String())
 	}
+
+	sort.Strings(withStatus)
 
 	return strings.Join(withStatus, ", ")
-}
-
-func NewFeatureFlags(availableFlags map[FeatureFlag]string) FeatureFlags {
-	if availableFlags == nil {
-		availableFlags = map[FeatureFlag]string{}
-	}
-
-	ffs := FeatureFlags{
-		available: availableFlags,
-		active:    map[FeatureFlag]bool{},
-	}
-
-	return ffs
 }

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -1,49 +1,108 @@
 package featureflags
 
 import (
+	"errors"
 	"fmt"
-	"log/slog"
+	"maps"
+	"slices"
 	"strings"
 )
 
-var activeFlags map[featureFlag]bool = make(map[featureFlag]bool)
+type FeatureFlag string
 
-type featureFlag string
+var (
+	ErrActiveNotInitialized = errors.New("field with active flags is not initialized")
+	ErrUknownFeatureFlag    = errors.New("unknown feature flag")
+)
 
-// availableFlags is the source of truth of flags available to the user. The value in the map should contain documentation for the feature flag
-var availableFlags = map[featureFlag]string{}
-
-func SetActiveFromArg(arg string) error {
-	active, err := parseFlags(arg, availableFlags)
-	if err != nil {
-		return err
-	}
-
-	activeFlags = active
-
-	return nil
+type FeatureFlags struct {
+	// available is the source of truth of flags available to the user. The value in the map should contain documentation for the feature flag
+	available map[FeatureFlag]string
+	active    map[FeatureFlag]bool
 }
 
-func parseFlags(arg string, existing map[featureFlag]string) (map[featureFlag]bool, error) {
-	active := make(map[featureFlag]bool)
+func (ffs *FeatureFlags) IsActive(ff FeatureFlag) bool {
+	// TODO: handle not available
+	return ffs.active[ff]
+}
+
+func (ffs *FeatureFlags) IsAvailable(ff FeatureFlag) bool {
+	// TODO: handle not available
+	_, isAvailable := ffs.available[ff]
+
+	return isAvailable
+}
+
+func (ffs *FeatureFlags) SetActive(ff FeatureFlag) error {
+	if ffs.active == nil {
+		return ErrActiveNotInitialized
+	}
+
+	if ffs.IsAvailable(ff) {
+		// TODO: add safety?
+		ffs.active[ff] = true
+
+		return nil
+	}
+
+	return ErrUknownFeatureFlag
+}
+
+func (ffs *FeatureFlags) SetActiveFromArg(arg string) error {
+	toActivate := []FeatureFlag{}
+	unknown := []string{}
 
 	for f := range strings.SplitSeq(arg, ",") {
 		if f == "" {
 			continue
 		}
 
-		ff := featureFlag(f)
-		if _, ok := existing[ff]; !ok {
-			return nil, fmt.Errorf("unknown feature flag: '%s'", ff)
-		}
+		ff := FeatureFlag(f)
 
-		slog.Info("activating feature flag", "flag", ff)
-		active[ff] = true
+		if ffs.IsAvailable(ff) {
+			toActivate = append(toActivate, ff)
+		} else {
+			unknown = append(unknown, f)
+		}
 	}
 
-	return active, nil
+	if len(unknown) > 0 {
+		return fmt.Errorf("unknown feature flags: %s", strings.Join(unknown, ","))
+	}
+
+	for _, ff := range toActivate {
+		err := ffs.SetActive(ff)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-func IsEnabled(flag featureFlag) bool {
-	return activeFlags[flag]
+func (ffs *FeatureFlags) String() string {
+	available := slices.Sorted(maps.Keys(ffs.available))
+
+	withStatus := make([]string, 0, len(available))
+
+	for _, ff := range available {
+		withStatus = append(
+			withStatus, fmt.Sprintf("%s: %t", ff, ffs.IsActive(ff)),
+		)
+	}
+
+	return strings.Join(withStatus, ", ")
+}
+
+func NewFeatureFlags(availableFlags map[FeatureFlag]string) FeatureFlags {
+	if availableFlags == nil {
+		availableFlags = map[FeatureFlag]string{}
+	}
+
+	ffs := FeatureFlags{
+		available: availableFlags,
+		active:    map[FeatureFlag]bool{},
+	}
+
+	return ffs
 }

--- a/pkg/featureflags/featureflags_test.go
+++ b/pkg/featureflags/featureflags_test.go
@@ -1,59 +1,164 @@
 package featureflags
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestFeatureFlagParsing(t *testing.T) {
+func TestFeatureFlagsIsActive(t *testing.T) {
+	fActive := FeatureFlag("active")
+	fInactive := FeatureFlag("inactive")
+
+	ffs := FeatureFlags{
+		active: map[FeatureFlag]bool{
+			fActive:   true,
+			fInactive: false,
+		},
+	}
+
+	assert.True(t, ffs.IsActive(fActive))
+	assert.False(t, ffs.IsActive(fInactive))
+}
+
+func TestFeatureFlagsIsAvailable(t *testing.T) {
+	fAvailable := FeatureFlag("available")
+	fNonAvailable := FeatureFlag("non-available")
+
+	ffs := FeatureFlags{
+		available: map[FeatureFlag]string{
+			fAvailable: "test flag",
+		},
+	}
+
+	assert.True(t, ffs.IsAvailable(fAvailable))
+	assert.False(t, ffs.IsAvailable(fNonAvailable))
+}
+
+func TestFeatureFlagsSetActive(t *testing.T) {
+	fAvailable := FeatureFlag("available")
+	fNonAvailable := FeatureFlag("non-available")
+
+	ffs := FeatureFlags{
+		available: map[FeatureFlag]string{
+			fAvailable: "test flag",
+		},
+		active: map[FeatureFlag]bool{},
+	}
+
+	err := ffs.SetActive(fAvailable)
+	require.NoError(t, err)
+
+	err = ffs.SetActive(fNonAvailable)
+	require.ErrorIs(t, err, ErrUknownFeatureFlag)
+}
+
+func TestFeatureFlagsSetActiveFromArg(t *testing.T) {
+	fAvailable1 := FeatureFlag("available1")
+	fAvailable2 := FeatureFlag("available2")
+
 	tests := []struct {
-		name    string
-		arg     string
-		valid   map[featureFlag]string
-		want    map[featureFlag]bool
-		wantErr string
+		name       string
+		arg        string
+		wantActive map[FeatureFlag]bool
+		wantError  bool
 	}{
 		{
-			name: "Empty arg",
-			arg:  "",
-			valid: map[featureFlag]string{
-				"flag1": "",
-			},
-			want: map[featureFlag]bool{},
+			name:       "empty arg",
+			arg:        "",
+			wantActive: map[FeatureFlag]bool{},
+			wantError:  false,
 		},
 		{
-			name: "Valid feature flags",
-			arg:  "flag1,flag2",
-			valid: map[featureFlag]string{
-				"flag1": "",
-				"flag2": "",
-				"flag3": "",
-			},
-			want: map[featureFlag]bool{
-				"flag1": true,
-				"flag2": true,
+			name: "valid flag",
+			arg:  fmt.Sprintf("%s", fAvailable1),
+			wantActive: map[FeatureFlag]bool{
+				fAvailable1: true,
 			},
 		},
 		{
-			name: "Invalid feature flag",
-			arg:  "flag1,flag2",
-			valid: map[featureFlag]string{
-				"flag1": "",
+			name: "valid flags",
+			arg:  fmt.Sprintf("%s,%s", fAvailable1, fAvailable2),
+			wantActive: map[FeatureFlag]bool{
+				fAvailable1: true,
+				fAvailable2: true,
 			},
-			wantErr: "invalid",
+		},
+		{
+			name:       "invalid flag",
+			arg:        "non-available",
+			wantActive: map[FeatureFlag]bool{},
+			wantError:  true,
+		},
+		{
+			name:       "invalid flag amongst correct flags",
+			arg:        fmt.Sprintf("%s,%s,non-available", fAvailable1, fAvailable2),
+			wantActive: map[FeatureFlag]bool{},
+			wantError:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseFlags(tt.arg, tt.valid)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, "unknown feature flag")
+			ffs := FeatureFlags{
+				available: map[FeatureFlag]string{
+					fAvailable1: "available flag 1",
+					fAvailable2: "available flag 2",
+				},
+				active: map[FeatureFlag]bool{},
 			}
 
-			assert.Equal(t, tt.want, got)
+			err := ffs.SetActiveFromArg(tt.arg)
+			if tt.wantError {
+				require.Error(t, err)
+			}
+
+			assert.Equal(t, tt.wantActive, ffs.active)
 		})
 	}
+}
+
+func TestNewFeatureFlags(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		got := NewFeatureFlags(
+			nil,
+		)
+		want := FeatureFlags{
+			available: map[FeatureFlag]string{},
+			active:    map[FeatureFlag]bool{},
+		}
+
+		assert.Equal(t, got, want)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		got := NewFeatureFlags(
+			map[FeatureFlag]string{},
+		)
+		want := FeatureFlags{
+			available: map[FeatureFlag]string{},
+			active:    map[FeatureFlag]bool{},
+		}
+
+		assert.Equal(t, got, want)
+	})
+
+	t.Run("defined", func(t *testing.T) {
+		availableFlags := map[FeatureFlag]string{
+			FeatureFlag("flag1"): "test flag",
+		}
+
+		want := FeatureFlags{
+			available: availableFlags,
+			active:    map[FeatureFlag]bool{},
+		}
+
+		got := NewFeatureFlags(
+			availableFlags,
+		)
+
+		assert.Equal(t, got, want)
+	})
 }

--- a/pkg/featureflags/featureflags_test.go
+++ b/pkg/featureflags/featureflags_test.go
@@ -8,157 +8,108 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFeatureFlagsIsActive(t *testing.T) {
-	fActive := FeatureFlag("active")
-	fInactive := FeatureFlag("inactive")
+func getFF(t *testing.T, name string, isActive bool) *FeatureFlag {
+	t.Helper()
 
-	ffs := FeatureFlags{
-		active: map[FeatureFlag]bool{
-			fActive:   true,
-			fInactive: false,
-		},
+	ff := &FeatureFlag{
+		Name:     name,
+		IsActive: isActive,
 	}
 
-	assert.True(t, ffs.IsActive(fActive))
-	assert.False(t, ffs.IsActive(fInactive))
-}
-
-func TestFeatureFlagsIsAvailable(t *testing.T) {
-	fAvailable := FeatureFlag("available")
-	fNonAvailable := FeatureFlag("non-available")
-
-	ffs := FeatureFlags{
-		available: map[FeatureFlag]string{
-			fAvailable: "test flag",
-		},
-	}
-
-	assert.True(t, ffs.IsAvailable(fAvailable))
-	assert.False(t, ffs.IsAvailable(fNonAvailable))
+	return ff
 }
 
 func TestFeatureFlagsSetActive(t *testing.T) {
-	fAvailable := FeatureFlag("available")
-	fNonAvailable := FeatureFlag("non-available")
+	const name = "available"
 
 	ffs := FeatureFlags{
-		available: map[FeatureFlag]string{
-			fAvailable: "test flag",
-		},
-		active: map[FeatureFlag]bool{},
+		name: getFF(t, name, false),
 	}
 
-	err := ffs.SetActive(fAvailable)
+	err := ffs.SetActive(name)
 	require.NoError(t, err)
+	assert.True(t, ffs[name].IsActive)
 
-	err = ffs.SetActive(fNonAvailable)
+	err = ffs.SetActive("unknown")
 	require.ErrorIs(t, err, ErrUknownFeatureFlag)
 }
 
 func TestFeatureFlagsSetActiveFromArg(t *testing.T) {
-	fAvailable1 := FeatureFlag("available1")
-	fAvailable2 := FeatureFlag("available2")
+	const name1 = "ff1"
+	const name2 = "ff2"
 
 	tests := []struct {
-		name       string
-		arg        string
-		wantActive map[FeatureFlag]bool
-		wantError  bool
+		name      string
+		arg       string
+		ffs       FeatureFlags
+		want      FeatureFlags
+		wantError bool
 	}{
 		{
-			name:       "empty arg",
-			arg:        "",
-			wantActive: map[FeatureFlag]bool{},
-			wantError:  false,
+			name:      "empty arg",
+			arg:       "",
+			ffs:       FeatureFlags{},
+			want:      FeatureFlags{},
+			wantError: false,
 		},
 		{
 			name: "valid flag",
-			arg:  fmt.Sprintf("%s", fAvailable1),
-			wantActive: map[FeatureFlag]bool{
-				fAvailable1: true,
+			arg:  fmt.Sprintf("%s", name1),
+			ffs: FeatureFlags{
+				name1: getFF(t, name1, false),
+			},
+			want: FeatureFlags{
+				name1: getFF(t, name1, true),
 			},
 		},
 		{
 			name: "valid flags",
-			arg:  fmt.Sprintf("%s,%s", fAvailable1, fAvailable2),
-			wantActive: map[FeatureFlag]bool{
-				fAvailable1: true,
-				fAvailable2: true,
+			arg:  fmt.Sprintf("%s,%s", name1, name2),
+			ffs: FeatureFlags{
+				name1: getFF(t, name1, false),
+				name2: getFF(t, name2, false),
+			},
+			want: FeatureFlags{
+				name1: getFF(t, name1, true),
+				name2: getFF(t, name2, true),
 			},
 		},
 		{
-			name:       "invalid flag",
-			arg:        "non-available",
-			wantActive: map[FeatureFlag]bool{},
-			wantError:  true,
+			name: "uknown flag",
+			arg:  "unknown",
+			ffs: FeatureFlags{
+				name1: getFF(t, name1, false),
+			},
+			want: FeatureFlags{
+				name1: getFF(t, name1, false),
+			},
+			wantError: true,
 		},
 		{
-			name:       "invalid flag amongst correct flags",
-			arg:        fmt.Sprintf("%s,%s,non-available", fAvailable1, fAvailable2),
-			wantActive: map[FeatureFlag]bool{},
-			wantError:  true,
+			name: "unknown flag amongst correct flags",
+			arg:  fmt.Sprintf("%s,%s,unknown", name1, name2),
+			ffs: FeatureFlags{
+				name1: getFF(t, name1, false),
+			},
+			want: FeatureFlags{
+				name1: getFF(t, name1, false),
+			},
+			wantError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ffs := FeatureFlags{
-				available: map[FeatureFlag]string{
-					fAvailable1: "available flag 1",
-					fAvailable2: "available flag 2",
-				},
-				active: map[FeatureFlag]bool{},
-			}
-
-			err := ffs.SetActiveFromArg(tt.arg)
+			err := tt.ffs.SetActiveFromArg(tt.arg)
 			if tt.wantError {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.wantActive, ffs.active)
+			got := tt.ffs
+
+			assert.Equal(t, tt.want, got)
 		})
 	}
-}
-
-func TestNewFeatureFlags(t *testing.T) {
-	t.Run("nil", func(t *testing.T) {
-		got := NewFeatureFlags(
-			nil,
-		)
-		want := FeatureFlags{
-			available: map[FeatureFlag]string{},
-			active:    map[FeatureFlag]bool{},
-		}
-
-		assert.Equal(t, got, want)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		got := NewFeatureFlags(
-			map[FeatureFlag]string{},
-		)
-		want := FeatureFlags{
-			available: map[FeatureFlag]string{},
-			active:    map[FeatureFlag]bool{},
-		}
-
-		assert.Equal(t, got, want)
-	})
-
-	t.Run("defined", func(t *testing.T) {
-		availableFlags := map[FeatureFlag]string{
-			FeatureFlag("flag1"): "test flag",
-		}
-
-		want := FeatureFlags{
-			available: availableFlags,
-			active:    map[FeatureFlag]bool{},
-		}
-
-		got := NewFeatureFlags(
-			availableFlags,
-		)
-
-		assert.Equal(t, got, want)
-	})
 }

--- a/pkg/featureflags/featureflags_test.go
+++ b/pkg/featureflags/featureflags_test.go
@@ -35,8 +35,10 @@ func TestFeatureFlagsSetActive(t *testing.T) {
 }
 
 func TestFeatureFlagsSetActiveFromArg(t *testing.T) {
-	const name1 = "ff1"
-	const name2 = "ff2"
+	const (
+		name1 = "ff1"
+		name2 = "ff2"
+	)
 
 	tests := []struct {
 		name      string
@@ -54,7 +56,7 @@ func TestFeatureFlagsSetActiveFromArg(t *testing.T) {
 		},
 		{
 			name: "valid flag",
-			arg:  fmt.Sprintf("%s", name1),
+			arg:  name1,
 			ffs: FeatureFlags{
 				name1: getFF(t, name1, false),
 			},


### PR DESCRIPTION
In #2695, we added support for providing feature flags.

I thought that it might be handy to have a slightly more complex `FeatureFlag` type, so we can:
- have a way to activate a flag by default;
- mark it as deprecated;
- easily print status of all feature flags;
- merge documentation into the flag itself;
- bring it all to the same package as many other configuration options.

Thus the PR.

Pretty sure there are still some things to improve (e.g. to add a way to disable a flag from arg), let me know if you like the approach. To simplify review, I left an example of how a flag can be registered.

From `main()`, it can be referenced as:

```
if config.FoldersUseNewAPI.IsActive {
 // ...
}
```

Example of logs:

```
2026-05-16T16:08:57.692+0200    info    setup   activation status of the feature flags  {"version": "dev", "flags": "FoldersUseNewAPI: false"}
```