### PR TITLE
feat(Grafana): add support for scale subresource

### DIFF
--- a/api/v1beta1/grafana_types.go
+++ b/api/v1beta1/grafana_types.go
@@ -242,6 +242,8 @@ type GrafanaStatus struct {
 	Manifests             NamespacedResourceList `json:"manifests,omitempty"`
 	Version               string                 `json:"version,omitempty"`
 	Conditions            []metav1.Condition     `json:"conditions,omitempty"`
+	Replicas              int32                  `json:"replicas,omitempty"`
+	Selector              string                 `json:"selector,omitempty"`
 }
 
 func (in *GrafanaStatus) StatusList(cr client.Object) (*NamespacedResourceList, string, error) {
@@ -278,6 +280,7 @@ func (in *GrafanaStatus) StatusList(cr client.Object) (*NamespacedResourceList, 
 // +kubebuilder:printcolumn:name="Stage status",type="string",JSONPath=".status.stageStatus",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:resource:categories={all,grafana-operator}
+// +kubebuilder:subresource:scale:specpath=.spec.deployment.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 type Grafana struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -8977,6 +8977,11 @@ spec:
                   items:
                     type: string
                   type: array
+                replicas:
+                  format: int32
+                  type: integer
+                selector:
+                  type: string
                 serviceaccounts:
                   items:
                     type: string
@@ -8994,4 +8999,8 @@ spec:
       served: true
       storage: true
       subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.deployment.spec.replicas
+          statusReplicasPath: .status.replicas
         status: {}

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/grafana/grafana-operator/v5/controllers/resources"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -380,12 +381,40 @@ func removeSuspended(conditions *[]metav1.Condition) {
 	meta.RemoveStatusCondition(conditions, conditionSuspended)
 }
 
-func ignoreStatusUpdates() predicate.Predicate {
+type IgnoreStatusUpdatesOpt func(oldObj, newObj client.Object) bool
+
+func ignoreStatusUpdates(opts ...IgnoreStatusUpdatesOpt) predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			// Ignore updates to CR status in which case metadata.Generation does not change
-			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+
+			for _, opt := range opts {
+				if opt(e.ObjectOld, e.ObjectNew) {
+					return true
+				}
+			}
+
+			return false
 		},
+	}
+}
+
+func exceptDeploymentReplicas() IgnoreStatusUpdatesOpt {
+	return func(oldObj, newObj client.Object) bool {
+		oldDeployment, ok := oldObj.(*appsv1.Deployment)
+		if !ok {
+			return false
+		}
+
+		newDeployment, ok := newObj.(*appsv1.Deployment)
+		if !ok {
+			return false
+		}
+
+		return oldDeployment.Status.Replicas != newDeployment.Status.Replicas
 	}
 }
 

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -336,7 +336,7 @@ func (r *GrafanaReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.Grafana{}, builder.WithPredicates(ignoreStatusUpdates())).
-		Owns(&appsv1.Deployment{}, builder.WithPredicates(ignoreStatusUpdates())).
+		Owns(&appsv1.Deployment{}, builder.WithPredicates(ignoreStatusUpdates(exceptDeploymentReplicas()))).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.PersistentVolumeClaim{}, builder.WithPredicates(ignoreStatusUpdates())).
 		Owns(&corev1.Secret{}).

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -17,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -99,7 +100,18 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafan
 		return v1beta1.OperatorStageResultFailed, err
 	}
 
+	selector := labels.SelectorFromValidatedSet(getSelectorLabels(cr))
+
+	cr.Status.Replicas = deployment.Status.Replicas
+	cr.Status.Selector = selector.String()
+
 	return v1beta1.OperatorStageResultSuccess, nil
+}
+
+func getSelectorLabels(cr *v1beta1.Grafana) map[string]string {
+	return map[string]string{
+		appLabel: cr.Name,
+	}
 }
 
 func getResources() corev1.ResourceRequirements {
@@ -347,9 +359,7 @@ func getDeploymentSpec(cr *v1beta1.Grafana, deploymentName string, scheme *runti
 
 	return appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				appLabel: cr.Name,
-			},
+			MatchLabels: getSelectorLabels(cr),
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/reconcilers/grafana/deployment_reconciler_test.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler_test.go
@@ -11,8 +11,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -259,5 +261,96 @@ var _ = Describe("Deployment reconciler secrets hash", func() {
 
 		require.NoError(t, err)
 		assert.Equal(t, v1beta1.OperatorStageResultSuccess, status)
+	})
+})
+
+var _ = Describe("Deployment reconciler scale subresource", func() {
+	t := GinkgoT()
+
+	It("sets status.selector to the deployment's pod selector", func() {
+		ctx := context.Background()
+
+		cr := &v1beta1.Grafana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "deploy-scale-selector-grafana",
+			},
+		}
+
+		err := cl.Create(ctx, cr)
+		require.NoError(t, err)
+
+		r := NewDeploymentReconciler(cl, false)
+		vars := &v1beta1.OperatorReconcileVars{}
+
+		status, err := r.Reconcile(context.Background(), cr, vars, scheme.Scheme)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1beta1.OperatorStageResultSuccess, status)
+		assert.Equal(t, fmt.Sprintf("app=%s", cr.Name), cr.Status.Selector)
+	})
+
+	It("sets status.replicas from the reconciled deployment", func() {
+		ctx := context.Background()
+
+		cr := &v1beta1.Grafana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "deploy-scale-replicas-grafana",
+			},
+		}
+
+		err := cl.Create(ctx, cr)
+		require.NoError(t, err)
+
+		r := NewDeploymentReconciler(cl, false)
+		vars := &v1beta1.OperatorReconcileVars{}
+
+		status, err := r.Reconcile(context.Background(), cr, vars, scheme.Scheme)
+		require.NoError(t, err)
+		assert.Equal(t, v1beta1.OperatorStageResultSuccess, status)
+
+		deployment := &appsv1.Deployment{}
+		err = cl.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name + "-deployment"}, deployment)
+		require.NoError(t, err)
+
+		assert.Equal(t, deployment.Status.Replicas, cr.Status.Replicas)
+	})
+
+	It("propagates spec.deployment.spec.replicas to the deployment", func() {
+		ctx := context.Background()
+
+		replicas := int32(3)
+
+		cr := &v1beta1.Grafana{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "deploy-scale-propagate-grafana",
+			},
+			Spec: v1beta1.GrafanaSpec{
+				Deployment: &v1beta1.DeploymentV1{
+					Spec: v1beta1.DeploymentV1Spec{
+						Replicas: &replicas,
+					},
+				},
+			},
+		}
+
+		err := cl.Create(ctx, cr)
+		require.NoError(t, err)
+
+		r := NewDeploymentReconciler(cl, false)
+		vars := &v1beta1.OperatorReconcileVars{}
+
+		status, err := r.Reconcile(context.Background(), cr, vars, scheme.Scheme)
+		require.NoError(t, err)
+		assert.Equal(t, v1beta1.OperatorStageResultSuccess, status)
+
+		deployment := &appsv1.Deployment{}
+		err = cl.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name + "-deployment"}, deployment)
+		require.NoError(t, err)
+
+		require.NotNil(t, deployment.Spec.Replicas)
+		assert.Equal(t, replicas, *deployment.Spec.Replicas)
 	})
 })

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
@@ -8977,6 +8977,11 @@ spec:
                   items:
                     type: string
                   type: array
+                replicas:
+                  format: int32
+                  type: integer
+                selector:
+                  type: string
                 serviceaccounts:
                   items:
                     type: string
@@ -8994,4 +8999,8 @@ spec:
       served: true
       storage: true
       subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.deployment.spec.replicas
+          statusReplicasPath: .status.replicas
         status: {}

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -13287,6 +13287,11 @@ spec:
                 items:
                   type: string
                 type: array
+              replicas:
+                format: int32
+                type: integer
+              selector:
+                type: string
               serviceaccounts:
                 items:
                   type: string
@@ -13304,6 +13309,10 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.deployment.spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -29080,6 +29080,22 @@ GrafanaStatus defines the observed state of Grafana
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>replicas</b></td>
+        <td>integer</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>selector</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>serviceaccounts</b></td>
         <td>[]string</td>
         <td>


### PR DESCRIPTION
Related to #2534.

## Changes

* Adds necessary status fields to the Grafana resource (replica count, selector)
* Adds kubebuilder tags to enable the status subresource for the Grafana resource
* Modifies `ignoreStatusUpdates` to accept a variadic set of 'options' - including one to trigger reconciliation on a Grafana resource when its Deployment updates _its_ own replica count
* Adds a helper method `getSelectorLabels` - since there are now two places that reference labels selecting for a Grafana resource's deployment
* Adds unit tests to verify the above changes

## Validation

* Ensured unit-tests pass
* Ran e2e tests with `kind` - ensuring that things more or less work as expected
* Ran `pre-commit` to ensure there's no weird formatting issues left behind

## Notes

I intentionally wanted to avoid defaulting the Grafana resource's `.spec.deployment.replicas` field because I wanted it to continue to be faithful to the underlying Deployment resource's spec (where replicas is an optional field).  As a result, if you try to use the scale subresource _and_ you don't have the `.spec.deployment.replicas` field set - the scale subresource will fail with a server error.  Looking over my infrastructure-as-code for `Alertmanager` (via `prometheus-operator`) - it appears that I had to deliberately specify the resource count for this very reason - and thus assume this edge-case is reasonable.  Let me know if you think we should change this behavior!