### PR TITLE
chore(workflows): update test matrix

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -129,11 +129,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: v1.33.7
+          - version: v1.33.12
             grafana_version: "10.4.5"
-          - version: v1.34.3
-            grafana_version: "" # default
-          - version: v1.35.0
+          - version: v1.34.8
+            grafana_version: "11.0.0"
+          - version: v1.35.5
+            grafana_version: "12.0.0"
+          - version: v1.36.1
             grafana_version: "" # default
     env:
       GF_TEST_CONTAINER_VERSION: ${{ matrix.grafana_version }}

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -19,7 +19,7 @@ HELM_DOCS_VERSION = 1.14.2
 HELM_VERSION = v3.17.3
 HUGO_VERSION = 0.151.0
 # renovate: datasource=github-tags depName=kubernetes-sigs/kind
-KIND_VERSION = v0.31.0
+KIND_VERSION = v0.32.0
 # renovate: datasource=github-tags depName=ko-build/ko
 KO_VERSION = 0.18.1
 # renovate: datasource=github-tags depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>.*)$

--- a/hack/kind/start-kind.sh
+++ b/hack/kind/start-kind.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 KIND=${KIND:-kind}
-KIND_NODE_VERSION=${KIND_NODE_VERSION:-v1.35.0}
+KIND_NODE_VERSION=${KIND_NODE_VERSION:-v1.36.1}
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kind-grafana}
 KUBECONFIG=${KUBECONFIG:-~/.kube/kind-grafana-operator}
 set -eu


### PR DESCRIPTION
- toolchain:
  - bumped kind to `v0.32.0` (it now supports k8s v1.36);
- workflows:
  - updated test matrix:
    - bumped kind node image tags to versions referenced in the the release notes for [v0.32.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.32.0);
    - added Grafana `11.0.0` and `12.0.0`.