### PR TITLE
chore: disable lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "github>grafana/grafana-renovate-config//presets/base"
   ],
+  "ignorePresets": [":maintainLockFilesWeekly"],
   "ignoreDeps": [
     "ghcr.io/grafana/grafana-operator",
     "github.com/openshift/api"


### PR DESCRIPTION
Apparently lock file maintenance does not care about the top level `ignore` directive. As it does not matter for go anyways, this disables lock file maintenance all together