### PR TITLE
docs(GrafanaDashboard): add note pointing people to GrafanaManifest for V2 dashboards

### DIFF
--- a/examples/dashboard/_index.md
+++ b/examples/dashboard/_index.md
@@ -5,6 +5,10 @@ tags:
   - Folders
 ---
 
+{{% alert title="Note" color="primary" %}}
+The GrafanaDashboard CR only supports V1 dashboards(legacy API), but it is possible to provision V2 dashboards via the [`GrafanaManifest`](https://grafana.github.io/grafana-operator/docs/examples/manifests/dashboards-v2/) resource.
+{{% /alert %}}
+
 [Dashboards](https://grafana.com/docs/grafana/latest/dashboards/) is the core feature of Grafana and of course something that you can manage through the operator.
 
 To view the entire configuration that you can do within Dashboards, look at our [API documentation](/docs/api/#grafanadashboardspec).


### PR DESCRIPTION
As suggested in #2710, a quick note at the top of the GrafanaDashboard docs explaining the V1 limitation.

Renders to:
<img width="719" height="266" alt="image" src="https://github.com/user-attachments/assets/5847dda7-029d-4b7e-9b73-6d91f4a1bc91" />
