### PR TITLE
chore(controllers): deprecate support for k8s 1.33 and Grafana 10

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         grafana_version:
-          - 10.4.5
+          - 11.0.0
           - "" # default
     env:
       GF_TEST_CONTAINER_VERSION: ${{ matrix.grafana_version }}
@@ -129,8 +129,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: v1.33.12
-            grafana_version: "10.4.5"
           - version: v1.34.8
             grafana_version: "11.0.0"
           - version: v1.35.5

--- a/controllers/contactpoint_controller.go
+++ b/controllers/contactpoint_controller.go
@@ -187,7 +187,7 @@ func (r *GrafanaContactPointReconciler) reconcileWithInstance(ctx context.Contex
 		return fmt.Errorf("building grafana client: %w", err)
 	}
 
-	remoteReceivers, err := r.getReceiversFromName(gClient, cr)
+	remoteReceivers, err := r.getReceivers(gClient, cr)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func (r *GrafanaContactPointReconciler) buildContactPointSettings(ctx context.Co
 	return allSettings, nil
 }
 
-func (r *GrafanaContactPointReconciler) getReceiversFromName(gClient *genapi.GrafanaHTTPAPI, cr *v1beta1.GrafanaContactPoint) ([]*models.EmbeddedContactPoint, error) {
+func (r *GrafanaContactPointReconciler) getReceivers(gClient *genapi.GrafanaHTTPAPI, cr *v1beta1.GrafanaContactPoint) ([]*models.EmbeddedContactPoint, error) {
 	name := cr.NameFromSpecOrMeta()
 	params := provisioning.NewGetContactpointsParams().WithName(&name)
 
@@ -340,7 +340,7 @@ func (r *GrafanaContactPointReconciler) finalize(ctx context.Context, cr *v1beta
 			return fmt.Errorf("building grafana client: %w", err)
 		}
 
-		remoteReceivers, err := r.getReceiversFromName(gClient, cr)
+		remoteReceivers, err := r.getReceivers(gClient, cr)
 		if err != nil {
 			return err
 		}

--- a/controllers/contactpoint_controller.go
+++ b/controllers/contactpoint_controller.go
@@ -37,13 +37,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	simplejson "github.com/bitly/go-simplejson"
-	"github.com/blang/semver/v4"
 	genapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/provisioning"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	grafanaclient "github.com/grafana/grafana-operator/v5/controllers/client"
-	"github.com/grafana/grafana-operator/v5/controllers/config"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -189,7 +187,7 @@ func (r *GrafanaContactPointReconciler) reconcileWithInstance(ctx context.Contex
 		return fmt.Errorf("building grafana client: %w", err)
 	}
 
-	remoteReceivers, err := r.getReceivers(gClient, instance, cr)
+	remoteReceivers, err := r.getReceiversFromName(gClient, cr)
 	if err != nil {
 		return err
 	}
@@ -314,25 +312,6 @@ func (r *GrafanaContactPointReconciler) buildContactPointSettings(ctx context.Co
 	return allSettings, nil
 }
 
-func (r *GrafanaContactPointReconciler) getReceivers(gClient *genapi.GrafanaHTTPAPI, instance *v1beta1.Grafana, cr *v1beta1.GrafanaContactPoint) ([]*models.EmbeddedContactPoint, error) {
-	version, err := semver.Parse(instance.Status.Version)
-	if err != nil {
-		version = semver.MustParse(config.GrafanaVersion)
-	}
-
-	// Versions that do not support "name" parameter in GetContactpoints API calls
-	// E.g. Amazon Managed Grafana is still pinned to <10.4.6
-	rangeChecker := semver.MustParseRange(">=10.4.0 <=10.4.5")
-	hasOldAPI := rangeChecker(version)
-
-	switch {
-	case hasOldAPI:
-		return r.getReceiversFromList(gClient, cr)
-	default:
-		return r.getReceiversFromName(gClient, cr)
-	}
-}
-
 func (r *GrafanaContactPointReconciler) getReceiversFromName(gClient *genapi.GrafanaHTTPAPI, cr *v1beta1.GrafanaContactPoint) ([]*models.EmbeddedContactPoint, error) {
 	name := cr.NameFromSpecOrMeta()
 	params := provisioning.NewGetContactpointsParams().WithName(&name)
@@ -343,25 +322,6 @@ func (r *GrafanaContactPointReconciler) getReceiversFromName(gClient *genapi.Gra
 	}
 
 	return remote.Payload, nil
-}
-
-func (r *GrafanaContactPointReconciler) getReceiversFromList(gClient *genapi.GrafanaHTTPAPI, cr *v1beta1.GrafanaContactPoint) ([]*models.EmbeddedContactPoint, error) {
-	params := provisioning.NewGetContactpointsParams()
-
-	remote, err := gClient.Provisioning.GetContactpoints(params)
-	if err != nil {
-		return make([]*models.EmbeddedContactPoint, 0), fmt.Errorf("getting receivers in contactpoint list: %w", err)
-	}
-
-	out := []*models.EmbeddedContactPoint{}
-
-	for _, cp := range remote.Payload {
-		if cp.Name == cr.NameFromSpecOrMeta() {
-			out = append(out, cp)
-		}
-	}
-
-	return out, nil
 }
 
 func (r *GrafanaContactPointReconciler) finalize(ctx context.Context, cr *v1beta1.GrafanaContactPoint) error {
@@ -380,7 +340,7 @@ func (r *GrafanaContactPointReconciler) finalize(ctx context.Context, cr *v1beta
 			return fmt.Errorf("building grafana client: %w", err)
 		}
 
-		remoteReceivers, err := r.getReceivers(gClient, &instance, cr)
+		remoteReceivers, err := r.getReceiversFromName(gClient, cr)
 		if err != nil {
 			return err
 		}

--- a/docs/docs/versioning.md
+++ b/docs/docs/versioning.md
@@ -3,6 +3,16 @@ title: Versioning
 weight: 60
 ---
 
+## Supported versions
+
+For Grafana, the operator intends to support only the last 3 major versions.
+
+For Kubernetes, we follow its [release schedule](https://kubernetes.io/releases/). Once a particular version reaches its EOL, we remove it from our test matrix.
+
+> Depending on a controller, the operator is likely to work fine with versions outside of those boundaries, but we do not guarantee that.
+
+## Default Grafana version
+
 The Grafana version when unspecified in `Grafana#spec.version`
 
 > Only versions that have changes around Grafana image tags are mentioned below.


### PR DESCRIPTION
- workflows:
  - removed k8s 1.33 (EOL) and Grafana 10 from test matrix;
- controllers:
  - `GrafanaContactPoints`:
    - deprecated workaround for old receivers API (`>=10.4.0 <=10.4.5`), which was introduced to support Managed Grafana on AWS before they started offering support for in-place upgrades to Grafana 12 ([announcement](https://github.com/aws/amazon-managed-grafana-roadmap/discussions/105));
- docs:
  - added a section describing which k8s and Grafana versions we intend to support.
  