### PR TITLE
fix(docs): broken dashboard envFrom examples

### DIFF
--- a/examples/dashboard/_index.md
+++ b/examples/dashboard/_index.md
@@ -500,10 +500,12 @@ spec:
           name: custom-grafana-dashboard-secrets
           key: PROMETHEUS_USERNAME
   envFrom: # just example, such cm and secrets are not provided by vendor
-    - configMapRef:
+    - configMapKeyRef:
         name: custom-grafana-dashboard-cm
-    - secretRef:
+        key: GRAFANA_URL
+    - secretKeyRef:
         name: custom-grafana-dashboard-secrets
+        key: PROMETHEUS_USERNAME
   jsonnet: |
    local grafana = import 'grafonnet/grafana.libsonnet';
    local dashboard = grafana.dashboard;
@@ -605,10 +607,12 @@ spec:
           name: custom-grafana-dashboard-secrets
           key: PROMETHEUS_USERNAME
   envFrom: # just example, such cm and secrets are not provided by vendor
-    - configMapRef:
+    - configMapKeyRef:
         name: custom-grafana-dashboard-cm
-    - secretRef:
+        key: GRAFANA_URL
+    - secretKeyRef:
         name: custom-grafana-dashboard-secrets
+        key: PROMETHEUS_USERNAME
   jsonnetLib:
     jPath:
       - "vendor"


### PR DESCRIPTION
Current dashboard docs use `configMapRef` and `secretRef` for `envFrom`.
That is a bit off. The dashboard CRD only supports `configMapKeyRef` and `secretKeyRef`, both with `key`.

Repro
1. Copy the snippet from `examples/dashboard/_index.md` into a `GrafanaDashboard`.
2. Check `GrafanaDashboard.spec.envFrom` in the API docs or CRD.
3. The fields from the snippet are not part of that schema, so those env refs wont resolve.

Fix
Replace the refs in both examples with the keyed variants and add the missing `key` fields.
