### PR TITLE
fix(controllers): avoid overwriting finalizers during resource cleanup

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -520,15 +520,24 @@ func addFinalizer(ctx context.Context, cl client.Client, cr client.Object) error
 	return nil
 }
 
-// Remove finalizer through a MergePatch
-// Avoids updating the entire object and only changes the finalizers
+// Remove finalizer through a JSONPatch
+// Only removes our own entry, overwriting the whole array re-adds finalizers owned by others (e.g. foregroundDeletion)
+// when our copy of the object is out of date, which the API server rejects once the object is being deleted.
 func removeFinalizer(ctx context.Context, cl client.Client, cr client.Object) error {
-	// Only update when changed
-	if controllerutil.RemoveFinalizer(cr, grafanaFinalizer) {
-		return patchFinalizers(ctx, cl, cr)
+	idx := slices.Index(cr.GetFinalizers(), grafanaFinalizer)
+	if idx == -1 {
+		return nil
 	}
 
-	return nil
+	controllerutil.RemoveFinalizer(cr, grafanaFinalizer)
+
+	patch := fmt.Sprintf(`[
+		{"op":"test","path":"/metadata/finalizers/%d","value":"%s"},
+		{"op":"remove","path":"/metadata/finalizers/%d"}
+		]`, idx, grafanaFinalizer, idx,
+	)
+
+	return cl.Patch(ctx, cr, client.RawPatch(types.JSONPatchType, []byte(patch)))
 }
 
 // Helper func for add/remove, avoid using directly

--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -722,3 +723,125 @@ func TestIsNotErrorType(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 }
+
+// Finalizer owned by somebody else. Kubernetes adds foregroundDeletion itself when a
+// resource is deleted with foreground propagation, which is how Argo CD prunes.
+const foreignFinalizer = "foregroundDeletion"
+
+var _ = Describe("Finalizer patches", func() {
+	newDashboard := func(name string, finalizers []string) *v1beta1.GrafanaDashboard {
+		t := GinkgoT()
+
+		cr := &v1beta1.GrafanaDashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "default",
+				Name:       name,
+				Finalizers: finalizers,
+			},
+			Spec: v1beta1.GrafanaDashboardSpec{
+				GrafanaCommonSpec: v1beta1.GrafanaCommonSpec{
+					InstanceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"finalizer-test": "true"},
+					},
+				},
+				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
+			},
+		}
+
+		require.NoError(t, cl.Create(testCtx, cr))
+
+		return cr
+	}
+
+	cleanup := func(cr *v1beta1.GrafanaDashboard) {
+		DeferCleanup(func() {
+			t := GinkgoT()
+
+			live := &v1beta1.GrafanaDashboard{}
+
+			err := cl.Get(testCtx, client.ObjectKeyFromObject(cr), live)
+			if err != nil {
+				require.True(t, apierrors.IsNotFound(err), "unexpected error during cleanup: %v", err)
+				return
+			}
+
+			live.SetFinalizers(nil)
+			require.NoError(t, cl.Update(testCtx, live))
+
+			// Dropping the last finalizer already reaps an object under deletion
+			if err := cl.Delete(testCtx, live); err != nil {
+				require.True(t, apierrors.IsNotFound(err), "unexpected error during cleanup: %v", err)
+			}
+		})
+	}
+
+	setLiveFinalizers := func(cr *v1beta1.GrafanaDashboard, finalizers []string) {
+		t := GinkgoT()
+
+		live := &v1beta1.GrafanaDashboard{}
+		require.NoError(t, cl.Get(testCtx, client.ObjectKeyFromObject(cr), live))
+
+		live.SetFinalizers(finalizers)
+		require.NoError(t, cl.Update(testCtx, live))
+	}
+
+	liveFinalizers := func(cr *v1beta1.GrafanaDashboard) []string {
+		t := GinkgoT()
+
+		live := &v1beta1.GrafanaDashboard{}
+		require.NoError(t, cl.Get(testCtx, client.ObjectKeyFromObject(cr), live))
+
+		return live.GetFinalizers()
+	}
+
+	// Overwriting the whole array from the stale copy patches
+	// metadata.finalizers back to ["foregroundDeletion"], which the API server rejects
+	// with "no new finalizers can be added if the object is being deleted".
+	It("removes our finalizer when a foreign one disappeared after we read the object", func() {
+		t := GinkgoT()
+
+		cr := newDashboard("finalizer-stale-removal", []string{grafanaFinalizer, foreignFinalizer})
+		cleanup(cr)
+
+		stale := cr.DeepCopy()
+
+		require.NoError(t, cl.Delete(testCtx, cr))
+
+		setLiveFinalizers(cr, []string{grafanaFinalizer})
+
+		require.NoError(t, removeFinalizer(testCtx, cl, stale))
+
+		err := cl.Get(testCtx, client.ObjectKeyFromObject(cr), &v1beta1.GrafanaDashboard{})
+		assert.True(t, apierrors.IsNotFound(err), "expected the dashboard to be gone, got %v", err)
+
+		assert.NotContains(t, stale.GetFinalizers(), grafanaFinalizer, "caller's copy should be kept in sync")
+	})
+
+	It("leaves a foreign finalizer we never saw untouched", func() {
+		t := GinkgoT()
+
+		cr := newDashboard("finalizer-foreign-preserved", []string{grafanaFinalizer})
+		cleanup(cr)
+
+		stale := cr.DeepCopy()
+
+		setLiveFinalizers(cr, []string{grafanaFinalizer, foreignFinalizer})
+
+		require.NoError(t, cl.Delete(testCtx, cr))
+		require.NoError(t, removeFinalizer(testCtx, cl, stale))
+
+		got := liveFinalizers(cr)
+		assert.NotContains(t, got, grafanaFinalizer)
+		assert.Contains(t, got, foreignFinalizer)
+	})
+
+	It("is a no-op when our finalizer is already gone", func() {
+		t := GinkgoT()
+
+		cr := newDashboard("finalizer-already-removed", []string{foreignFinalizer})
+		cleanup(cr)
+
+		require.NoError(t, removeFinalizer(testCtx, cl, cr.DeepCopy()))
+		assert.Equal(t, []string{foreignFinalizer}, liveFinalizers(cr))
+	})
+})


### PR DESCRIPTION
<!--

Thank you for investing your time in contributing to our project - we appreciate
it!

Please make sure to review our policy on code contributions:

The submitter is responsible for the code change, regardless of where that code
change came from, whether they wrote it themselves, used an "AI" or other tool,
or got it from someone else. That responsibility includes making sure that the
code change can be submitted under the Apache 2.0 license that we use.

The submitter needs to understand what code they are changing, what the change
does, and justify that change in the commit messages. Using coding assistants or
"AI" or other tools does not grant additional privileges or reduce our
expectations.

We'll get back to you once we had time to review your PR. If you want to discuss
your PR in a synchronous way, you can join our weekly sync call! The invite link
can be found in the README.md of the project
-->

From bug: https://github.com/grafana/grafana-operator/issues/2870:

`"failed to remove finalizer: GrafanaDashboard.grafana.integreatly.org \"<dashboard-name>\" is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{\"foregroundDeletion\"}",`

`patchFinalizers` replaced `metadata.finalizers` as a whole from a stale in memory copy, and with that could re add or silently drop finalizers owned by others. When we had foreground deletion by argocd prune, that meant patching `foregroundDeletion` back onto a deleting object, which the API server rejects leaving the resource stuck in `Terminating` and the reconciler looping. It nows re reads the object, mutates via `controllerutil`, and writes with `MergeFromWithOptimisticLock` so a racing write is a retriable.

Let me know if this work or if has some room for improving that I might be missing, thanks

Fixes: #2870