### PR TITLE
docs(cli): add 'All settings' section covering CLI configuration options (--help)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,6 +355,7 @@ prep-release: $(YQ)
 	sed -i.bak 's/--version 5.*/--version $(VERSION)/g' README.md
 	sed -i.bak 's/^VERSION ?= 5.*/VERSION ?= $(VERSION)/g' Makefile
 	grep -q "$(GRAFANA_VERSION)" docs/docs/versioning.md || sed -E -i.bak 's/\|-\|-\|/|-|-|\n| \`v$(VERSION)\` | \`$(GRAFANA_VERSION)\` |/' docs/docs/versioning.md
+	go run ./main.go --help > docs/docs/configuration/help.txt
 	$(YQ) -i '.images[0].newTag="v$(VERSION)"' deploy/kustomize/base/kustomization.yaml
 	$(YQ) -i '(select(.kind == "Deployment") | .spec.template.spec.containers[0].env[] | select (.name == "RELATED_IMAGE_GRAFANA")).value="$(GRAFANA_IMAGE):$(GRAFANA_VERSION)"' config/manager/manager.yaml
 	make helm-docs

--- a/docs/docs/configuration/_index.md
+++ b/docs/docs/configuration/_index.md
@@ -1,0 +1,13 @@
+---
+title: Configuration
+description:
+weight: 20
+---
+
+## All settings
+
+All available options in the latest Grafana-Operator version.
+
+Most, if not all options should be available with all installation methods.
+
+{{< readfile file="help.txt" code="true" lang="sh" >}}

--- a/docs/docs/configuration/_index.md
+++ b/docs/docs/configuration/_index.md
@@ -10,4 +10,4 @@ All available options in the latest Grafana-Operator version.
 
 Most, if not all options should be available with all installation methods.
 
-{{< readfile file="help.txt" code="true" lang="sh" >}}
+{{< readfile file="help.txt" code="true" >}}

--- a/docs/docs/configuration/help.txt
+++ b/docs/docs/configuration/help.txt
@@ -1,0 +1,57 @@
+Usage: grafana-operator [flags]
+
+Flags:
+  -h, --help                      Show context-sensitive help.
+      --cluster-domain=STRING     Fully specify the domain to address services
+                                  with using their FQDNs, e.g. 'cluster.local'
+                                  ($CLUSTER_DOMAIN)
+      --watch-namespace=STRING    Comma separated Namespaces to watch, If empty
+                                  or undefined, the operator will run in cluster
+                                  scope ($WATCH_NAMESPACE).
+      --watch-namespace-selector=STRING
+                                  The namespace label and key to watch, e.g.
+                                  'environment: dev', If empty or undefined,
+                                  the operator will run in cluster scope
+                                  ($WATCH_NAMESPACE_SELECTOR).
+      --watch-label-selectors=STRING
+                                  The resources to watch according to their
+                                  labels. e.g. 'partition in (customerA,
+                                  customerB),environment!=qa'. If empty of
+                                  undefined, the operator will watch all CRs
+                                  ($WATCH_LABEL_SELECTORS).
+      --caching-level="safe"      Configure cache limits. Valid
+                                  values are 'off', 'safe' and 'all'
+                                  ($ENFORCE_CACHE_LABELS)
+      --metrics-bind-address=":8080"
+                                  The address the metric endpoint binds to.
+      --health-probe-bind-address=":8081"
+                                  The address the probe endpoint binds to.
+      --pprof-addr=STRING         The address to expose the pprof server.
+                                  Empty string disables the pprof server.
+      --leader-elect              Enable leader election for controller
+                                  manager. Enabling this will ensure there
+                                  is only one active controller manager
+                                  ($ENABLE_LEADER_ELECTION).
+      --max-concurrent-reconciles=1
+                                  Maximum number of concurrent reconciles for
+                                  dashboard, datasource, folder controllers
+                                  ($MAX_CONCURRENT_RECONCILES).
+      --default-resync-period=10m
+                                  Controls the default .spec.resyncPeriod when
+                                  undefined on CRs ($DEFAULT_RESYNC_PERIOD).
+      --zap-devel                 Development Mode
+                                  defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn)
+      --zap-encoder="console"     Zap log encoding ('json' or 'console')
+      --zap-log-level="info"      Zap Level to configure the verbosity of
+                                  logging. Can be one of 'debug', 'info',
+                                  'error', 'panic' or any integer value > 0
+                                  which corresponds to custom debug levels of
+                                  increasing verbosity
+      --zap-time-encoding="iso8601"
+                                  Zap time encoding ('epoch', 'millis', 'nanos',
+                                  'iso8601', 'rfc3339' or 'rfc3339nano').
+      --zap-stacktrace-level="error"
+                                  Zap Level at and above which stacktraces are
+                                  captured (one of 'info', 'error', 'panic').
+      --feature-flags=STRING      Specify feature flags to be enabled or
+                                  disabled. Comma separated ($FEATURE_FLAGS)


### PR DESCRIPTION
A tiny setup for exposing all available CLI options that we have registered with Kong.

Everything was put in the _index.md with the intention of adding more pages in the configuration folder that document Scaling and securing a deployment.

I considered putting the help generation command into api-docs or similar, but we often hold off from merging docs for new features until releases, so it fit quite well in the release-prep target.