### PR TITLE
feat(CRDs): include in 'all' resource category

### DIFF
--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -277,7 +277,7 @@ func (in *GrafanaStatus) StatusList(cr client.Object) (*NamespacedResourceList, 
 // +kubebuilder:printcolumn:name="Stage",type="string",JSONPath=".status.stage",description=""
 // +kubebuilder:printcolumn:name="Stage status",type="string",JSONPath=".status.stageStatus",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type Grafana struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanaalertrulegroup_types.go
+++ b/api/v1beta1/grafanaalertrulegroup_types.go
@@ -174,7 +174,7 @@ type AlertQuery struct {
 // GrafanaAlertRuleGroup is the Schema for the grafanaalertrulegroups API
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaAlertRuleGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanacontactpoint_types.go
+++ b/api/v1beta1/grafanacontactpoint_types.go
@@ -104,7 +104,7 @@ type ContactPointReceiver struct {
 // GrafanaContactPoint is the Schema for the grafanacontactpoints API
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaContactPoint struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -66,7 +66,7 @@ type GrafanaDashboardStatus struct {
 // +kubebuilder:printcolumn:name="No matching instances",type="boolean",JSONPath=".status.NoMatchingInstances",description=""
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaDashboard struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -101,7 +101,7 @@ type GrafanaDatasourceStatus struct {
 // +kubebuilder:printcolumn:name="No matching instances",type="boolean",JSONPath=".status.NoMatchingInstances",description=""
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaDatasource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanafolder_types.go
+++ b/api/v1beta1/grafanafolder_types.go
@@ -72,7 +72,7 @@ type GrafanaFolderStatus struct {
 // +kubebuilder:printcolumn:name="No matching instances",type="boolean",JSONPath=".status.NoMatchingInstances",description=""
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaFolder struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanalibrarypanel_types.go
+++ b/api/v1beta1/grafanalibrarypanel_types.go
@@ -38,7 +38,7 @@ type GrafanaLibraryPanelStatus struct {
 // GrafanaLibraryPanel is the Schema for the grafanalibrarypanels API
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaLibraryPanel struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanamanifest_types.go
+++ b/api/v1beta1/grafanamanifest_types.go
@@ -61,7 +61,7 @@ type GrafanaManifestStatus struct {
 // +kubebuilder:printcolumn:name="Kind",type="string",JSONPath=".spec.template.kind",description=""
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaManifest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanamutetiming_types.go
+++ b/api/v1beta1/grafanamutetiming_types.go
@@ -82,7 +82,7 @@ type TimeRange struct {
 // GrafanaMuteTiming is the Schema for the GrafanaMuteTiming API
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaMuteTiming struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafananotificationpolicy_types.go
+++ b/api/v1beta1/grafananotificationpolicy_types.go
@@ -233,7 +233,7 @@ type GrafanaNotificationPolicyStatus struct {
 // GrafanaNotificationPolicy is the Schema for the GrafanaNotificationPolicy API
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaNotificationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafananotificationpolicyroute_types.go
+++ b/api/v1beta1/grafananotificationpolicyroute_types.go
@@ -38,7 +38,7 @@ type GrafanaNotificationPolicyRouteSpec struct {
 //+kubebuilder:subresource:status
 
 // GrafanaNotificationPolicyRoute is the Schema for the grafananotificationpolicyroutes API
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaNotificationPolicyRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafananotificationtemplate_types.go
+++ b/api/v1beta1/grafananotificationtemplate_types.go
@@ -43,7 +43,7 @@ type GrafanaNotificationTemplateSpec struct {
 // GrafanaNotificationTemplate is the Schema for the GrafanaNotificationTemplate API
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaNotificationTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/grafanaserviceaccount_types.go
+++ b/api/v1beta1/grafanaserviceaccount_types.go
@@ -137,7 +137,7 @@ type GrafanaServiceAccountStatus struct {
 // GrafanaServiceAccount is the Schema for the grafanaserviceaccounts API
 // +kubebuilder:printcolumn:name="Last resync",type="date",format="date-time",JSONPath=".status.lastResync",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
-// +kubebuilder:resource:categories={grafana-operator}
+// +kubebuilder:resource:categories={all,grafana-operator}
 type GrafanaServiceAccount struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaAlertRuleGroup
     listKind: GrafanaAlertRuleGroupList

--- a/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaContactPoint
     listKind: GrafanaContactPointList

--- a/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaDashboard
     listKind: GrafanaDashboardList

--- a/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaDatasource
     listKind: GrafanaDatasourceList

--- a/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanafolders.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaFolder
     listKind: GrafanaFolderList

--- a/config/crd/bases/grafana.integreatly.org_grafanalibrarypanels.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanalibrarypanels.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaLibraryPanel
     listKind: GrafanaLibraryPanelList

--- a/config/crd/bases/grafana.integreatly.org_grafanamanifests.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanamanifests.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaManifest
     listKind: GrafanaManifestList

--- a/config/crd/bases/grafana.integreatly.org_grafanamutetimings.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanamutetimings.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaMuteTiming
     listKind: GrafanaMuteTimingList

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationPolicy
     listKind: GrafanaNotificationPolicyList

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationpolicyroutes.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationpolicyroutes.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationPolicyRoute
     listKind: GrafanaNotificationPolicyRouteList

--- a/config/crd/bases/grafana.integreatly.org_grafananotificationtemplates.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafananotificationtemplates.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationTemplate
     listKind: GrafanaNotificationTemplateList

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+      - all
       - grafana-operator
     kind: Grafana
     listKind: GrafanaList

--- a/config/crd/bases/grafana.integreatly.org_grafanaserviceaccounts.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanaserviceaccounts.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaServiceAccount
     listKind: GrafanaServiceAccountList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanaalertrulegroups.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaAlertRuleGroup
     listKind: GrafanaAlertRuleGroupList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanacontactpoints.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanacontactpoints.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaContactPoint
     listKind: GrafanaContactPointList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanadashboards.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanadashboards.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaDashboard
     listKind: GrafanaDashboardList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanadatasources.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanadatasources.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaDatasource
     listKind: GrafanaDatasourceList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanafolders.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanafolders.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaFolder
     listKind: GrafanaFolderList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanalibrarypanels.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanalibrarypanels.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaLibraryPanel
     listKind: GrafanaLibraryPanelList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanamanifests.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanamanifests.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaManifest
     listKind: GrafanaManifestList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanamutetimings.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanamutetimings.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaMuteTiming
     listKind: GrafanaMuteTimingList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafananotificationpolicies.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationPolicy
     listKind: GrafanaNotificationPolicyList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafananotificationpolicyroutes.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafananotificationpolicyroutes.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationPolicyRoute
     listKind: GrafanaNotificationPolicyRouteList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafananotificationtemplates.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafananotificationtemplates.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationTemplate
     listKind: GrafanaNotificationTemplateList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+      - all
       - grafana-operator
     kind: Grafana
     listKind: GrafanaList

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanaserviceaccounts.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanaserviceaccounts.yaml
@@ -9,6 +9,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaServiceAccount
     listKind: GrafanaServiceAccountList

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -8,6 +8,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaAlertRuleGroup
     listKind: GrafanaAlertRuleGroupList
@@ -412,6 +413,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaContactPoint
     listKind: GrafanaContactPointList
@@ -816,6 +818,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaDashboard
     listKind: GrafanaDashboardList
@@ -1376,6 +1379,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaDatasource
     listKind: GrafanaDatasourceList
@@ -1719,6 +1723,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaFolder
     listKind: GrafanaFolderList
@@ -1955,6 +1960,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaLibraryPanel
     listKind: GrafanaLibraryPanelList
@@ -2502,6 +2508,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaManifest
     listKind: GrafanaManifestList
@@ -2836,6 +2843,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaMuteTiming
     listKind: GrafanaMuteTimingList
@@ -3100,6 +3108,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationPolicy
     listKind: GrafanaNotificationPolicyList
@@ -3463,6 +3472,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationPolicyRoute
     listKind: GrafanaNotificationPolicyRouteList
@@ -3708,6 +3718,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaNotificationTemplate
     listKind: GrafanaNotificationTemplateList
@@ -3922,6 +3933,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: Grafana
     listKind: GrafanaList
@@ -13280,6 +13292,7 @@ spec:
   group: grafana.integreatly.org
   names:
     categories:
+    - all
     - grafana-operator
     kind: GrafanaServiceAccount
     listKind: GrafanaServiceAccountList


### PR DESCRIPTION
- CRDs:
  - some other operators (e.g. flux) include their CRDs in `all` resource category, so all resources are visible in the outputs of `kubectl get all`. I think it's very convenient and we should embrace that practice as well.