### PR TITLE
feat: manage Grafana alertmanagersChoice via spec.alertmanager

### DIFF
--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -103,7 +103,19 @@ type GrafanaSpec struct {
 	// DisableDefaultSecurityContext prevents the operator from populating securityContext on deployments
 	// +kubebuilder:validation:Enum=Pod;Container;All
 	DisableDefaultSecurityContext string `json:"disableDefaultSecurityContext,omitempty"`
+	// Alertmanager controls which Alertmanager instances Grafana uses.
+	// +kubebuilder:validation:Enum=internal;external;all
+	// +kubebuilder:default=all
+	// +optional
+	Alertmanager string `json:"alertmanager,omitempty"`
 }
+
+// Permitted values for GrafanaSpec.Alertmanager.
+const (
+	AlertmanagerInternal = "internal"
+	AlertmanagerExternal = "external"
+	AlertmanagerAll      = "all"
+)
 
 func (in *GrafanaSpec) GetAllContainers() []corev1.Container {
 	if in.Deployment == nil ||

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -54,6 +54,14 @@ spec:
             spec:
               description: GrafanaSpec defines the desired state of Grafana
               properties:
+                alertmanager:
+                  default: all
+                  description: Alertmanager controls which Alertmanager instances Grafana uses.
+                  enum:
+                    - internal
+                    - external
+                    - all
+                  type: string
                 client:
                   description: Client defines how the grafana-operator talks to the grafana instance.
                   properties:

--- a/controllers/client/http_client.go
+++ b/controllers/client/http_client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -15,6 +16,14 @@ import (
 )
 
 const GrafanaVersionEndpoint = "/frontend/settings"
+
+// AlertmanagerStatusEndpoint returns the unified alerting admin status, including
+// the alertmanagersChoice and the number of configured external Alertmanagers.
+const AlertmanagerStatusEndpoint = "/v1/ngalert"
+
+// AlertmanagerAdminConfigEndpoint sets the unified alerting admin config, most
+// notably the alertmanagersChoice.
+const AlertmanagerAdminConfigEndpoint = "/v1/ngalert/admin_config"
 
 func NewHTTPClient(cr *v1beta1.Grafana, tlsConfig *tls.Config) *http.Client {
 	var timeout time.Duration
@@ -84,6 +93,116 @@ func GetGrafanaVersion(ctx context.Context, cl client.Client, cr *v1beta1.Grafan
 	}
 
 	return data.BuildInfo.Version, nil
+}
+
+// AlertmanagerStatus mirrors the relevant fields of Grafana's
+// GET /api/v1/ngalert response.
+type AlertmanagerStatus struct {
+	// AlertmanagersChoice is one of "internal", "external" or "all" and decides
+	// which Alertmanager(s) Grafana-managed alerts are dispatched to.
+	AlertmanagersChoice string `json:"alertmanagersChoice"`
+	// NumExternalAlertmanagers is the count of external Alertmanagers configured
+	// on the instance.
+	NumExternalAlertmanagers int `json:"numExternalAlertmanagers"`
+}
+
+// ReceivesAlerts reports whether external Alertmanagers are configured and the
+// instance is set up to actually route Grafana-managed alerts to them.
+func (s *AlertmanagerStatus) ReceivesAlerts() bool {
+	return s.NumExternalAlertmanagers > 0 &&
+		(s.AlertmanagersChoice == v1beta1.AlertmanagerExternal || s.AlertmanagersChoice == v1beta1.AlertmanagerAll)
+}
+
+func GetAlertmanagerStatus(ctx context.Context, cl client.Client, cr *v1beta1.Grafana) (*AlertmanagerStatus, error) {
+	tlsConfig, err := buildTLSConfiguration(ctx, cl, cr)
+	if err != nil {
+		return nil, fmt.Errorf("building tls config: %w", err)
+	}
+
+	httpClient := NewHTTPClient(cr, tlsConfig)
+
+	gURL, err := ParseAdminURL(cr.Status.AdminURL)
+	if err != nil {
+		return nil, err
+	}
+
+	instanceURL := gURL.JoinPath(AlertmanagerStatusEndpoint).String()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, instanceURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("building request to fetch alertmanager status: %w", err)
+	}
+
+	err = InjectAuthHeaders(ctx, cl, cr, req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching credentials for alertmanager status: %w", err)
+	}
+
+	resp, err := httpClient.Do(req) //#nosec G704
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch alertmanager status, got HTTP %d", resp.StatusCode)
+	}
+
+	data := &AlertmanagerStatus{}
+	if err := json.NewDecoder(resp.Body).Decode(data); err != nil {
+		return nil, fmt.Errorf("parsing data from %s: %w", AlertmanagerStatusEndpoint, err)
+	}
+
+	return data, nil
+}
+
+// SetAlertmanagerChoice sets the instance's alertmanagersChoice to the given
+// value ("internal", "external" or "all").
+func SetAlertmanagerChoice(ctx context.Context, cl client.Client, cr *v1beta1.Grafana, choice string) error {
+	tlsConfig, err := buildTLSConfiguration(ctx, cl, cr)
+	if err != nil {
+		return fmt.Errorf("building tls config: %w", err)
+	}
+
+	httpClient := NewHTTPClient(cr, tlsConfig)
+
+	gURL, err := ParseAdminURL(cr.Status.AdminURL)
+	if err != nil {
+		return err
+	}
+
+	instanceURL := gURL.JoinPath(AlertmanagerAdminConfigEndpoint).String()
+
+	body, err := json.Marshal(map[string]string{"alertmanagersChoice": choice})
+	if err != nil {
+		return fmt.Errorf("encoding alertmanager admin config: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, instanceURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building request to set alertmanager choice: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	err = InjectAuthHeaders(ctx, cl, cr, req)
+	if err != nil {
+		return fmt.Errorf("fetching credentials for setting alertmanager choice: %w", err)
+	}
+
+	resp, err := httpClient.Do(req) //#nosec G704
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("failed to set alertmanagersChoice to %q, got HTTP %d", choice, resp.StatusCode)
+	}
+
+	return nil
 }
 
 func GetAuthenticationStatus(ctx context.Context, cl client.Client, cr *v1beta1.Grafana) (bool, error) {

--- a/controllers/client/http_client_test.go
+++ b/controllers/client/http_client_test.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlertmanagerStatusReceivesAlerts(t *testing.T) {
+	tests := []struct {
+		name   string
+		status AlertmanagerStatus
+		want   bool
+	}{
+		{
+			name:   "no external alertmanager",
+			status: AlertmanagerStatus{AlertmanagersChoice: v1beta1.AlertmanagerExternal, NumExternalAlertmanagers: 0},
+			want:   false,
+		},
+		{
+			name:   "external configured but choice internal",
+			status: AlertmanagerStatus{AlertmanagersChoice: v1beta1.AlertmanagerInternal, NumExternalAlertmanagers: 1},
+			want:   false,
+		},
+		{
+			name:   "external configured and choice external",
+			status: AlertmanagerStatus{AlertmanagersChoice: v1beta1.AlertmanagerExternal, NumExternalAlertmanagers: 1},
+			want:   true,
+		},
+		{
+			name:   "external configured and choice all",
+			status: AlertmanagerStatus{AlertmanagersChoice: v1beta1.AlertmanagerAll, NumExternalAlertmanagers: 2},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.status.ReceivesAlerts())
+		})
+	}
+}

--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -2,14 +2,27 @@ package grafana
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	grafanaclient "github.com/grafana/grafana-operator/v5/controllers/client"
 	"github.com/grafana/grafana-operator/v5/controllers/reconcilers"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	conditionAlertmanagerReady = "AlertmanagerReady"
+
+	reasonAlertmanagerReady        = "AlertmanagerReady"
+	reasonAlertmanagerCheckFailed  = "AlertmanagerCheckFailed"
+	reasonAlertmanagerConfigFailed = "AlertmanagerConfigFailed"
+	reasonNoExternalAlertmanager   = "NoExternalAlertmanager"
 )
 
 type CompleteReconciler struct {
@@ -43,7 +56,70 @@ func (r *CompleteReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana,
 
 	cr.Status.Version = version
 
+	if err := r.reconcileAlertmanager(ctx, cr); err != nil {
+		return v1beta1.OperatorStageResultFailed, err
+	}
+
 	log.V(1).Info("reconciliation completed")
 
 	return v1beta1.OperatorStageResultSuccess, nil
+}
+
+// reconcileAlertmanager aligns the instance's alertmanagersChoice with
+// spec.alertmanager. Routing alerts to external Alertmanagers ("external")
+// additionally requires at least one external Alertmanager to be configured on
+// the instance; for "internal" and "all" this precondition is not relevant.
+func (r *CompleteReconciler) reconcileAlertmanager(ctx context.Context, cr *v1beta1.Grafana) error {
+	log := logf.FromContext(ctx).WithName("CompleteReconciler")
+
+	desired := cr.Spec.Alertmanager
+	if desired == "" {
+		meta.RemoveStatusCondition(&cr.Status.Conditions, conditionAlertmanagerReady)
+		return nil
+	}
+
+	status, err := grafanaclient.GetAlertmanagerStatus(ctx, r.client, cr)
+	if err != nil {
+		msg := fmt.Sprintf("failed to query alertmanager status: %s", err)
+		r.setAlertmanagerCondition(cr, metav1.ConditionFalse, reasonAlertmanagerCheckFailed, msg)
+
+		return fmt.Errorf("checking alertmanager status: %w", err)
+	}
+
+	// Precondition: routing alerts to external Alertmanagers requires at least
+	// one to be configured on the instance.
+	if desired == v1beta1.AlertmanagerExternal && status.NumExternalAlertmanagers == 0 {
+		msg := `spec.alertmanager is "external" but no external Alertmanager is configured on the instance`
+		r.setAlertmanagerCondition(cr, metav1.ConditionFalse, reasonNoExternalAlertmanager, msg)
+
+		return errors.New(msg)
+	}
+
+	if status.AlertmanagersChoice != desired {
+		log.Info("updating alertmanagersChoice", "from", status.AlertmanagersChoice, "to", desired)
+
+		if err := grafanaclient.SetAlertmanagerChoice(ctx, r.client, cr, desired); err != nil {
+			msg := fmt.Sprintf("failed to set alertmanagersChoice to %q: %s", desired, err)
+			r.setAlertmanagerCondition(cr, metav1.ConditionFalse, reasonAlertmanagerConfigFailed, msg)
+
+			return fmt.Errorf("configuring alertmanagersChoice: %w", err)
+		}
+	}
+
+	msg := fmt.Sprintf("alertmanagersChoice set to %q (%d external Alertmanager(s) configured)",
+		desired, status.NumExternalAlertmanagers)
+	r.setAlertmanagerCondition(cr, metav1.ConditionTrue, reasonAlertmanagerReady, msg)
+
+	return nil
+}
+
+func (r *CompleteReconciler) setAlertmanagerCondition(cr *v1beta1.Grafana, status metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(&cr.Status.Conditions, metav1.Condition{
+		Type:               conditionAlertmanagerReady,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: cr.Generation,
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+	})
 }

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
@@ -54,6 +54,14 @@ spec:
             spec:
               description: GrafanaSpec defines the desired state of Grafana
               properties:
+                alertmanager:
+                  default: all
+                  description: Alertmanager controls which Alertmanager instances Grafana uses.
+                  enum:
+                    - internal
+                    - external
+                    - all
+                  type: string
                 client:
                   description: Client defines how the grafana-operator talks to the grafana instance.
                   properties:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -3967,6 +3967,15 @@ spec:
           spec:
             description: GrafanaSpec defines the desired state of Grafana
             properties:
+              alertmanager:
+                default: all
+                description: Alertmanager controls which Alertmanager instances Grafana
+                  uses.
+                enum:
+                - internal
+                - external
+                - all
+                type: string
               client:
                 description: Client defines how the grafana-operator talks to the
                   grafana instance.

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -7413,6 +7413,16 @@ GrafanaSpec defines the desired state of Grafana
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>alertmanager</b></td>
+        <td>enum</td>
+        <td>
+          Alertmanager controls which Alertmanager instances Grafana uses.<br/>
+          <br/>
+            <i>Enum</i>: internal, external, all<br/>
+            <i>Default</i>: all<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#grafanaspecclient">client</a></b></td>
         <td>object</td>
         <td>

--- a/tests/e2e/example-test/18-alertmanager-all.yaml
+++ b/tests/e2e/example-test/18-alertmanager-all.yaml
@@ -1,0 +1,6 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+spec:
+  alertmanager: all

--- a/tests/e2e/example-test/18-alertmanager-external.yaml
+++ b/tests/e2e/example-test/18-alertmanager-external.yaml
@@ -1,0 +1,6 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+spec:
+  alertmanager: external

--- a/tests/e2e/example-test/18-alertmanager-internal.yaml
+++ b/tests/e2e/example-test/18-alertmanager-internal.yaml
@@ -1,0 +1,6 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+spec:
+  alertmanager: internal

--- a/tests/e2e/example-test/18-assert-all.yaml
+++ b/tests/e2e/example-test/18-assert-all.yaml
@@ -1,0 +1,14 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+status:
+  stage: complete
+  stageStatus: success
+  conditions:
+    - type: AlertmanagerReady
+      status: "True"
+      reason: AlertmanagerReady
+    - type: GrafanaReady
+      status: "True"
+      reason: GrafanaReady

--- a/tests/e2e/example-test/18-assert-external.yaml
+++ b/tests/e2e/example-test/18-assert-external.yaml
@@ -1,0 +1,9 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+status:
+  conditions:
+    - type: AlertmanagerReady
+      status: "False"
+      reason: NoExternalAlertmanager

--- a/tests/e2e/example-test/18-assert-internal.yaml
+++ b/tests/e2e/example-test/18-assert-internal.yaml
@@ -1,0 +1,11 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+status:
+  stage: complete
+  stageStatus: success
+  conditions:
+    - type: AlertmanagerReady
+      status: "True"
+      reason: AlertmanagerReady

--- a/tests/e2e/example-test/chainsaw-test.yaml
+++ b/tests/e2e/example-test/chainsaw-test.yaml
@@ -115,3 +115,20 @@ spec:
             file: 17-manifest.yaml
         - assert:
             file: 17-assert.yaml
+    - name: step-18
+      try:
+        # internal: choice is configured, no external Alertmanager required
+        - patch:
+            file: 18-alertmanager-internal.yaml
+        - assert:
+            file: 18-assert-internal.yaml
+        # external: no external Alertmanager configured -> precondition fails
+        - patch:
+            file: 18-alertmanager-external.yaml
+        - assert:
+            file: 18-assert-external.yaml
+        # all: choice is configured again, instance becomes ready
+        - patch:
+            file: 18-alertmanager-all.yaml
+        - assert:
+            file: 18-assert-all.yaml


### PR DESCRIPTION
## Summary

Adds a new `spec.alertmanager` field (`internal` | `external` | `all`, default `all`) so the operator reconciles a Grafana instance's `alertmanagersChoice`.

- The complete reconciler queries the ngalert admin status, updates the choice when it drifts, and rejects `external` when the instance has no external Alertmanager configured.
- State is surfaced through an `AlertmanagerReady` status condition.
- Adds e2e cases for `internal`/`external`/`all` and a unit test for the client.

## Notes

Endpoint constants are relative to `/api` (`ParseAdminURL` appends it), so the ngalert paths must not repeat the `/api` prefix — otherwise requests hit `/api/api/v1/ngalert` and return 404.

Closes #1926

🤖 Generated with [Claude Code](https://claude.com/claude-code)