### PR TITLE
chore: update grafana image to 13.1.3

### DIFF
--- a/config/crd/bases/grafana.integreatly.org_grafanas.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanas.yaml
@@ -8876,7 +8876,7 @@ spec:
                   description: |-
                     Version sets the tag of the default image: docker.io/grafana/grafana.
                     Allows full image refs with/without sha256checksum: "registry/repo/image:tag@sha"
-                    default: 13.1.0
+                    default: 13.1.3
                   type: string
               type: object
             status:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,7 +69,7 @@ spec:
             - name: ENABLE_LEADER_ELECTION
               value: "true"
             - name: RELATED_IMAGE_GRAFANA
-              value: "docker.io/grafana/grafana:13.1.0"
+              value: "docker.io/grafana/grafana:13.1.3"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -3,7 +3,7 @@ package config
 const (
 	// Grafana
 	GrafanaImage   = "docker.io/grafana/grafana"
-	GrafanaVersion = "13.1.0"
+	GrafanaVersion = "13.1.3"
 
 	// Paths
 	GrafanaDataPath               = "/var/lib/grafana"

--- a/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
+++ b/deploy/helm/grafana-operator/files/crds/grafana.integreatly.org_grafanas.yaml
@@ -8876,7 +8876,7 @@ spec:
                   description: |-
                     Version sets the tag of the default image: docker.io/grafana/grafana.
                     Allows full image refs with/without sha256checksum: "registry/repo/image:tag@sha"
-                    default: 13.1.0
+                    default: 13.1.3
                   type: string
               type: object
             status:

--- a/deploy/kustomize/base/crds.yaml
+++ b/deploy/kustomize/base/crds.yaml
@@ -13210,7 +13210,7 @@ spec:
                 description: |-
                   Version sets the tag of the default image: docker.io/grafana/grafana.
                   Allows full image refs with/without sha256checksum: "registry/repo/image:tag@sha"
-                  default: 13.1.0
+                  default: 13.1.3
                 type: string
             type: object
           status:

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -7638,7 +7638,7 @@ GrafanaSpec defines the desired state of Grafana
         <td>
           Version sets the tag of the default image: docker.io/grafana/grafana.
 Allows full image refs with/without sha256checksum: "registry/repo/image:tag@sha"
-default: 13.1.0<br/>
+default: 13.1.3<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/docs/versioning.md
+++ b/docs/docs/versioning.md
@@ -19,6 +19,7 @@ The Grafana version when unspecified in `Grafana#spec.version`
 
 | Operator Version | Default Grafana Image |
 |-|-|
+| `v5.24.0` | `13.0.1` |
 | `v5.23.0` | `13.0.1` |
 | `v5.22.1` | `12.4.1` |
 | `v5.22.0` | `12.3.3` |


### PR DESCRIPTION
This has gotten out-of-date due to broken renovate PRs. Bumping this now in preparation of a new release