### PR TITLE
chore(controllers): refactor addFinalizer and simplify tests for removeFinalizer

### DIFF
--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -509,8 +509,7 @@ func getReferencedValue(ctx context.Context, cl client.Client, namespace string,
 	return getConfigMapValue(ctx, cl, namespace, source.ConfigMapKeyRef)
 }
 
-// Add finalizer through a MergePatch
-// Avoids updating the entire object and only changes the finalizers
+// Adds finalizer if missing
 func addFinalizer(ctx context.Context, cl client.Client, cr client.Object) error {
 	if controllerutil.AddFinalizer(cr, grafanaFinalizer) {
 		finalizers := cr.GetFinalizers()
@@ -528,9 +527,7 @@ func addFinalizer(ctx context.Context, cl client.Client, cr client.Object) error
 	return nil
 }
 
-// Remove finalizer through a JSONPatch
-// Only removes our own entry, overwriting the whole array re-adds finalizers owned by others (e.g. foregroundDeletion)
-// when our copy of the object is out of date, which the API server rejects once the object is being deleted.
+// Removes finalizer if present
 func removeFinalizer(ctx context.Context, cl client.Client, cr client.Object) error {
 	idx := slices.Index(cr.GetFinalizers(), grafanaFinalizer)
 	if idx == -1 {
@@ -539,6 +536,9 @@ func removeFinalizer(ctx context.Context, cl client.Client, cr client.Object) er
 
 	controllerutil.RemoveFinalizer(cr, grafanaFinalizer)
 
+	// Here, we use a JSONPatch to avoid accidental attempts to re-add finalizers (owned by other controllers)
+	// due to stale controller-runtime's cache. - Such attempts would be refused by the API server (no new finalizers
+	// can be added if the object is being deleted).
 	patch := fmt.Sprintf(`[
 		{"op":"test","path":"/metadata/finalizers/%d","value":"%s"},
 		{"op":"remove","path":"/metadata/finalizers/%d"}

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -512,9 +512,17 @@ func getReferencedValue(ctx context.Context, cl client.Client, namespace string,
 // Add finalizer through a MergePatch
 // Avoids updating the entire object and only changes the finalizers
 func addFinalizer(ctx context.Context, cl client.Client, cr client.Object) error {
-	// Only update when changed
 	if controllerutil.AddFinalizer(cr, grafanaFinalizer) {
-		return patchFinalizers(ctx, cl, cr)
+		finalizers := cr.GetFinalizers()
+
+		patch, err := json.Marshal(
+			map[string]any{"metadata": map[string]any{"finalizers": finalizers}},
+		)
+		if err != nil {
+			return err
+		}
+
+		return cl.Patch(ctx, cr, client.RawPatch(types.MergePatchType, patch))
 	}
 
 	return nil
@@ -538,19 +546,6 @@ func removeFinalizer(ctx context.Context, cl client.Client, cr client.Object) er
 	)
 
 	return cl.Patch(ctx, cr, client.RawPatch(types.JSONPatchType, []byte(patch)))
-}
-
-// Helper func for add/remove, avoid using directly
-func patchFinalizers(ctx context.Context, cl client.Client, cr client.Object) error {
-	crFinalizers := cr.GetFinalizers()
-
-	// Create patch using slice
-	patch, err := json.Marshal(map[string]any{"metadata": map[string]any{"finalizers": crFinalizers}})
-	if err != nil {
-		return err
-	}
-
-	return cl.Patch(ctx, cr, client.RawPatch(types.MergePatchType, patch))
 }
 
 func addAnnotation(ctx context.Context, cl client.Client, cr client.Object, key, value string) error {

--- a/controllers/controller_shared_test.go
+++ b/controllers/controller_shared_test.go
@@ -17,15 +17,16 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/grafana/grafana-operator/v5/pkg/tk8s"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -724,124 +725,43 @@ func TestIsNotErrorType(t *testing.T) {
 	})
 }
 
-// Finalizer owned by somebody else. Kubernetes adds foregroundDeletion itself when a
-// resource is deleted with foreground propagation, which is how Argo CD prunes.
-const foreignFinalizer = "foregroundDeletion"
+func TestRemoveFinalizer(t *testing.T) {
+	t.Parallel()
 
-var _ = Describe("Finalizer patches", func() {
-	newDashboard := func(name string, finalizers []string) *v1beta1.GrafanaDashboard {
-		t := GinkgoT()
+	const extraFinalizer = "extraFinalizer"
 
-		cr := &v1beta1.GrafanaDashboard{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:  "default",
-				Name:       name,
-				Finalizers: finalizers,
+	cr := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test",
+			Finalizers: []string{
+				grafanaFinalizer,
+				extraFinalizer,
 			},
-			Spec: v1beta1.GrafanaDashboardSpec{
-				GrafanaCommonSpec: v1beta1.GrafanaCommonSpec{
-					InstanceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"finalizer-test": "true"},
-					},
-				},
-				GrafanaContentSpec: v1beta1.GrafanaContentSpec{JSON: "{}"},
-			},
-		}
-
-		require.NoError(t, cl.Create(testCtx, cr))
-
-		return cr
+		},
 	}
 
-	cleanup := func(cr *v1beta1.GrafanaDashboard) {
-		DeferCleanup(func() {
-			t := GinkgoT()
+	ctx := context.Background()
+	cl := tk8s.GetFakeClient(t)
 
-			live := &v1beta1.GrafanaDashboard{}
+	err := cl.Create(ctx, cr)
+	require.NoError(t, err)
 
-			err := cl.Get(testCtx, client.ObjectKeyFromObject(cr), live)
-			if err != nil {
-				require.True(t, apierrors.IsNotFound(err), "unexpected error during cleanup: %v", err)
-				return
-			}
+	err = removeFinalizer(ctx, cl, cr)
+	require.NoError(t, err)
 
-			live.SetFinalizers(nil)
-			require.NoError(t, cl.Update(testCtx, live))
+	// Make sure the finalizer is removed from the object
+	assert.NotContains(t, cr.GetFinalizers(), grafanaFinalizer)
 
-			// Dropping the last finalizer already reaps an object under deletion
-			if err := cl.Delete(testCtx, live); err != nil {
-				require.True(t, apierrors.IsNotFound(err), "unexpected error during cleanup: %v", err)
-			}
-		})
-	}
+	// Fetch the CR from API-server to make sure the finalizer is gone there as well
+	cr.Finalizers = []string{}
+	key := tk8s.GetRequestKey(t, cr)
 
-	setLiveFinalizers := func(cr *v1beta1.GrafanaDashboard, finalizers []string) {
-		t := GinkgoT()
+	err = cl.Get(ctx, key, cr)
+	require.NoError(t, err)
 
-		live := &v1beta1.GrafanaDashboard{}
-		require.NoError(t, cl.Get(testCtx, client.ObjectKeyFromObject(cr), live))
+	want := []string{extraFinalizer}
+	got := cr.GetFinalizers()
 
-		live.SetFinalizers(finalizers)
-		require.NoError(t, cl.Update(testCtx, live))
-	}
-
-	liveFinalizers := func(cr *v1beta1.GrafanaDashboard) []string {
-		t := GinkgoT()
-
-		live := &v1beta1.GrafanaDashboard{}
-		require.NoError(t, cl.Get(testCtx, client.ObjectKeyFromObject(cr), live))
-
-		return live.GetFinalizers()
-	}
-
-	// Overwriting the whole array from the stale copy patches
-	// metadata.finalizers back to ["foregroundDeletion"], which the API server rejects
-	// with "no new finalizers can be added if the object is being deleted".
-	It("removes our finalizer when a foreign one disappeared after we read the object", func() {
-		t := GinkgoT()
-
-		cr := newDashboard("finalizer-stale-removal", []string{grafanaFinalizer, foreignFinalizer})
-		cleanup(cr)
-
-		stale := cr.DeepCopy()
-
-		require.NoError(t, cl.Delete(testCtx, cr))
-
-		setLiveFinalizers(cr, []string{grafanaFinalizer})
-
-		require.NoError(t, removeFinalizer(testCtx, cl, stale))
-
-		err := cl.Get(testCtx, client.ObjectKeyFromObject(cr), &v1beta1.GrafanaDashboard{})
-		assert.True(t, apierrors.IsNotFound(err), "expected the dashboard to be gone, got %v", err)
-
-		assert.NotContains(t, stale.GetFinalizers(), grafanaFinalizer, "caller's copy should be kept in sync")
-	})
-
-	It("leaves a foreign finalizer we never saw untouched", func() {
-		t := GinkgoT()
-
-		cr := newDashboard("finalizer-foreign-preserved", []string{grafanaFinalizer})
-		cleanup(cr)
-
-		stale := cr.DeepCopy()
-
-		setLiveFinalizers(cr, []string{grafanaFinalizer, foreignFinalizer})
-
-		require.NoError(t, cl.Delete(testCtx, cr))
-		require.NoError(t, removeFinalizer(testCtx, cl, stale))
-
-		got := liveFinalizers(cr)
-		assert.NotContains(t, got, grafanaFinalizer)
-		assert.Contains(t, got, foreignFinalizer)
-	})
-
-	It("is a no-op when our finalizer is already gone", func() {
-		t := GinkgoT()
-
-		cr := newDashboard("finalizer-already-removed", []string{foreignFinalizer})
-		cleanup(cr)
-
-		require.NoError(t, removeFinalizer(testCtx, cl, cr.DeepCopy()))
-		assert.Equal(t, []string{foreignFinalizer}, liveFinalizers(cr))
-	})
-})
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
As a follow-up for #2880:

- controllers:
  - merged `patchFinalizers` into `addFinalizer` as it's no longer used by `removeFinalizer`;
  - simplified tests for `removeFinalizer`:
    - now, we only check that the finalizer is gone from our original object and the change is applied to the API-server. I think that having this test coupled with a comment explaining why we chose a JSONPatch is sufficient;
    - there's no need to rely on ginkgo and/or envtest;
    - since the function is generic, there's no need to tie it to any of our custom data types, so switched it to one of k8s core types (`ConfigMap`), whose spec is less likely to change over time.