### PR TITLE
Fix(Grafana): `GrafanaMuteTimings` always removed from `status.mutetimings` on startup

### DIFF
--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -263,7 +263,7 @@ func (r *GrafanaReconciler) syncStatuses(ctx context.Context) error {
 		return err
 	}
 
-	muteTimings := &v1beta1.GrafanaLibraryPanelList{}
+	muteTimings := &v1beta1.GrafanaMuteTimingList{}
 
 	err = r.List(ctx, muteTimings)
 	if err != nil {


### PR DESCRIPTION
Noticed that the wrong type was used for listing `GrafanaMuteTimings` when updating the Grafana status on startup.

This results in all matching timings being removed from the status, unless there was an overlap with a `GrafanaLibraryPanel` Namespace/Name, which is highly unlikely in most setups.