### PR TITLE
fix(AlertRuleGroup): normalize query model before drift compare

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -265,12 +266,33 @@ func (r *GrafanaAlertRuleGroupReconciler) matchesStateInGrafana(exists bool, mod
 		return false
 	}
 
-	matchesRemoteState := remoteModel.FolderUID == model.FolderUID &&
-		remoteModel.Interval == model.Interval &&
-		reflect.DeepEqual(remoteModel.Rules, model.Rules) &&
-		remoteModel.Title == model.Title
+	normalizedModel := normalizeAlertRuleGroupForComparison(model)
+	normalizedRemoteModel := normalizeAlertRuleGroupForComparison(remoteModel)
+
+	matchesRemoteState := normalizedRemoteModel.FolderUID == normalizedModel.FolderUID &&
+		normalizedRemoteModel.Interval == normalizedModel.Interval &&
+		reflect.DeepEqual(normalizedRemoteModel.Rules, normalizedModel.Rules) &&
+		normalizedRemoteModel.Title == normalizedModel.Title
 
 	return matchesRemoteState
+}
+
+func normalizeAlertRuleGroupForComparison(group *models.AlertRuleGroup) *models.AlertRuleGroup {
+	if group == nil {
+		return nil
+	}
+
+	raw, err := json.Marshal(group)
+	if err != nil {
+		return group
+	}
+
+	var normalized models.AlertRuleGroup
+	if err := json.Unmarshal(raw, &normalized); err != nil {
+		return group
+	}
+
+	return &normalized
 }
 
 func (r *GrafanaAlertRuleGroupReconciler) reconcileWithInstance(ctx context.Context, instance *v1beta1.Grafana, cr *v1beta1.GrafanaAlertRuleGroup, mGroup *models.AlertRuleGroup, disableProvenance *string) error {

--- a/controllers/alertrulegroup_controller_test.go
+++ b/controllers/alertrulegroup_controller_test.go
@@ -1,8 +1,12 @@
 package controllers
 
 import (
+	"encoding/json"
+	"testing"
 	"time"
 
+	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -294,3 +298,54 @@ var _ = Describe("AlertRuleGroup Controller Conversion", func() {
 		})
 	})
 })
+
+func TestGrafanaAlertRuleGroupMatchesStateInGrafanaNormalizesEquivalentQueryModels(t *testing.T) {
+	noDataState := "NoData"
+	durationString := "60s"
+
+	cr := &v1beta1.GrafanaAlertRuleGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-group",
+			Namespace: "default",
+		},
+		Spec: v1beta1.GrafanaAlertRuleGroupSpec{
+			Name:      "test-group",
+			FolderUID: "test-folder",
+			Interval:  metav1.Duration{Duration: 60 * time.Second},
+			Rules: []v1beta1.AlertRule{
+				{
+					Title:        "TestRule",
+					UID:          "test-uid",
+					Condition:    "A",
+					ExecErrState: "Error",
+					NoDataState:  &noDataState,
+					For:          &durationString,
+					Data: []*v1beta1.AlertQuery{
+						{
+							RefID:         "A",
+							DatasourceUID: "__expr__",
+							Model: &apiextensionsv1.JSON{
+								Raw: []byte(`{"expression":"1 > 0","refId":"A","type":"math"}`),
+							},
+							RelativeTimeRange: &models.RelativeTimeRange{From: 0, To: 0},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	model, err := crToModel(cr, "test-folder")
+	require.NoError(t, err)
+
+	remotePayloadBytes, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var remoteModel models.AlertRuleGroup
+	require.NoError(t, json.Unmarshal(remotePayloadBytes, &remoteModel))
+
+	reconciler := &GrafanaAlertRuleGroupReconciler{}
+	assert.True(t, reconciler.matchesStateInGrafana(true, &model, &provisioning.GetAlertRuleGroupOK{
+		Payload: &remoteModel,
+	}))
+}


### PR DESCRIPTION
Fixes #2655

This was a small but annoying footgun. `matchesStateInGrafana` kept missing equal state because `rules[].data[].model` is `*apiextensionsv1.JSON` locally, but comes back from Grafana as `map[string]any`. So the operator kept doing a PUT every resync, even tho nothing changed.

What changed
- normalize both alert rule group payloads through JSON before comparing
- add a regression test that failed before this fix

How to repro
1. Run grafana-operator v5.22.0+ against any Grafana instance.
2. Create a `GrafanaAlertRuleGroup` with any rule that has `data[].model`.
3. Wait for the next `resyncPeriod`.
4. Before this patch you keep getting `updating alert rule group` on every loop, and a PUT each time, pretty noisy.

Validation
- `make test-short`
- focused controller test for equivalent local vs remote query models