### PR TITLE
chore: bump grafana to v13.1.0

### DIFF
--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -8887,7 +8887,7 @@ spec:
                   description: |-
                     Version sets the tag of the default image: docker.io/grafana/grafana.
                     Allows full image refs with/without sha256checksum: "registry/repo/image:tag@sha"
-                    default: 13.0.1
+                    default: 13.1.0
                   type: string
               type: object
             status:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,7 +69,7 @@ spec:
             - name: ENABLE_LEADER_ELECTION
               value: "true"
             - name: RELATED_IMAGE_GRAFANA
-              value: "docker.io/grafana/grafana:13.0.1"
+              value: "docker.io/grafana/grafana:13.1.0"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -3,7 +3,7 @@ package config
 const (
 	// Grafana
 	GrafanaImage   = "docker.io/grafana/grafana"
-	GrafanaVersion = "13.0.1"
+	GrafanaVersion = "13.1.0"
 
 	// Paths
 	GrafanaDataPath               = "/var/lib/grafana"

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
@@ -8887,7 +8887,7 @@ spec:
                   description: |-
                     Version sets the tag of the default image: docker.io/grafana/grafana.
                     Allows full image refs with/without sha256checksum: "registry/repo/image:tag@sha"
-                    default: 13.0.1
+                    default: 13.1.0
                   type: string
               type: object
             status:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -13161,7 +13161,7 @@ spec:
                 description: |-
                   Version sets the tag of the default image: docker.io/grafana/grafana.
                   Allows full image refs with/without sha256checksum: "registry/repo/image:tag@sha"
-                  default: 13.0.1
+                  default: 13.1.0
                 type: string
             type: object
           status:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -7525,7 +7525,7 @@ GrafanaSpec defines the desired state of Grafana
         <td>
           Version sets the tag of the default image: docker.io/grafana/grafana.
 Allows full image refs with/without sha256checksum: "registry/repo/image:tag@sha"
-default: 13.0.1<br/>
+default: 13.1.0<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
- bumped Grafana to v13.1.0 (automated update got stuck under #2734).