### PR TITLE
Fix(Grafana): Retry on K8s write conflicts

### DIFF
--- a/controllers/folder_controller_test.go
+++ b/controllers/folder_controller_test.go
@@ -1,6 +1,9 @@
 package controllers
 
 import (
+	"context"
+	"fmt"
+	"testing"
 	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
@@ -11,10 +14,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	. "github.com/onsi/ginkgo/v2"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var _ = Describe("Folder Reconciler: Provoke Conditions", func() {
@@ -236,3 +243,59 @@ var _ = Describe("Folder reconciler", func() {
 		assert.IsType(t, &folders.GetFolderByUIDNotFound{}, err) //nolint:testifylint
 	})
 })
+
+var genericFolderInterceptCnt = 0
+
+func TestGenericReconcileRetryOnConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cr := &v1beta1.GrafanaFolder{
+		ObjectMeta: objectMetaSuspended,
+		Spec: v1beta1.GrafanaFolderSpec{
+			Suspend: true,
+		},
+	}
+
+	interceptFns := &interceptor.Funcs{
+		// "Get" Normally will never return a "409 Conflict".
+		// But it's a very convenient way of testing the RetryOnConflict wrapper.
+		Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if genericFolderInterceptCnt < 2 {
+				genericFolderInterceptCnt++
+
+				return apierrors.NewConflict(schema.GroupResource{
+					Group:    obj.GetObjectKind().GroupVersionKind().Group,
+					Resource: obj.GetObjectKind().GroupVersionKind().Kind,
+				}, obj.GetName(), fmt.Errorf("Forced Conflict"))
+			}
+
+			return client.Get(ctx, key, obj, opts...)
+		},
+	}
+	cl := tk8s.GetFakeInterceptingClient(t, interceptFns)
+	err := v1beta1.AddToScheme(cl.Scheme())
+	require.NoError(t, err)
+
+	err = cl.Create(ctx, cr)
+	require.NoError(t, err)
+
+	r := NewGenericFolderReconciler(cl, &Config{
+		ResyncPeriod: 5 * time.Second,
+	})
+	req := tk8s.GetRequest(t, cr)
+
+	// Expect Conflict
+	_, err = r.ReconcilerWithRetry(ctx, req)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err))
+	assert.Equal(t, 1, genericFolderInterceptCnt, "Should return on the first error (conflict)")
+
+	// Reset intercept count to re-enable intercept client
+	genericFolderInterceptCnt = 0
+
+	// Retry multiple times until conflict disappears
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 2, genericFolderInterceptCnt, "Retrying more than once is expected")
+}

--- a/controllers/folder_controller_test.go
+++ b/controllers/folder_controller_test.go
@@ -286,7 +286,7 @@ func TestGenericReconcileRetryOnConflict(t *testing.T) {
 	req := tk8s.GetRequest(t, cr)
 
 	// Expect Conflict
-	_, err = r.ReconcilerWithRetry(ctx, req)
+	_, err = r.reconcile(ctx, req)
 	require.Error(t, err)
 	assert.True(t, apierrors.IsConflict(err))
 	assert.Equal(t, 1, genericFolderInterceptCnt, "Should return on the first error (conflict)")

--- a/controllers/generic_controller.go
+++ b/controllers/generic_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,6 +66,20 @@ func (r *GenericReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Reque
 	log := logf.FromContext(ctx).WithName(fmt.Sprintf("Generic%sReconciler", r.ResourceName))
 	ctx = logf.IntoContext(ctx, log)
 
+	var res ctrl.Result
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		result, err := r.ReconcilerWithRetry(ctx, req)
+		res = result
+
+		return err
+	})
+
+	return res, err
+}
+
+func (r *GenericReconciler[T, PT]) ReconcilerWithRetry(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	cr := PT(new(T))
 
 	err := r.Get(ctx, req.NamespacedName, cr)

--- a/controllers/generic_controller.go
+++ b/controllers/generic_controller.go
@@ -69,7 +69,7 @@ func (r *GenericReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Reque
 	var res ctrl.Result
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		result, err := r.ReconcilerWithRetry(ctx, req)
+		result, err := r.reconcile(ctx, req)
 		res = result
 
 		return err
@@ -78,7 +78,7 @@ func (r *GenericReconciler[T, PT]) Reconcile(ctx context.Context, req ctrl.Reque
 	return res, err
 }
 
-func (r *GenericReconciler[T, PT]) ReconcilerWithRetry(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *GenericReconciler[T, PT]) reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	cr := PT(new(T))
 

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -83,7 +83,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	var res ctrl.Result
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		result, err := r.ReconcilerWithRetry(ctx, req)
+		result, err := r.reconcile(ctx, req)
 		res = result
 
 		return err
@@ -92,7 +92,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return res, err
 }
 
-func (r *GrafanaReconciler) ReconcilerWithRetry(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *GrafanaReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	cr := &v1beta1.Grafana{}
 

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,6 +80,20 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	log := logf.FromContext(ctx).WithName("GrafanaReconciler")
 	ctx = logf.IntoContext(ctx, log)
 
+	var res ctrl.Result
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		result, err := r.ReconcilerWithRetry(ctx, req)
+		res = result
+
+		return err
+	})
+
+	return res, err
+}
+
+func (r *GrafanaReconciler) ReconcilerWithRetry(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
 	cr := &v1beta1.Grafana{}
 
 	err := r.Get(ctx, req.NamespacedName, cr)

--- a/controllers/grafana_controller_test.go
+++ b/controllers/grafana_controller_test.go
@@ -363,7 +363,7 @@ func TestGrafanaReconcileRetryOnConflict(t *testing.T) {
 	req := tk8s.GetRequest(t, cr)
 
 	// Expect Conflict
-	_, err = r.ReconcilerWithRetry(ctx, req)
+	_, err = r.reconcile(ctx, req)
 	require.Error(t, err)
 	assert.True(t, apierrors.IsConflict(err))
 	assert.Equal(t, 1, grafanaInterceptCnt, "Should return on the first error (conflict)")

--- a/controllers/grafana_controller_test.go
+++ b/controllers/grafana_controller_test.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana-operator/v5/api/v1beta1"
@@ -8,7 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	. "github.com/onsi/ginkgo/v2"
 )
@@ -316,3 +322,57 @@ var _ = Describe("Grafana Reconciler: Provoke Conditions", func() {
 		})
 	}
 })
+
+var grafanaInterceptCnt = 0
+
+func TestGrafanaReconcileRetryOnConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cr := &v1beta1.Grafana{
+		ObjectMeta: objectMetaSuspended,
+		Spec: v1beta1.GrafanaSpec{
+			Suspend: true,
+		},
+	}
+
+	interceptFns := &interceptor.Funcs{
+		// "Get" Normally will never return a "409 Conflict".
+		// But it's a very convenient way of testing the RetryOnConflict wrapper.
+		Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if grafanaInterceptCnt < 2 {
+				grafanaInterceptCnt++
+
+				return apierrors.NewConflict(schema.GroupResource{
+					Group:    obj.GetObjectKind().GroupVersionKind().Group,
+					Resource: obj.GetObjectKind().GroupVersionKind().Kind,
+				}, obj.GetName(), fmt.Errorf("Forced Conflict"))
+			}
+
+			return client.Get(ctx, key, obj, opts...)
+		},
+	}
+	cl := tk8s.GetFakeInterceptingClient(t, interceptFns)
+	err := v1beta1.AddToScheme(cl.Scheme())
+	require.NoError(t, err)
+
+	err = cl.Create(ctx, cr)
+	require.NoError(t, err)
+
+	r := GrafanaReconciler{Client: cl, Scheme: cl.Scheme()}
+	req := tk8s.GetRequest(t, cr)
+
+	// Expect Conflict
+	_, err = r.ReconcilerWithRetry(ctx, req)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsConflict(err))
+	assert.Equal(t, 1, grafanaInterceptCnt, "Should return on the first error (conflict)")
+
+	// Reset intercept count to re-enable intercept client
+	grafanaInterceptCnt = 0
+
+	// Retry multiple times until conflict disappears
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, 2, grafanaInterceptCnt, "Retrying more than once is expected")
+}

--- a/pkg/tk8s/client.go
+++ b/pkg/tk8s/client.go
@@ -9,10 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
-// GetFakeClient returns a fake k8s client with preconfigured runtime scheme and, optionally, initObjects
-func GetFakeClient(t *testing.T, initObjs ...client.Object) client.WithWatch {
+func getFakeClientBuilder(t *testing.T, initObjs ...client.Object) *fake.ClientBuilder {
 	t.Helper()
 
 	s := runtime.NewScheme()
@@ -23,10 +23,35 @@ func GetFakeClient(t *testing.T, initObjs ...client.Object) client.WithWatch {
 	err = appsv1.AddToScheme(s)
 	require.NoError(t, err)
 
-	cl := fake.NewClientBuilder().
+	cb := fake.NewClientBuilder().
 		WithScheme(s).
-		WithObjects(initObjs...).
+		WithObjects(initObjs...)
+
+	return cb
+}
+
+// GetFakeClient returns a fake k8s client with preconfigured runtime scheme and, optionally, initObjects
+func GetFakeClient(t *testing.T, initObjs ...client.Object) client.WithWatch {
+	t.Helper()
+
+	cl := getFakeClientBuilder(t, initObjs...).
 		Build()
+
+	return cl
+}
+
+// GetFakeInterceptingClient returns a fake k8s client with preconfigured runtime scheme, and, optionally, initObjects
+// But allows overriding client functions Apply, Update, etc...
+func GetFakeInterceptingClient(t *testing.T, intercepterFns *interceptor.Funcs, initObjs ...client.Object) client.WithWatch {
+	t.Helper()
+
+	cb := getFakeClientBuilder(t, initObjs...)
+
+	if intercepterFns != nil {
+		cb.WithInterceptorFuncs(*intercepterFns)
+	}
+
+	cl := cb.Build()
 
 	return cl
 }


### PR DESCRIPTION
Wraps the `Grafana` and `Generic` Controllers with `retryOnConflict`, resulting a slightly more durable writes.

As the Operator uses LeaderElection by default and primarily updates Statuses on the CRs, most of the controllers will not gain much from this.

But the sub-reconcilers in the `Grafana` controller will likely benefit a lot, as here the operator has to contend with Kubernetes own controllers.

This is reflected in the respective default retry values used for the Generic and Grafana Controllers.
[wait.Backoff fields](https://pkg.go.dev/k8s.io/apimachinery@v0.37.0/pkg/util/wait#Backoff)
```go
// DefaultRetry is the recommended retry for a conflict where multiple clients
// are making changes to the same resource.
var DefaultRetry = wait.Backoff{
	Steps:    5,
	Duration: 10 * time.Millisecond,
	Factor:   1.0,
	Jitter:   0.1,
}

// DefaultBackoff is the recommended backoff for a conflict where a client
// may be attempting to make an unrelated modification to a resource under
// active management by one or more controllers.
var DefaultBackoff = wait.Backoff{
	Steps:    4,
	Duration: 10 * time.Millisecond,
	Factor:   5.0,
	Jitter:   0.1,
}
```

closes #2942