### PR TITLE
chore(workflows): expand test matrix to k8s v1.37.0

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -129,11 +129,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: v1.34.8
+          - version: v1.34.11
             grafana_version: "11.0.0"
-          - version: v1.35.5
+          - version: v1.35.8
             grafana_version: "12.0.0"
-          - version: v1.36.1
+          - version: v1.36.4
+            grafana_version: "" # default
+          - version: v1.37.0
             grafana_version: "" # default
     env:
       GF_TEST_CONTAINER_VERSION: ${{ matrix.grafana_version }}

--- a/Toolchain.mk
+++ b/Toolchain.mk
@@ -20,7 +20,7 @@ HELM_DOCS_VERSION = 1.14.2
 HELM_VERSION = v4.2.4
 HUGO_VERSION = 0.151.0
 # renovate: datasource=github-tags depName=kubernetes-sigs/kind
-KIND_VERSION = v0.32.0
+KIND_VERSION = v0.33.0
 # renovate: datasource=github-tags depName=ko-build/ko
 KO_VERSION = 0.19.1
 # renovate: datasource=github-tags depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>.*)$


### PR DESCRIPTION
- toolchain:
  - `kind` -> v0.33.0;
- workflows:
  - added k8s v1.37.0;
  - updated other k8s tags to match images pre-built for kind v0.33.0.