### PR TITLE
chore(go): bump to 1.27.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-operator/v5
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5


### PR DESCRIPTION
- `go`:
  - bumped to 1.27.1.