### PR TITLE
fix: OLM deployment of operator unable to reconcile Grafana when using kube auth

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,5 +74,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['olm.targetNamespaces']
+          volumeMounts:
+            - name: kubeauth-token-volume
+              mountPath: /var/run/secrets/grafana.com/serviceaccount
+              readOnly: true
+      volumes:
+        - name: kubeauth-token-volume
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: operator.grafana.com
+                  expirationSeconds: 3600
+                  path: token
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Addresses issue https://github.com/grafana/grafana-operator/issues/2708:  

Adds the missing `kubeauth-token-volume` volume to the Grafana operator controller manager deployment.  
(Using the same values as the helm chart template and kustomize manifest.)

Fix deployed in cluster:
```bash
$ k get po -l app.kubernetes.io/name=grafana-operator -o yaml | yq .items[0].spec.volumes[0]
name: kubeauth-token-volume
projected:
  defaultMode: 420
  sources:
    - serviceAccountToken:
        audience: operator.grafana.com
        expirationSeconds: 3600
        path: token

$ k get po -l app.kubernetes.io/name=grafana-operator -o yaml | yq .items[0].spec.containers[0].volumeMounts
- mountPath: /var/run/secrets/grafana.com/serviceaccount
  name: kubeauth-token-volume
  readOnly: true
- mountPath: /var/run/secrets/kubernetes.io/serviceaccount
  name: kube-api-access-rrkh5
  readOnly: true

$ k get grafanas.grafana.integreatly.org grafana -o yaml | yq .spec.client
useKubeAuth: true

$ k get grafanas.grafana.integreatly.org 
NAME      VERSION   STAGE      STAGE STATUS   AGE
grafana   13.0.1    complete   success        52m

```

ClusterServiceVersion:
```bash
❯ k get csv grafana-operator.v5.22.2 -o yaml | yq .spec.install.spec.deployments[0].spec.template.spec.volumes
- name: kubeauth-token-volume
  projected:
    sources:
      - serviceAccountToken:
          audience: operator.grafana.com
          expirationSeconds: 3600
          path: token

$ k get csv grafana-operator.v5.22.2 -o yaml | yq .spec.install.spec.deployments[0].spec.template.spec.containers[0].volumeMounts
- mountPath: /var/run/secrets/grafana.com/serviceaccount
  name: kubeauth-token-volume
  readOnly: true
```

_Note that I haven't incremented any versions, I got the impression that you're bumping versions in separate PRs._