### PR TITLE
cache: limit gzip decompression size to avoid OOM

### DIFF
--- a/controllers/content/cache/gzip.go
+++ b/controllers/content/cache/gzip.go
@@ -3,16 +3,29 @@ package cache
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 )
+
+// MaxGunzipSize caps decompressed gzip payload size to avoid OOM from
+// highly compressed inputs (zip bombs). See grafana/grafana-operator#2815.
+const MaxGunzipSize = 10 * 1024 * 1024 // 10 MiB
 
 func Gunzip(compressed []byte) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewReader(compressed))
 	if err != nil {
 		return nil, err
 	}
+	defer gz.Close()
 
-	return io.ReadAll(gz)
+	data, err := io.ReadAll(io.LimitReader(gz, MaxGunzipSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxGunzipSize {
+		return nil, fmt.Errorf("gzip content exceeds maximum allowed size of %d bytes", MaxGunzipSize)
+	}
+	return data, nil
 }
 
 func Gzip(content []byte) ([]byte, error) {

--- a/controllers/content/cache/gzip_test.go
+++ b/controllers/content/cache/gzip_test.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"bytes"
+	"compress/gzip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,4 +18,17 @@ func TestCompressDecompress(t *testing.T) {
 	require.NoError(t, err)
 
 	require.JSONEq(t, string(contentJSON), string(decompressed))
+}
+
+func TestGunzipRejectsOversizedPayload(t *testing.T) {
+	var raw bytes.Buffer
+	gz := gzip.NewWriter(&raw)
+	// Highly compressible zeros exceed MaxGunzipSize after inflate.
+	_, err := gz.Write(make([]byte, MaxGunzipSize+1024))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	_, err = Gunzip(raw.Bytes())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "maximum allowed size")
 }


### PR DESCRIPTION
## Summary
- Cap `Gunzip` inflate at 10MiB so high-ratio gzip payloads cannot OOM the operator
- Close the gzip reader; add a regression test for oversized payloads

Addresses grafana/grafana-operator#2815

## Test plan
- [x] `go test ./controllers/content/cache/`