### PR TITLE
fix(GrafanaDatasource): correctly handle already deleted datasource

### DIFF
--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -224,7 +224,7 @@ func (r *GrafanaDatasourceReconciler) deleteOldDatasource(ctx context.Context, c
 
 		_, err = gClient.Datasources.DeleteDataSourceByUID(*uid) //nolint
 		if err != nil {
-			if IsNotErrorType[*datasources.GetDataSourceByUIDNotFound](err) {
+			if IsNotErrorType[*datasources.DeleteDataSourceByUIDNotFound](err) {
 				return fmt.Errorf("deleting datasource to update uid %s: %w", *uid, err)
 			}
 		}


### PR DESCRIPTION
**Fixes #2763.**

When GrafanaDatasource detects an updated UID, deleteOldDatasource deletes
the old datasource by calling DeleteDataSourceByUID. If a later reconcile
attempts the same old-UID delete again, Grafana can return
DeleteDataSourceByUIDNotFound.

The UID-update path was checking GetDataSourceByUIDNotFound, so the
delete-specific not-found response was treated as a reconcile error. This
change uses the same delete-specific not-found handling as the finalizer path
and shares that predicate between both delete paths.

**Testing**

Added unit coverage that distinguishes DeleteDataSourceByUIDNotFound from
GetDataSourceByUIDNotFound for datasource UID deletes.