### PR TITLE
fix(controllers): add a reconciliation delay upon UID changes in dashboards and datasources

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -158,8 +158,8 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// Clean up uid, so further reconciliations can track changes there
 		cr.Status.UID = ""
 
-		// Trigger the next reconciliation right away
-		return ctrl.Result{Requeue: true}, nil
+		// Requeue after a short delay to let the cache observe the status update
+		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 	}
 
 	folderUID, err := getFolderUID(ctx, r.Client, cr)

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -141,8 +141,8 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		// Clean up uid, so further reconcilications can track changes there
 		cr.Status.UID = ""
 
-		// Force requeue for datasource creation
-		return ctrl.Result{Requeue: true}, nil
+		// Requeue after a short delay to let the cache observe the status update
+		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 	}
 
 	datasource, hash, err := r.buildDatasourceModel(ctx, cr)


### PR DESCRIPTION
Fixes #2769.

Both `GrafanaDashboard` and `GrafanaDatasource` controllers use `Requeue: true` after clearing `Status.UID` when a UID change is detected. The problem is that `Requeue: true` fires immediately, before the informer cache picks up the status update. So the next reconcile can still see the old UID, hit `IsUpdatedUID()` again, and retry the deletion for no reason.

Changed both to `RequeueAfter: RequeueDelay` (10s), which is the same constant already used across all other controllers and as the base for exponential backoff.

How to reproduce: change the UID of a `GrafanaDatasource` or `GrafanaDashboard` and watch the logs - you'll see the delete-old-uid path triggered more than once in quick succession.

Tested: `make test` passes.