### PR TITLE
fix(Grafana): use contents for tracking cm/secret state instead of resourceVersion

### DIFF
--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -3,9 +3,10 @@ package grafana
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -384,10 +385,11 @@ func (r *DeploymentReconciler) computeSecretsHash(ctx context.Context, cr *v1bet
 	log := logf.FromContext(ctx).WithName("DeploymentReconciler")
 	secretNames, configMapNames := cr.ReferencedSecretsAndConfigMaps()
 
-	var resourceVersions []string // entries "secret/name=rv" or "configmap/name=rv", later sorted and hashed
+	var subHashes []string // coerce to string to simplify sorting
 
 	for _, name := range secretNames {
 		secret := &corev1.Secret{}
+		dataHash := sha256.New()
 
 		err := r.client.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: name}, secret)
 		if err != nil {
@@ -400,11 +402,16 @@ func (r *DeploymentReconciler) computeSecretsHash(ctx context.Context, cr *v1bet
 			return "", fmt.Errorf("fetching secret %s: %w", name, err)
 		}
 
-		resourceVersions = append(resourceVersions, fmt.Sprintf("secret/%s=%s", name, secret.ResourceVersion))
+		if err := json.NewEncoder(dataHash).Encode(secret.Data); err != nil {
+			return "", fmt.Errorf("calculating secret hash: %w", err)
+		}
+
+		subHashes = append(subHashes, string(dataHash.Sum(nil)))
 	}
 
 	for _, name := range configMapNames {
 		cm := &corev1.ConfigMap{}
+		dataHash := sha256.New()
 
 		err := r.client.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: name}, cm)
 		if err != nil {
@@ -417,24 +424,27 @@ func (r *DeploymentReconciler) computeSecretsHash(ctx context.Context, cr *v1bet
 			return "", fmt.Errorf("fetching configmap %s: %w", name, err)
 		}
 
-		resourceVersions = append(resourceVersions, fmt.Sprintf("configmap/%s=%s", name, cm.ResourceVersion))
+		if err := json.NewEncoder(dataHash).Encode(cm.Data); err != nil {
+			return "", fmt.Errorf("calculating config map hash: %w", err)
+		}
+
+		subHashes = append(subHashes, string(dataHash.Sum(nil)))
 	}
 
-	return hashResourceVersions(resourceVersions), nil
+	return aggregateHash(subHashes), nil
 }
 
-// hashResourceVersions produces a deterministic hex hash from a slice of "kind/name=resourceVersion"
-// entries. Sorts the slice so order does not affect the hash, then SHA-256 hashes the concatenated strings.
-func hashResourceVersions(versions []string) string {
-	if len(versions) == 0 {
+// aggregateHash takes the passed list of hashes and sorts/sums them
+func aggregateHash(hashes []string) string {
+	if len(hashes) == 0 {
 		return ""
 	}
 
-	sort.Strings(versions)
+	slices.Sort(hashes)
 
 	h := sha256.New()
 
-	for _, v := range versions {
+	for _, v := range hashes {
 		io.WriteString(h, v) //nolint:errcheck
 	}
 

--- a/controllers/reconcilers/grafana/deployment_reconciler_test.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler_test.go
@@ -56,41 +56,41 @@ func TestGetGrafanaImage(t *testing.T) {
 	}
 }
 
-func TestHashResourceVersions(t *testing.T) {
+func TestAggregateHash(t *testing.T) {
 	t.Run("empty list returns empty string", func(t *testing.T) {
-		result := hashResourceVersions(nil)
+		result := aggregateHash(nil)
 		assert.Empty(t, result)
 
-		result = hashResourceVersions([]string{})
+		result = aggregateHash([]string{})
 		assert.Empty(t, result)
 	})
 
 	t.Run("same inputs produce same hash", func(t *testing.T) {
-		versions := []string{"secret/db=100", "configmap/cfg=200"}
+		versions := []string{string([]byte{1, 2, 3}), string([]byte{4, 5, 6})}
 
-		hash1 := hashResourceVersions(versions)
-		hash2 := hashResourceVersions(versions)
+		hash1 := aggregateHash(versions)
+		hash2 := aggregateHash(versions)
 
 		assert.Equal(t, hash1, hash2)
 		assert.NotEmpty(t, hash1)
 	})
 
 	t.Run("different inputs produce different hashes", func(t *testing.T) {
-		hash1 := hashResourceVersions([]string{"secret/db=100"})
-		hash2 := hashResourceVersions([]string{"secret/db=101"})
+		hash1 := aggregateHash([]string{string([]byte{1, 2, 3}), string([]byte{4, 5, 6})})
+		hash2 := aggregateHash([]string{string([]byte{1, 2, 3})})
 
 		assert.NotEqual(t, hash1, hash2)
 	})
 
 	t.Run("order-independent: same entries in different order produce same hash", func(t *testing.T) {
-		hash1 := hashResourceVersions([]string{"secret/a=1", "configmap/b=2"})
-		hash2 := hashResourceVersions([]string{"configmap/b=2", "secret/a=1"})
+		hash1 := aggregateHash([]string{string([]byte{1, 2, 3}), string([]byte{4, 5, 6})})
+		hash2 := aggregateHash([]string{string([]byte{4, 5, 6}), string([]byte{1, 2, 3})})
 
 		assert.Equal(t, hash1, hash2)
 	})
 
 	t.Run("returns a valid hex string", func(t *testing.T) {
-		result := hashResourceVersions([]string{"secret/x=42"})
+		result := aggregateHash([]string{string([]byte{1, 2, 3})})
 		assert.Regexp(t, `^[0-9a-f]{64}$`, result)
 	})
 }


### PR DESCRIPTION
Fixes #2899 