### PR TITLE
fix(GrafanaManifest): always pass resourceVersion in update requests to avoid version mismatch errors

### DIFF
--- a/controllers/client/dynamic_client.go
+++ b/controllers/client/dynamic_client.go
@@ -134,8 +134,7 @@ func (c *DynamicClient) Apply(ctx context.Context, obj *unstructured.Unstructure
 		return fmt.Errorf("fetching existing resource: %w", err)
 	}
 
-	// App Platform APIs enforce optimistic concurrency: an update without the
-	// current resourceVersion is rejected, so carry it over from the live object.
+	// Carry over the resource version to ensure the object will be accepted if other updates have been made
 	obj.SetResourceVersion(existing.GetResourceVersion())
 
 	if _, err := rc.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {

--- a/controllers/client/dynamic_client.go
+++ b/controllers/client/dynamic_client.go
@@ -122,7 +122,7 @@ func (c *DynamicClient) Apply(ctx context.Context, obj *unstructured.Unstructure
 
 	rc := c.Resource(gvr).Namespace(c.NamespaceFor(obj))
 
-	_, err = rc.Get(ctx, obj.GetName(), metav1.GetOptions{})
+	existing, err := rc.Get(ctx, obj.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err := rc.Create(ctx, obj, metav1.CreateOptions{})
 		if err != nil {
@@ -133,6 +133,10 @@ func (c *DynamicClient) Apply(ctx context.Context, obj *unstructured.Unstructure
 	} else if err != nil {
 		return fmt.Errorf("fetching existing resource: %w", err)
 	}
+
+	// App Platform APIs enforce optimistic concurrency: an update without the
+	// current resourceVersion is rejected, so carry it over from the live object.
+	obj.SetResourceVersion(existing.GetResourceVersion())
 
 	if _, err := rc.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("updating resource: %w", err)


### PR DESCRIPTION
Fixes #2864

`DynamicClient.Apply()` performs a `Get` to decide between create and update, but discards the fetched object and calls `Update()` with the desired object as-is, which carries no `metadata.resourceVersion`. Grafana's App Platform APIs enforce optimistic concurrency on update, so every update is rejected with:

```
updating resource: Provided version '' of route '<name>' does not match current version '<hash>'
```

The result is that any `GrafanaManifest` templating an App Platform resource (e.g. a named `RoutingTree`) can be created once but never updated. The same applies to anything else going through `DynamicClient.Apply()`, including the `GenericReconciler` path used by the `FoldersUseNewAPI` folder controller.

This change keeps the fetched object and copies its `resourceVersion` onto the desired object before calling `Update()`.

Verification:

Tested end to end against a Grafana Cloud stack (external `Grafana` CR with `spec.external` + `tenantNamespace`), with a `GrafanaManifest` templating a named `RoutingTree`:

- Before: create succeeds; every subsequent reconcile fails with the version-mismatch error above, even when the templated spec is identical to the live resource.
- After (operator built from this branch): reconcile of an unchanged spec succeeds, and changing the templated spec is applied to Grafana; the live resource's `resourceVersion` hash advances accordingly.

`go build` and `go vet` pass. There is currently no unit coverage for `DynamicClient.Apply()`; happy to add a test if you can point me at the preferred fake/mocking approach for the dynamic client.
