### PR TITLE
chore(docs): deprecate star history

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,3 @@ Feel free to drop into our Grafana Operator discussions on:
 ## Contributing
 
 For more information on how to contribute to the operator look at [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=grafana/grafana-operator&type=date&legend=top-left)](https://www.star-history.com/#grafana/grafana-operator&type=date&legend=top-left)


### PR DESCRIPTION
- docs:
  - deprecated star history section of our readme as now GitHub requires an API token to fetch the data unless a user has privileged access to the repository.