### PR TITLE
feat: disable gzip compression in grafana >= 13

### DIFF
--- a/controllers/config/grafana_ini.go
+++ b/controllers/config/grafana_ini.go
@@ -6,13 +6,15 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/blang/semver/v4"
 )
 
 const globalSection = "global"
 
 // NOTE: even though there is no need to return map, it's added here to make sure
 // we can test the case where the passed value is nil
-func setDefaults(cfg map[string]map[string]string) map[string]map[string]string {
+func SetDefaults(cfg map[string]map[string]string, version string) map[string]map[string]string {
 	if cfg == nil {
 		cfg = make(map[string]map[string]string)
 	}
@@ -43,12 +45,27 @@ func setDefaults(cfg map[string]map[string]string) map[string]map[string]string 
 		cfg["unified_alerting"]["rule_version_record_limit"] = GrafanaRuleVersionRecordLimit
 	}
 
+	parsedVersion, err := semver.Parse(version)
+	if err != nil {
+		// if we can't infer the version, return early
+		return cfg
+	}
+
+	if parsedVersion.GE(semver.MustParse("13.0.0")) {
+		// OOM due to changes in gzip implementation: https://github.com/grafana/grafana/issues/123017
+		if cfg["server"] == nil {
+			cfg["server"] = make(map[string]string)
+		}
+
+		if cfg["server"]["enable_gzip"] == "" {
+			cfg["server"]["enable_gzip"] = "false"
+		}
+	}
+
 	return cfg
 }
 
 func WriteIni(cfg map[string]map[string]string) string {
-	cfg = setDefaults(cfg)
-
 	sections := make([]string, 0, len(cfg))
 	hasGlobal := false
 

--- a/controllers/config/grafana_ini_test.go
+++ b/controllers/config/grafana_ini_test.go
@@ -51,7 +51,7 @@ func getDefaultConfig(t *testing.T) map[string]map[string]string {
 
 func TestSetDefaults(t *testing.T) {
 	t.Run("Nil config is properly handled", func(t *testing.T) {
-		cfg := setDefaults(nil)
+		cfg := SetDefaults(nil, "")
 
 		got := cfg
 		want := getDefaultConfig(t)
@@ -61,7 +61,7 @@ func TestSetDefaults(t *testing.T) {
 
 	t.Run("All defaults are set", func(t *testing.T) {
 		cfg := map[string]map[string]string{}
-		cfg = setDefaults(cfg)
+		cfg = SetDefaults(cfg, "")
 
 		got := cfg
 		want := getDefaultConfig(t)
@@ -78,7 +78,7 @@ func TestSetDefaults(t *testing.T) {
 				"provisioning": "d",
 			},
 		}
-		cfg = setDefaults(cfg)
+		cfg = SetDefaults(cfg, "")
 
 		got := cfg
 		want := getDefaultConfig(t)
@@ -98,7 +98,7 @@ func TestSetDefaults(t *testing.T) {
 			"dashboards":       dashboardsOverrides,
 			"unified_alerting": unifiedAlertingOverrides,
 		}
-		cfg = setDefaults(cfg)
+		cfg = SetDefaults(cfg, "")
 
 		got := cfg
 		want := getDefaultConfig(t)
@@ -116,7 +116,7 @@ func TestSetDefaults(t *testing.T) {
 		cfg := map[string]map[string]string{
 			"custom_section": customSectionOverrides,
 		}
-		cfg = setDefaults(cfg)
+		cfg = SetDefaults(cfg, "")
 
 		got := cfg
 		want := getDefaultConfig(t)

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -170,13 +170,15 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{}, nil
 }
 
-func (r *GrafanaReconciler) setDefaultGrafanaVersion(ctx context.Context, cr client.Object) error {
+func (r *GrafanaReconciler) setDefaultGrafanaVersion(ctx context.Context, cr *v1beta1.Grafana) error {
 	// For clusters where RELATED_IMAGE_GRAFANA is set to an image hash,
 	// we want to set version to the value of the variable to support airgapped clusters as well
 	targetVersion := config.GrafanaVersion
 	if envVersion := os.Getenv("RELATED_IMAGE_GRAFANA"); isImageSHA256(envVersion) {
 		targetVersion = envVersion
 	}
+
+	cr.Spec.Version = targetVersion
 
 	// Create patch with the target version
 	patch, err := json.Marshal(map[string]any{"spec": map[string]any{"version": targetVersion}})

--- a/controllers/reconcilers/grafana/config_reconciler.go
+++ b/controllers/reconcilers/grafana/config_reconciler.go
@@ -26,7 +26,7 @@ func NewConfigReconciler(cl client.Client) reconcilers.OperatorGrafanaReconciler
 func (r *ConfigReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, vars *v1beta1.OperatorReconcileVars, scheme *runtime.Scheme) (v1beta1.OperatorStageStatus, error) {
 	_ = logf.FromContext(ctx)
 
-	cfg := config.WriteIni(cr.Spec.Config)
+	cfg := config.WriteIni(config.SetDefaults(cr.Spec.Config, cr.Spec.Version))
 	vars.ConfigHash = config.GetHash(cfg)
 
 	configMap := resources.GetGrafanaConfigMap(cr, scheme)


### PR DESCRIPTION
Moves `SetDefaults` out of the `WriteIni` function and conditionally apply a workaround for 
https://github.com/grafana/grafana/issues/123017