### PR TITLE
feat(helm): render watchNamespaces through tpl

### DIFF
--- a/deploy/helm/grafana-operator/templates/deployment.yaml
+++ b/deploy/helm/grafana-operator/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               {{- if and .Values.namespaceScope (eq .Values.watchNamespaces "") }}
               value: {{ include "grafana-operator.namespace" . }}
               {{ else }}
-              value: {{ .Values.watchNamespaces | quote }}
+              value: {{ tpl .Values.watchNamespaces . | quote }}
               {{- end }}
             - name: WATCH_NAMESPACE_SELECTOR
               value: {{ .Values.watchNamespaceSelector | quote }}


### PR DESCRIPTION
The WATCH_NAMESPACE env var previously took the raw value.watchNamespaces string, so any Go template expression in it was passed to the operator verbatim. Piping the value through `tpl` lets users compose the namespace list from the release context and their own values, e.g.:

  watchNamespaces: "{{ .Release.Namespace }},{{ .Values.environment }}"

This is useful when the chart is deployed by a wrapper chart or GitOps tooling that only knows the target namespaces at render time.

Plain strings render unchanged, and the namespaceScope fallback to the release namespace when watchNamespaces is empty is unaffected, so existing values files keep working.

<!--

Thank you for investing your time in contributing to our project - we appreciate
it!

Please make sure to review our policy on code contributions:

The submitter is responsible for the code change, regardless of where that code
change came from, whether they wrote it themselves, used an "AI" or other tool,
or got it from someone else. That responsibility includes making sure that the
code change can be submitted under the Apache 2.0 license that we use.

The submitter needs to understand what code they are changing, what the change
does, and justify that change in the commit messages. Using coding assistants or
"AI" or other tools does not grant additional privileges or reduce our
expectations.

We'll get back to you once we had time to review your PR. If you want to discuss
your PR in a synchronous way, you can join our weekly sync call! The invite link
can be found in the README.md of the project
-->
