### PR TITLE
enhance: update status only when the resource status is changed

### DIFF
--- a/controllers/alertrulegroup_controller.go
+++ b/controllers/alertrulegroup_controller.go
@@ -92,7 +92,7 @@ func (r *GrafanaAlertRuleGroupReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/contactpoint_controller.go
+++ b/controllers/contactpoint_controller.go
@@ -99,7 +99,7 @@ func (r *GrafanaContactPointReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers/resources"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -579,12 +580,18 @@ type statusResource interface {
 	CommonStatus() *v1beta1.GrafanaCommonStatus
 }
 
-func UpdateStatus(ctx context.Context, cl client.Client, cr statusResource) {
+func UpdateStatus(ctx context.Context, cl client.Client, cr statusResource, original ...statusResource) {
 	log := logf.FromContext(ctx)
 
-	cr.CommonStatus().LastResync = metav1.Time{Time: time.Now()}
-	if err := cl.Status().Update(ctx, cr); err != nil {
-		log.Error(err, "updating status")
+	// Only write the status subresource when no original snapshot was provided
+	// (preserving the unconditional behavior) or when the status actually
+	// changed since the start of the reconcile, so identical resyncs no longer
+	// issue needless ETCD writes.
+	if len(original) == 0 || statusChanged(cr, original[0]) {
+		cr.CommonStatus().LastResync = metav1.Time{Time: time.Now()}
+		if err := cl.Status().Update(ctx, cr); err != nil {
+			log.Error(err, "updating status")
+		}
 	}
 
 	if meta.IsStatusConditionTrue(cr.CommonStatus().Conditions, conditionNoMatchingInstance) {
@@ -596,6 +603,29 @@ func UpdateStatus(ctx context.Context, cl client.Client, cr statusResource) {
 			log.Error(err, "failed to set finalizer")
 		}
 	}
+}
+
+// snapshotStatus returns a deep copy of cr to capture its status before the
+// reconcile mutates it. Pass the result to UpdateStatus as the original
+// snapshot. It is evaluated where the defer is declared, so it records the
+// pre-reconcile state while cr itself reflects the final state at execution.
+// A nil result makes UpdateStatus fall back to writing unconditionally.
+func snapshotStatus(cr statusResource) statusResource {
+	snapshot, ok := cr.DeepCopyObject().(statusResource)
+	if !ok {
+		return nil
+	}
+
+	return snapshot
+}
+
+// statusChanged reports whether cr's status differs from the original snapshot
+// taken at the start of the reconcile. LastResync is never mutated during a
+// reconcile (only UpdateStatus bumps it, after this comparison), so cr and the
+// snapshot still share it; together with their identical metadata and spec
+// baseline, a whole-object comparison reduces to comparing the status.
+func statusChanged(cr, original statusResource) bool {
+	return original == nil || !equality.Semantic.DeepEqual(cr, original)
 }
 
 // IsErrorType finds the first error in err's tree that matches the type E, and

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -95,7 +95,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -94,7 +94,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -92,7 +92,7 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/generic_controller.go
+++ b/controllers/generic_controller.go
@@ -94,7 +94,7 @@ func (r *GenericReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Reque
 
 		return ctrl.Result{}, nil
 	}
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.CommonSpec().Suspend {
 		setSuspended(cr.Conditions(), cr.GetGeneration(), conditionReasonApplySuspended)

--- a/controllers/librarypanel_controller.go
+++ b/controllers/librarypanel_controller.go
@@ -94,7 +94,7 @@ func (r *GrafanaLibraryPanelReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/manifest_controller.go
+++ b/controllers/manifest_controller.go
@@ -83,7 +83,7 @@ func (r *GrafanaManifestReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/mutetiming_controller.go
+++ b/controllers/mutetiming_controller.go
@@ -80,7 +80,7 @@ func (r *GrafanaMuteTimingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/notificationpolicy_controller.go
+++ b/controllers/notificationpolicy_controller.go
@@ -100,7 +100,7 @@ func (r *GrafanaNotificationPolicyReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/notificationtemplate_controller.go
+++ b/controllers/notificationtemplate_controller.go
@@ -79,7 +79,7 @@ func (r *GrafanaNotificationTemplateReconciler) Reconcile(ctx context.Context, r
 		return ctrl.Result{}, nil
 	}
 
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	if cr.Spec.Suspend {
 		setSuspended(&cr.Status.Conditions, cr.Generation, conditionReasonApplySuspended)

--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -127,7 +127,7 @@ func (r *GrafanaServiceAccountReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// 3. From here on, we're handling normal reconciliation (not deletion)
-	defer UpdateStatus(ctx, r.Client, cr)
+	defer UpdateStatus(ctx, r.Client, cr, snapshotStatus(cr))
 
 	// Check if reconciliation is suspended
 	if cr.Spec.Suspend {


### PR DESCRIPTION
Every resync period, the controller update the `status.LastResync` with the `time.Now()` to indicate the last timestamp the controller handles the CR.

From our production environment, we saw that the kube apiserver periodically write the GrafanaDashboard CR to the ETCD because the GrafanaDashboard CR `status.LastResync` got updated. We have over 1k GrafanaDashboard CRs and our resync period is short (30 secs). This impacted our K8s ETCD starts fragmentation quickly. We did tried to disable to _only_ update the GrafanaDashboard CR when there is a change on the spec via configured the resync period to 0, however, it make it worse because it starts to update the GrafanaDashboard CR every second.

The current workaround way for us is to increase the resync period (24 hrs) for each GrafanaDashboard CR however, we think that the GrafanaDashboard CR status should updated _only when_ there is a change.

We'd like to expand this concept to all the Grafana Operator CR.