### PR TITLE
chore(renovate): ignore hugo packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
     "ghcr.io/grafana/grafana-operator",
     "github.com/openshift/api"
   ],
+  "ignorePaths": [
+    "hugo/**"
+  ],
   "npm": {
     "enabled": false
   },


### PR DESCRIPTION
- renovate:
  - this should help us to get rid of the NPM / go.mod updates for hugo:
    - as discussed previously, there's no need to maintain up-to-date NPM modules as we use those only to generate docs;
    - plus, for hugo, renovate opens broken gomod PRs.