### PR TITLE
chore(renovate): disable gomod indirect (transitive) dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
       "groupName": "github-actions (non-major)"
     },
     {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "custom.regex"
       ],


### PR DESCRIPTION
- renovate
  - recently, something changed in upstream renovate configuration causing a flood of transitive dependency updates. This PR should revert the behaviour.