### PR TITLE
feat(runtime): periodically update GOMEMLIMIT and allow configuring the memlimit/RAM ratio

### DIFF
--- a/deploy/helm/grafana-operator/README.md
+++ b/deploy/helm/grafana-operator/README.md
@@ -93,6 +93,7 @@ It's easier to just manage this configuration outside of the operator.
 | extraVolumes | list | `[]` | extra pod volumes |
 | fullnameOverride | string | `""` | Overrides the fully qualified app name. |
 | global.imageRegistry | string | `nil` | Overrides the Docker registry globally for all images |
+| gomemlimitRatio | string | `"0.9"` | Sets the GOMEMLIMIT variable to a percentage of either the CGroup (v2 or v1) with fallback to the System. Results in less GC cycles when there's memory to spare and more when nearing the limit to reduce OOM kills. |
 | hostUsers | bool | `true` | Set to false to opt-in to use user namespaces |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use in grafana operator container |
 | image.registry | string | `"ghcr.io"` | grafana operator image registry |

--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -78,6 +78,7 @@ spec:
             - --leader-elect
             {{- end }}
             - --max-concurrent-reconciles={{ .Values.maxConcurrentReconciles }}
+            - --gomemlimit-ratio={{ .Values.gomemlimitRatio }}
           volumeMounts:
             - name: dashboards-dir
               mountPath: /tmp/dashboards

--- a/deploy/helm/grafana-operator/values.yaml
+++ b/deploy/helm/grafana-operator/values.yaml
@@ -54,6 +54,10 @@ clusterDomain: ""
 # Useful when you want to either lower or raise the duration between reconciliations.
 defaultResyncPeriod: 10m
 
+# -- Sets the GOMEMLIMIT variable to a percentage of either the CGroup (v2 or v1) with fallback to the System.
+# Results in less GC cycles when there's memory to spare and more when nearing the limit to reduce OOM kills.
+gomemlimitRatio: "0.9"
+
 # -- Maximum number of concurrent reconciles per Custom Resource.
 maxConcurrentReconciles: 1
 

--- a/main.go
+++ b/main.go
@@ -92,6 +92,7 @@ var operatorConfig struct {
 	PprofAddr               string        `name:"pprof-addr"                                                                help:"The address to expose the pprof server. Empty string disables the pprof server."`
 	EnableLeaderElection    bool          `name:"leader-elect"              default:"false" env:"ENABLE_LEADER_ELECTION"    help:"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager."`
 	MaxConcurrentReconciles int           `name:"max-concurrent-reconciles" default:"1"     env:"MAX_CONCURRENT_RECONCILES" help:"Maximum number of concurrent reconciles for dashboard, datasource, folder controllers."`
+	MemLimitRatio           float64       `name:"gomemlimit-ratio"          default:"0.9"   env:"GOMEMLIMIT_RATIO"          help:"The limit defaults to 90% of either the CGroup (v2 or v1) with fallback to the System. Results in less GC cycles when there's memory to spare and more when nearing the limit to reduce OOM kills."`
 	ResyncPeriod            time.Duration `name:"default-resync-period"     default:"10m"   env:"DEFAULT_RESYNC_PERIOD"     help:"Controls the default .spec.resyncPeriod when undefined on CRs."`
 
 	ZapDevel           bool   `name:"zap-devel"            default:"false"                                                         help:"Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn)"`
@@ -202,10 +203,8 @@ func main() { //nolint:gocyclo
 	}
 
 	// Optimize GC cycles by setting and periodically updating GOMEMLIMIT.
-	// The limit is 95% of either the CGroup (v2 or v1) with fallback to the System.
-	// Results in less cycles when there's memory to space and more when nearing the limit to reduce OOM kills.
 	memlimit.SetGoMemLimitWithOpts( //nolint:errcheck
-		memlimit.WithRatio(0.95),
+		memlimit.WithRatio(operatorConfig.MemLimitRatio),
 		memlimit.WithRefreshInterval(1*time.Minute),
 		memlimit.WithProvider(
 			memlimit.ApplyFallback(

--- a/main.go
+++ b/main.go
@@ -201,8 +201,20 @@ func main() { //nolint:gocyclo
 		os.Exit(1)
 	}
 
-	// Optimize Go runtime based on CGroup limits (GOMEMLIMIT, sets a soft memory limit for the runtime)
-	memlimit.SetGoMemLimitWithOpts(memlimit.WithLogger(slogger)) //nolint:errcheck
+	// Optimize GC cycles by setting and periodically updating GOMEMLIMIT.
+	// The limit is 95% of either the CGroup (v2 or v1) with fallback to the System.
+	// Results in less cycles when there's memory to space and more when nearing the limit to reduce OOM kills.
+	memlimit.SetGoMemLimitWithOpts( //nolint:errcheck
+		memlimit.WithRatio(0.95),
+		memlimit.WithRefreshInterval(1*time.Minute),
+		memlimit.WithProvider(
+			memlimit.ApplyFallback(
+				memlimit.FromCgroup,
+				memlimit.FromSystem,
+			),
+		),
+		memlimit.WithLogger(slogger),
+	)
 
 	// Determine LeaderElectionID from
 	leHash := sha256.New()


### PR DESCRIPTION
Makes the automemlimit configuration more explicit and enables the `refreshInterval`.
Periodically updating GOMEMLIMIT aligns with the mutable container resource requests that Kubernetes have been implementing lately.

~~Changed the ratio to 95% of available memory, up from 90% since the memory usage is relatively stable after all the caches have been built.~~

```
./bin/manager --help
Usage: grafana-operator [flags]

Flags:
      ...
      --gomemlimit-ratio=0.9                 The limit defaults to 90% of either the CGroup (v2 or v1) with fallback to the System. Results in less GC cycles when there's memory to spare and more when nearing the limit to reduce OOM kills ($GOMEMLIMIT_RATIO).
      ...
```

Using the flag:
```
./bin/manager --gomemlimit-ratio 0.9
2026-07-18T13:50:51.373+0200    info    setup   GOMEMLIMIT is updated   {"GOMEMLIMIT": 15051571200, "previous": 9223372036854775807}

./bin/manager --gomemlimit-ratio 0.99
2026-07-18T13:50:56.683+0200    info    setup   GOMEMLIMIT is updated   {"GOMEMLIMIT": 16556728320, "previous": 9223372036854775807}

./bin/manager --gomemlimit-ratio 0.5
2026-07-18T13:52:44.126+0200    info    setup   GOMEMLIMIT is updated   {"GOMEMLIMIT": 8361984000, "previous": 9223372036854775807}
```
