### PR TITLE
chore(go): bump to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-operator/v5
 
-go 1.26.3
+go 1.26.6
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
- go:
  - bumped to the latest patch release (1.26.6).