### PR TITLE
chore(controllers): migrate to uuid package

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -23,8 +23,8 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"uuid"
 
-	"github.com/google/uuid"
 	genapi "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"

--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -21,8 +21,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -300,7 +300,8 @@ var _ = Describe("Dashboard Reconciler", Ordered, func() {
 				Dashboard: model,
 				FolderUID: dash.Payload.Meta.FolderUID,
 				Overwrite: true,
-			})
+			},
+		)
 		require.NoError(t, err)
 
 		dash, err = gClient.Dashboards.GetDashboardByUID(uid)
@@ -520,7 +521,7 @@ func TestGrafanaDashboardReconcilerMatchesStateInGrafana(t *testing.T) {
 }
 
 func TestGrafanaDashboardReconcilerPublicDashboardMatchesStateInGrafana(t *testing.T) {
-	uid := uuid.NewString()
+	uid := uuid.New().String()
 
 	defaultPublicDashboard := dashboards.GetPublicDashboardOK{
 		Payload: &models.PublicDashboard{
@@ -580,7 +581,7 @@ func TestGrafanaDashboardReconcilerPublicDashboardMatchesStateInGrafana(t *testi
 			name: "AccessToken changes should recreate",
 			changes: &models.PublicDashboardDTO{
 				UID:                  uid,
-				AccessToken:          uuid.NewString(),
+				AccessToken:          uuid.New().String(),
 				IsEnabled:            new(true),
 				AnnotationsEnabled:   new(false),
 				TimeSelectionEnabled: new(false),
@@ -610,7 +611,7 @@ func TestGrafanaDashboardReconcilerPublicDashboardMatchesStateInGrafana(t *testi
 				AnnotationsEnabled:   new(false),
 				TimeSelectionEnabled: new(false),
 			},
-			annotations:  map[string]string{annotationSyncedPublicSharing: uuid.NewString()},
+			annotations:  map[string]string{annotationSyncedPublicSharing: uuid.New().String()},
 			wantMatch:    false,
 			wantRecreate: true,
 		},

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/go-openapi/runtime v0.33.1
 	github.com/go-openapi/strfmt v0.27.0
 	github.com/google/go-jsonnet v0.22.0
-	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20260724161645-6029e6c64947
 	github.com/grafana/grafana/apps/folder v0.0.0-20260511051340-90bed70d199c
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260511053550-5c87510b9bf6
@@ -89,6 +88,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/pprof v0.0.0-20260604005048-7023385849c0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/grafana/grafana-app-sdk v0.56.2 // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
- controllers:
  - Go 1.27 has introduced `uuid` package, so we can now deprecate direct dependency on `github.com/google/uuid` in favour of `uuid`. Thus the PR.
  
**NOTE:** not like it matters much at this point, but, in future, the transient dependency might go away as well once the `uuid` package is picked up by others.