### PR TITLE
fix(controllers): clarify folderRef failures for legacy folders

### DIFF
--- a/controllers/alertrulegroup_controller_test.go
+++ b/controllers/alertrulegroup_controller_test.go
@@ -243,10 +243,10 @@ var _ = Describe("AlertRulegroup Reconciler: folder fallback diagnostics", func(
 		gClient, err := grafanaclient.NewGeneratedGrafanaClient(testCtx, cl, externalGrafanaCr)
 		require.NoError(t, err)
 
-		_, err = gClient.Folders.CreateFolder(&models.CreateFolderCommand{
+		_, err = gClient.Folders.CreateFolder(&models.CreateFolderCommand{ //nolint:errcheck
 			Title: folderName,
 			UID:   remoteUID,
-		}) //nolint:errcheck
+		})
 		require.NoError(t, err)
 
 		folder := &v1beta1.GrafanaFolder{
@@ -272,8 +272,8 @@ var _ = Describe("AlertRulegroup Reconciler: folder fallback diagnostics", func(
 		require.NoError(t, err)
 		require.NotEqual(t, remoteUID, folder.GetGrafanaUID())
 		assert.True(t, tk8s.HasCondition(t, folder, metav1.Condition{
-			Type:   conditionNoMatchingFolder,
-			Reason: conditionReasonLegacyFolderUID,
+			Type:   conditionFolderUIDMismatch,
+			Reason: conditionReasonFolderUIDInferred,
 		}))
 
 		alertRuleGroup := &v1beta1.GrafanaAlertRuleGroup{
@@ -318,7 +318,7 @@ var _ = Describe("AlertRulegroup Reconciler: folder fallback diagnostics", func(
 
 		hasCondition := tk8s.HasCondition(t, alertRuleGroup, metav1.Condition{
 			Type:   conditionNoMatchingFolder,
-			Reason: conditionReasonLegacyFolderUID,
+			Reason: conditionReasonFolderUIDInferred,
 		})
 		assert.True(t, hasCondition)
 	})

--- a/controllers/alertrulegroup_controller_test.go
+++ b/controllers/alertrulegroup_controller_test.go
@@ -311,7 +311,7 @@ var _ = Describe("AlertRulegroup Reconciler: folder fallback diagnostics", func(
 		require.NoError(t, err)
 
 		_, err = alertReconciler.Reconcile(testCtx, alertReq)
-		require.ErrorContains(t, err, "legacy title fallback")
+		require.ErrorContains(t, err, "UID was inferred")
 
 		err = cl.Get(testCtx, alertReq.NamespacedName, alertRuleGroup)
 		require.NoError(t, err)

--- a/controllers/alertrulegroup_controller_test.go
+++ b/controllers/alertrulegroup_controller_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	grafanaclient "github.com/grafana/grafana-operator/v5/controllers/client"
+	"github.com/grafana/grafana-operator/v5/pkg/tk8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -227,6 +229,99 @@ var _ = Describe("AlertRulegroup Reconciler: Provoke Conditions", func() {
 			reconcileAndValidateCondition(r, cr, tt.want, tt.wantErr)
 		})
 	}
+})
+
+var _ = Describe("AlertRulegroup Reconciler: folder fallback diagnostics", func() {
+	t := GinkgoT()
+
+	It("sets a clear condition when folderRef points to a title-fallback folder", func() {
+		const (
+			folderName = "legacy-fallback-folder-alertgroup"
+			remoteUID  = "legacy-fallback-uid-alertgroup"
+		)
+
+		gClient, err := grafanaclient.NewGeneratedGrafanaClient(testCtx, cl, externalGrafanaCr)
+		require.NoError(t, err)
+
+		_, err = gClient.Folders.CreateFolder(&models.CreateFolderCommand{
+			Title: folderName,
+			UID:   remoteUID,
+		}) //nolint:errcheck
+		require.NoError(t, err)
+
+		folder := &v1beta1.GrafanaFolder{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      folderName,
+			},
+			Spec: v1beta1.GrafanaFolderSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
+			},
+		}
+
+		folderReq := tk8s.GetRequest(t, folder)
+		folderReconciler := &GrafanaFolderReconciler{Client: cl, Scheme: cl.Scheme()}
+
+		err = cl.Create(testCtx, folder)
+		require.NoError(t, err)
+
+		_, err = folderReconciler.Reconcile(testCtx, folderReq)
+		require.NoError(t, err)
+
+		err = cl.Get(testCtx, folderReq.NamespacedName, folder)
+		require.NoError(t, err)
+		require.NotEqual(t, remoteUID, folder.GetGrafanaUID())
+		assert.True(t, tk8s.HasCondition(t, folder, metav1.Condition{
+			Type:   conditionNoMatchingFolder,
+			Reason: conditionReasonLegacyFolderUID,
+		}))
+
+		alertRuleGroup := &v1beta1.GrafanaAlertRuleGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "legacy-fallback-group",
+			},
+			Spec: v1beta1.GrafanaAlertRuleGroupSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
+				FolderRef:         folder.Name,
+				Interval:          metav1.Duration{Duration: 60 * time.Second},
+				Rules: []v1beta1.AlertRule{
+					{
+						Title:     "LegacyFallbackRule",
+						UID:       "legacy-fallback-rule",
+						Condition: "A",
+						Data: []*v1beta1.AlertQuery{
+							{
+								RefID:         "A",
+								DatasourceUID: "__expr__",
+								Model:         &apiextensionsv1.JSON{Raw: []byte(`{"expression": "1", "refId": "A"}`)},
+							},
+						},
+						ExecErrState: "Error",
+						NoDataState:  new("NoData"),
+					},
+				},
+			},
+		}
+
+		alertReq := tk8s.GetRequest(t, alertRuleGroup)
+		alertReconciler := &GrafanaAlertRuleGroupReconciler{Client: cl, Scheme: cl.Scheme()}
+
+		err = cl.Create(testCtx, alertRuleGroup)
+		require.NoError(t, err)
+
+		_, err = alertReconciler.Reconcile(testCtx, alertReq)
+		require.ErrorContains(t, err, "legacy title fallback")
+
+		err = cl.Get(testCtx, alertReq.NamespacedName, alertRuleGroup)
+		require.NoError(t, err)
+
+		hasCondition := tk8s.HasCondition(t, alertRuleGroup, metav1.Condition{
+			Type:   conditionNoMatchingFolder,
+			Reason: conditionReasonLegacyFolderUID,
+		})
+		assert.True(t, hasCondition)
+	})
 })
 
 var _ = Describe("AlertRuleGroup Controller Conversion", func() {

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -53,6 +53,7 @@ const (
 	conditionReasonApplySuspended  = "ApplySuspended"
 	conditionReasonEmptyAPIReply   = "EmptyAPIReply"
 	conditionReasonInvalidPatch    = "InvalidPatch"
+	conditionReasonLegacyFolderUID = "LegacyFolderUIDMismatch"
 
 	// Finalizer
 	grafanaFinalizer = "operator.grafana.com/finalizer"
@@ -193,9 +194,26 @@ func getFolderUID(ctx context.Context, cl client.Client, ref v1beta1.FolderRefer
 		return "", err
 	}
 
+	if mismatch := meta.FindStatusCondition(folder.Status.Conditions, conditionNoMatchingFolder); mismatch != nil && mismatch.Reason == conditionReasonLegacyFolderUID {
+		setNoMatchingFolder(ref.Conditions(), ref.GetGeneration(), mismatch.Reason, mismatch.Message)
+		return "", errors.New(mismatch.Message)
+	}
+
 	removeNoMatchingFolder(ref.Conditions())
 
 	return folder.GetGrafanaUID(), nil
+}
+
+func setLegacyFolderUIDMismatch(conditions *[]metav1.Condition, generation int64, namespace, name, trackedUID, resolvedUID string) {
+	message := fmt.Sprintf(
+		"GrafanaFolder %s/%s was adopted through legacy title fallback. Grafana tracks it as uid %s, but folderRef resolves it to %s. Set spec.uid on the GrafanaFolder and recreate it before referencing this folder from other resources.",
+		namespace,
+		name,
+		trackedUID,
+		resolvedUID,
+	)
+
+	setNoMatchingFolder(conditions, generation, conditionReasonLegacyFolderUID, message)
 }
 
 func labelsSatisfyMatchExpressions(labels map[string]string, matchExpressions []metav1.LabelSelectorRequirement) bool {

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -43,6 +43,7 @@ const (
 	// condition types
 	conditionNoMatchingInstance             = "NoMatchingInstance"
 	conditionNoMatchingFolder               = "NoMatchingFolder"
+	conditionFolderUIDMismatch              = "FolderUIDMismatch"
 	conditionInvalidSpec                    = "InvalidSpec"
 	conditionNotificationPolicyLoopDetected = "NotificationPolicyLoopDetected"
 	conditionSuspended                      = "Suspended"
@@ -53,7 +54,6 @@ const (
 	conditionReasonApplySuspended  = "ApplySuspended"
 	conditionReasonEmptyAPIReply   = "EmptyAPIReply"
 	conditionReasonInvalidPatch    = "InvalidPatch"
-	conditionReasonLegacyFolderUID = "LegacyFolderUIDMismatch"
 
 	// Finalizer
 	grafanaFinalizer = "operator.grafana.com/finalizer"
@@ -194,26 +194,14 @@ func getFolderUID(ctx context.Context, cl client.Client, ref v1beta1.FolderRefer
 		return "", err
 	}
 
-	if mismatch := meta.FindStatusCondition(folder.Status.Conditions, conditionNoMatchingFolder); mismatch != nil && mismatch.Reason == conditionReasonLegacyFolderUID {
-		setNoMatchingFolder(ref.Conditions(), ref.GetGeneration(), mismatch.Reason, mismatch.Message)
+	if mismatch := meta.FindStatusCondition(folder.Status.Conditions, conditionFolderUIDMismatch); mismatch != nil && mismatch.Status == metav1.ConditionTrue {
+		setNoMatchingFolder(ref.Conditions(), ref.GetGeneration(), mismatch.Reason, "Unalbe to apply resource to folder as UID was inferred. See folder resource for more details")
 		return "", errors.New(mismatch.Message)
 	}
 
 	removeNoMatchingFolder(ref.Conditions())
 
 	return folder.GetGrafanaUID(), nil
-}
-
-func setLegacyFolderUIDMismatch(conditions *[]metav1.Condition, generation int64, namespace, name, trackedUID, resolvedUID string) {
-	message := fmt.Sprintf(
-		"GrafanaFolder %s/%s was adopted through legacy title fallback. Grafana tracks it as uid %s, but folderRef resolves it to %s. Set spec.uid on the GrafanaFolder and recreate it before referencing this folder from other resources.",
-		namespace,
-		name,
-		trackedUID,
-		resolvedUID,
-	)
-
-	setNoMatchingFolder(conditions, generation, conditionReasonLegacyFolderUID, message)
 }
 
 func labelsSatisfyMatchExpressions(labels map[string]string, matchExpressions []metav1.LabelSelectorRequirement) bool {

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -195,7 +195,7 @@ func getFolderUID(ctx context.Context, cl client.Client, ref v1beta1.FolderRefer
 	}
 
 	if mismatch := meta.FindStatusCondition(folder.Status.Conditions, conditionFolderUIDMismatch); mismatch != nil && mismatch.Status == metav1.ConditionTrue {
-		setNoMatchingFolder(ref.Conditions(), ref.GetGeneration(), mismatch.Reason, "Unalbe to apply resource to folder as UID was inferred. See folder resource for more details")
+		setNoMatchingFolder(ref.Conditions(), ref.GetGeneration(), mismatch.Reason, "Unable to synchronize resource, the uid of the folder was inferred. See the GrafanaFolder resource for more details")
 		return "", errors.New(mismatch.Message)
 	}
 

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/models"
@@ -31,6 +32,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	genapi "github.com/grafana/grafana-openapi-client-go/client"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,8 +45,10 @@ import (
 )
 
 const (
-	conditionFolderSynchronized = "FolderSynchronized"
-	conditionReasonCyclicParent = "CyclicParent"
+	conditionFolderSynchronized      = "FolderSynchronized"
+	conditionReasonCyclicParent      = "CyclicParent"
+	conditionReasonFolderUIDInferred = "FolderUIDInferred"
+	conditionReasonConsistentUID     = "ConsistentUID"
 
 	LogMsgCyclicFolder = "failed to validate GrafanaFolder, parentFolderUID must not reference the uid of the current folder"
 )
@@ -142,27 +146,24 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	applyErrors := make(map[string]string)
-	legacyTrackedUID := ""
+	uidMismatches := make(map[string]string)
 
 	for _, grafana := range instances {
 		trackedUID, err := r.onFolderCreated(ctx, &grafana, cr, parentFolderUID)
-		if legacyTrackedUID == "" && trackedUID != "" {
-			legacyTrackedUID = trackedUID
-		}
-
 		if err != nil {
 			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
+			continue
+		}
+
+		if trackedUID != cr.GetGrafanaUID() {
+			uidMismatches[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = trackedUID
 		}
 	}
 
-	if legacyTrackedUID != "" {
-		setLegacyFolderUIDMismatch(&cr.Status.Conditions, cr.Generation, cr.Namespace, cr.Name, legacyTrackedUID, cr.GetGrafanaUID())
-	} else {
-		removeNoMatchingFolder(&cr.Status.Conditions)
-	}
-
-	condition := buildSynchronizedCondition("Folder", conditionFolderSynchronized, cr.Generation, applyErrors, len(instances))
-	meta.SetStatusCondition(&cr.Status.Conditions, condition)
+	synchronizedCondition := buildSynchronizedCondition("Folder", conditionFolderSynchronized, cr.Generation, applyErrors, len(instances))
+	meta.SetStatusCondition(&cr.Status.Conditions, synchronizedCondition)
+	mismatchCondition := buildUIDMismatchCondition(cr.Generation, uidMismatches, len(instances))
+	meta.SetStatusCondition(&cr.Status.Conditions, mismatchCondition)
 
 	if len(applyErrors) > 0 {
 		err = fmt.Errorf(FmtStrApplyErrors, applyErrors)
@@ -229,15 +230,10 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 		return "", err
 	}
 
-	legacyTrackedUID := ""
-	if exists && cr.Spec.CustomUID == "" && remoteUID != uid {
-		legacyTrackedUID = remoteUID
-	}
-
 	// Update when missing, the CR is updated or parentFolder has changed.
 	if exists && cr.Unchanged() && parentFolderUID == remoteParent {
 		log.V(1).Info("folder unchanged. skipping remaining requests")
-		return legacyTrackedUID, nil
+		return remoteUID, nil
 	}
 
 	if exists {
@@ -250,7 +246,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 				Title:     title,
 			})
 			if err != nil {
-				return legacyTrackedUID, err
+				return "", err
 			}
 		}
 
@@ -259,7 +255,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 				ParentUID: parentFolderUID,
 			})
 			if err != nil {
-				return legacyTrackedUID, err
+				return "", err
 			}
 		}
 	} else {
@@ -271,7 +267,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 
 		_, err := gClient.Folders.CreateFolder(body) //nolint:errcheck
 		if err != nil {
-			return legacyTrackedUID, err
+			return "", err
 		}
 	}
 
@@ -281,17 +277,17 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 
 		err = json.Unmarshal([]byte(cr.Spec.Permissions), &permissions)
 		if err != nil {
-			return legacyTrackedUID, fmt.Errorf("failed to unmarshal spec.permissions: %w", err)
+			return "", fmt.Errorf("failed to unmarshal spec.permissions: %w", err)
 		}
 
 		_, err = gClient.Folders.UpdateFolderPermissions(uid, &permissions) //nolint:errcheck
 		if err != nil {
-			return legacyTrackedUID, fmt.Errorf("failed to update folder permissions: %w", err)
+			return "", fmt.Errorf("failed to update folder permissions: %w", err)
 		}
 	}
 
 	// Update grafana instance Status
-	return legacyTrackedUID, grafana.AddNamespacedResource(ctx, r.Client, cr, cr.NamespacedResource(uid))
+	return uid, grafana.AddNamespacedResource(ctx, r.Client, cr, cr.NamespacedResource(uid))
 }
 
 // Check if the folder exists. Matches UID first and fall back to title. Title matching only works for non-nested folders
@@ -334,6 +330,34 @@ func (r *GrafanaFolderReconciler) Exists(gClient *genapi.GrafanaHTTPAPI, cr *v1b
 
 		page++
 	}
+}
+
+func buildUIDMismatchCondition(generation int64, uidMismatches map[string]string, total int) metav1.Condition {
+	condition := metav1.Condition{
+		Type:               conditionFolderUIDMismatch,
+		ObservedGeneration: generation,
+		LastTransitionTime: metav1.Time{
+			Time: time.Now(),
+		},
+	}
+
+	if len(uidMismatches) == 0 {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = conditionReasonConsistentUID
+		condition.Message = fmt.Sprintf("UIDs consistent across all %d instances", total)
+	} else {
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = conditionReasonFolderUIDInferred
+
+		var sb strings.Builder
+		for i, uid := range uidMismatches {
+			fmt.Fprintf(&sb, "\n- %s: inferred %s", i, uid)
+		}
+
+		condition.Message = fmt.Sprintf("UID was inferred for %d out of %d instances: %s", len(uidMismatches), total, sb.String())
+	}
+
+	return condition
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/folder_controller.go
+++ b/controllers/folder_controller.go
@@ -142,12 +142,23 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	applyErrors := make(map[string]string)
+	legacyTrackedUID := ""
 
 	for _, grafana := range instances {
-		err = r.onFolderCreated(ctx, &grafana, cr, parentFolderUID)
+		trackedUID, err := r.onFolderCreated(ctx, &grafana, cr, parentFolderUID)
+		if legacyTrackedUID == "" && trackedUID != "" {
+			legacyTrackedUID = trackedUID
+		}
+
 		if err != nil {
 			applyErrors[fmt.Sprintf("%s/%s", grafana.Namespace, grafana.Name)] = err.Error()
 		}
+	}
+
+	if legacyTrackedUID != "" {
+		setLegacyFolderUIDMismatch(&cr.Status.Conditions, cr.Generation, cr.Namespace, cr.Name, legacyTrackedUID, cr.GetGrafanaUID())
+	} else {
+		removeNoMatchingFolder(&cr.Status.Conditions)
 	}
 
 	condition := buildSynchronizedCondition("Folder", conditionFolderSynchronized, cr.Generation, applyErrors, len(instances))
@@ -202,7 +213,7 @@ func (r *GrafanaFolderReconciler) finalize(ctx context.Context, cr *v1beta1.Graf
 	return nil
 }
 
-func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *v1beta1.Grafana, cr *v1beta1.GrafanaFolder, parentFolderUID string) error {
+func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *v1beta1.Grafana, cr *v1beta1.GrafanaFolder, parentFolderUID string) (string, error) {
 	log := logf.FromContext(ctx)
 
 	title := cr.GetTitle()
@@ -210,18 +221,23 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 
 	gClient, err := grafanaclient.NewGeneratedGrafanaClient(ctx, r.Client, grafana)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	exists, remoteUID, remoteParent, err := r.Exists(gClient, cr)
 	if err != nil {
-		return err
+		return "", err
+	}
+
+	legacyTrackedUID := ""
+	if exists && cr.Spec.CustomUID == "" && remoteUID != uid {
+		legacyTrackedUID = remoteUID
 	}
 
 	// Update when missing, the CR is updated or parentFolder has changed.
 	if exists && cr.Unchanged() && parentFolderUID == remoteParent {
 		log.V(1).Info("folder unchanged. skipping remaining requests")
-		return nil
+		return legacyTrackedUID, nil
 	}
 
 	if exists {
@@ -234,7 +250,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 				Title:     title,
 			})
 			if err != nil {
-				return err
+				return legacyTrackedUID, err
 			}
 		}
 
@@ -243,7 +259,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 				ParentUID: parentFolderUID,
 			})
 			if err != nil {
-				return err
+				return legacyTrackedUID, err
 			}
 		}
 	} else {
@@ -255,7 +271,7 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 
 		_, err := gClient.Folders.CreateFolder(body) //nolint:errcheck
 		if err != nil {
-			return err
+			return legacyTrackedUID, err
 		}
 	}
 
@@ -265,17 +281,17 @@ func (r *GrafanaFolderReconciler) onFolderCreated(ctx context.Context, grafana *
 
 		err = json.Unmarshal([]byte(cr.Spec.Permissions), &permissions)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal spec.permissions: %w", err)
+			return legacyTrackedUID, fmt.Errorf("failed to unmarshal spec.permissions: %w", err)
 		}
 
 		_, err = gClient.Folders.UpdateFolderPermissions(uid, &permissions) //nolint:errcheck
 		if err != nil {
-			return fmt.Errorf("failed to update folder permissions: %w", err)
+			return legacyTrackedUID, fmt.Errorf("failed to update folder permissions: %w", err)
 		}
 	}
 
 	// Update grafana instance Status
-	return grafana.AddNamespacedResource(ctx, r.Client, cr, cr.NamespacedResource(uid))
+	return legacyTrackedUID, grafana.AddNamespacedResource(ctx, r.Client, cr, cr.NamespacedResource(uid))
 }
 
 // Check if the folder exists. Matches UID first and fall back to title. Title matching only works for non-nested folders

--- a/controllers/folder_controller_test.go
+++ b/controllers/folder_controller_test.go
@@ -113,10 +113,10 @@ var _ = Describe("Folder reconciler", func() {
 		gClient, err := grafanaclient.NewGeneratedGrafanaClient(testCtx, cl, externalGrafanaCr)
 		require.NoError(t, err)
 
-		_, err = gClient.Folders.CreateFolder(&models.CreateFolderCommand{
+		_, err = gClient.Folders.CreateFolder(&models.CreateFolderCommand{ //nolint:errcheck
 			Title: folderName,
 			UID:   remoteUID,
-		}) //nolint:errcheck
+		})
 		require.NoError(t, err)
 
 		folder := &v1beta1.GrafanaFolder{
@@ -142,8 +142,8 @@ var _ = Describe("Folder reconciler", func() {
 		require.NoError(t, err)
 		require.NotEqual(t, remoteUID, folder.GetGrafanaUID())
 		assert.True(t, tk8s.HasCondition(t, folder, metav1.Condition{
-			Type:   conditionNoMatchingFolder,
-			Reason: conditionReasonLegacyFolderUID,
+			Type:   conditionFolderUIDMismatch,
+			Reason: conditionReasonFolderUIDInferred,
 		}))
 	})
 

--- a/controllers/folder_controller_test.go
+++ b/controllers/folder_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
+	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	grafanaclient "github.com/grafana/grafana-operator/v5/controllers/client"
 	"github.com/grafana/grafana-operator/v5/pkg/tk8s"
@@ -102,6 +103,49 @@ var _ = Describe("Folder Reconciler: Provoke Conditions", func() {
 
 var _ = Describe("Folder reconciler", func() {
 	t := GinkgoT()
+
+	It("marks legacy title-fallback folders as unsafe for folderRef consumers", func() {
+		const (
+			folderName = "legacy-fallback-folder"
+			remoteUID  = "legacy-fallback-uid"
+		)
+
+		gClient, err := grafanaclient.NewGeneratedGrafanaClient(testCtx, cl, externalGrafanaCr)
+		require.NoError(t, err)
+
+		_, err = gClient.Folders.CreateFolder(&models.CreateFolderCommand{
+			Title: folderName,
+			UID:   remoteUID,
+		}) //nolint:errcheck
+		require.NoError(t, err)
+
+		folder := &v1beta1.GrafanaFolder{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      folderName,
+			},
+			Spec: v1beta1.GrafanaFolderSpec{
+				GrafanaCommonSpec: commonSpecSynchronized,
+			},
+		}
+
+		req := tk8s.GetRequest(t, folder)
+		reconciler := &GrafanaFolderReconciler{Client: cl, Scheme: cl.Scheme()}
+
+		err = cl.Create(testCtx, folder)
+		require.NoError(t, err)
+
+		_, err = reconciler.Reconcile(testCtx, req)
+		require.NoError(t, err)
+
+		err = cl.Get(testCtx, req.NamespacedName, folder)
+		require.NoError(t, err)
+		require.NotEqual(t, remoteUID, folder.GetGrafanaUID())
+		assert.True(t, tk8s.HasCondition(t, folder, metav1.Condition{
+			Type:   conditionNoMatchingFolder,
+			Reason: conditionReasonLegacyFolderUID,
+		}))
+	})
 
 	It("successfully deletes folder containing AlertRuleGroup", func() {
 		folder := struct {

--- a/examples/folder/_index.md
+++ b/examples/folder/_index.md
@@ -28,6 +28,7 @@ spec:
 {{% alert title="Note" color="primary" %}}
 The folder reconciler attempts to take control over existing folders if a folder with the same name already exists and `.spec.uid` is _empty/absent_.
 This can lead to unpredictable behavior and will be removed in future versions.
+If other resources need to use `.spec.folderRef`, set `.spec.uid` on the `GrafanaFolder` so the referenced folder keeps a stable UID.
 Please take care to make sure any managed folders are created by the operator.
 {{% /alert %}}
 


### PR DESCRIPTION
Related to #2715

This one is kinda sneaky. If a `GrafanaFolder` got adopted through the old title fallback, `folderRef` in `GrafanaAlertRuleGroup` can resolve the k8s object UID while Grafana tracks a different folder UID. Then you just get `folder with uid ... not found`, which is pretty opaque tbh.

This PR keeps behavior the same, but makes the failure way clearer:
- set `NoMatchingFolder` with the legacy fallback UID mismatch
- tell users to set `spec.uid` and recreate the folder
- add a short docs note for `folderRef`

Repro:
1. Create a folder in Grafana by hand with title `legacy-fallback-folder` and UID `legacy-fallback-uid`
2. Create a `GrafanaFolder` CR with the same name and no `spec.uid`
3. Reconcile it, then create a `GrafanaAlertRuleGroup` with `folderRef` to that folder
4. before this PR: `folder with uid <k8s uid> not found`
5. with this PR: `NoMatchingFolder` explains the mismatch and the fix

Tests:
`KUBEBUILDER_ASSETS="$PWD/bin/k8s/1.36.0-linux-amd64" go test ./controllers -count=1`
`KUBEBUILDER_ASSETS="$PWD/bin/k8s/1.36.0-linux-amd64" go test ./api/v1beta1 -count=1`