### PR TITLE
chore(toolchain): bump golangcilint to v2.13.1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -189,6 +189,10 @@ linters:
           - unparam
           - unused
         path: _test\.go
+      - linters:
+          - staticcheck
+        path: '(.+)_test\.go'
+        text: SA1019 # Suppresses warnings about deprecated fields like we have in GrafanaContactPointSpec
 
 formatters:
   enable:

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -13,7 +13,7 @@ CRDOC_VERSION = v0.6.4
 DART_SASS_VERSION = 1.86.0
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime)
 # renovate: datasource=github-tags depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION = v2.12.2
+GOLANGCI_LINT_VERSION = v2.13.1
 # renovate: datasource=github-tags depName=norwoodj/helm-docs
 HELM_DOCS_VERSION = 1.14.2
 # renovate: datasource=github-tags depName=helm/helm

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -612,7 +612,7 @@ func (r *GrafanaDashboardReconciler) matchesStateInGrafana(exists bool, model ma
 		return false, nil
 	}
 
-	remoteModel, ok := (remoteDashboard.GetPayload().Dashboard).(map[string]any)
+	remoteModel, ok := remoteDashboard.GetPayload().Dashboard.(map[string]any)
 	if !ok {
 		return false, fmt.Errorf("remote dashboard is not a valid object")
 	}


### PR DESCRIPTION
- toolchain:
  - golangci-lint:
    - bumped golangcilint to v2.13.1;
    - suppressed SA1019 in tests as the new version of staticcheck was generating 25 issues around usage of deprecated fields in `GrafanaContactPointSpec`'s tests;
    - reformatted code.

Supersedes #2902 (cannot push my changes there)